### PR TITLE
fix(harness): the degraded capability ledger must survive the reader hop (#1749)

### DIFF
--- a/scripts/compare_orchestration_modes.py
+++ b/scripts/compare_orchestration_modes.py
@@ -244,6 +244,21 @@ class ModeResult:
     phases_total: int = 0
     capabilities_used: List[str] = field(default_factory=list)
     capabilities_missing: List[str] = field(default_factory=list)
+    # #1749: the THIRD capability state — "ran and returned nothing". The
+    # pipeline removes degraded capabilities from ``capabilities_used`` on
+    # purpose (``unified_pipeline._collect_degraded_capabilities``, "so a
+    # degraded capability surfaces as degraded, NOT as used" — anti-theater
+    # #1019) and emits them in their own list. Reading only two of the three
+    # made that capability vanish: neither used nor missing, so a reader
+    # counted full coverage on a truncated ledger.
+    #
+    # Optional[List] with default None, NOT ``[]`` (same convention as
+    # ``state_fill_rate``, CG #1540): None = "this mode emits no ledger"
+    # (renders ``n/a``); [] = "ledger emitted, nothing degraded" (renders 0).
+    # An absent ledger is not an empty one — measured on the return dicts,
+    # only pipeline and conversational emit the three keys; the two
+    # hierarchical modes and conversation_deterministic emit none.
+    capabilities_degraded: Optional[List[str]] = None
     extra_metrics: Dict[str, Any] = field(default_factory=dict)
     # Trade-off columns (BO-4 #1480):
     terminates: bool = True
@@ -479,6 +494,56 @@ def _hit_its_wall_clock(result: "ModeResult") -> bool:
     return bool(result.terminated_by_budget) or bool(
         result.extra_metrics.get("wall_clock_bounded")
     )
+
+
+def _capability_ledger_lines(result: "ModeResult") -> List[str]:
+    """Render the THREE capability states for one row (#1749).
+
+    ``used`` / ``degraded`` / ``missing`` are three states, never two. They
+    call for three DIFFERENT actions, which is why folding any pair together
+    destroys the actionable content:
+
+    - ``used``     — ran, produced something.
+    - ``degraded`` — ran and produced nothing (e.g. an endpoint not configured
+      and the provider fails loud). Action: configure the environment.
+    - ``missing``  — no provider at all. Action: wire one.
+
+    A mode that emits NO ledger renders ``n/a``, not zeros: "0 degraded" is a
+    measurement claim ("I looked and found none") that such a mode never made.
+    Measured on the runners' return dicts — pipeline and conversational emit
+    all three keys; ``hierarchical_bridge`` / ``hierarchical_delegation`` /
+    ``conversation_deterministic`` emit none of them.
+
+    The degraded capabilities are listed BY NAME: the corrective action is
+    per-capability, so a bare count would say something is wrong without
+    saying what to do about it.
+    """
+    no_ledger = (
+        result.capabilities_degraded is None
+        and not result.capabilities_used
+        and not result.capabilities_missing
+    )
+    if no_ledger:
+        return [
+            f"**{result.mode}** capabilities: n/a "
+            f"(mode emits no capability ledger)",
+            "",
+        ]
+
+    degraded = result.capabilities_degraded
+    degraded_part = "n/a" if degraded is None else str(len(degraded))
+    lines = [
+        f"**{result.mode}** capabilities: {len(result.capabilities_used)} used / "
+        f"{degraded_part} degraded / {len(result.capabilities_missing)} missing",
+    ]
+    if result.capabilities_used:
+        lines.append(f"  - used: {', '.join(result.capabilities_used)}")
+    if degraded:
+        lines.append(f"  - degraded: {', '.join(degraded)}")
+    if result.capabilities_missing:
+        lines.append(f"  - missing: {', '.join(result.capabilities_missing)}")
+    lines.append("")
+    return lines
 
 
 def _fmt_count_in_perimeter(
@@ -980,6 +1045,11 @@ async def run_pipeline_mode(
         phases_total=summary.get("total", 0),
         capabilities_used=result.get("capabilities_used", []),
         capabilities_missing=result.get("capabilities_missing", []),
+        # #1749: no ``[]`` default — an absent key must land on None ("no
+        # ledger" -> n/a), never on a ``[]`` that would assert "looked, found
+        # none". That fabricated-default shape is the phantom-key defect this
+        # file has already been bitten by twice (CB #1528 item 3, #1560).
+        capabilities_degraded=result.get("capabilities_degraded"),
         # #1753: the pipeline ledger comes from the WorkflowExecutor, which
         # sees every phase — so an absent producer here really does mean "not
         # in the executed perimeter", and ``n/a`` is earned. This is the ONE
@@ -1113,6 +1183,12 @@ async def run_conversational_mode(
         phases_completed=len(phases_ran),
         phases_total=len(planned_phases),
         capabilities_used=result.get("capabilities_used", []),
+        # #1749: the defect blinds BOTH ledger-emitting modes. Fixing only the
+        # pipeline would leave this row silently truncated — and the
+        # conversational mode is the one whose ledger is already known to be
+        # non-exhaustive (#1753), so a dropped degradation here is the harder
+        # one to notice. Same no-default rule as the pipeline runner.
+        capabilities_degraded=result.get("capabilities_degraded"),
         # Track CA #1529: `decides` is no longer hand-set here — run_all
         # computes it uniformly from phases_completed + total_messages below.
         # #1752 (CORRECTED): this ``False`` is CORRECT and deliberate, not the
@@ -1849,13 +1925,15 @@ def generate_report(
             )
             lines.append("")
 
-        # Capabilities used
+        # Capability ledger — all THREE states, side by side (#1749).
+        # Previously this block printed only ``capabilities_used``, so a
+        # capability that ran and returned nothing appeared nowhere: the row
+        # read "14 used / 0 missing" on a run wrong by exactly one capability.
+        # The three are rendered together on one line because that is the
+        # readable form — "14 used / 1 degraded / 0 missing" is legible,
+        # "14 used / 0 missing" plus a footnote is how the state got lost.
         for r in corpus_results:
-            if r.capabilities_used:
-                lines.append(
-                    f"**{r.mode}** capabilities: {', '.join(r.capabilities_used)}"
-                )
-                lines.append("")
+            lines.extend(_capability_ledger_lines(r))
 
         lines.append("")
 

--- a/tests/unit/argumentation_analysis/orchestration/test_degraded_ledger_1749.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_degraded_ledger_1749.py
@@ -1,0 +1,365 @@
+# tests/unit/argumentation_analysis/orchestration/test_degraded_ledger_1749.py
+"""#1749 — the THIRD capability state must survive the reader hop.
+
+The pipeline renders three capability states — ``used`` / ``degraded`` /
+``missing``. The comparison harness read only two, so a capability that RAN
+and returned nothing (``degraded=True``) appeared in neither list: a reader
+counted "14 used / 0 missing" and concluded full coverage on a run that was
+wrong by exactly one capability.
+
+The producer is CORRECT and says so: ``_collect_degraded_capabilities``
+(``unified_pipeline.py:55-99``) removes degraded capabilities from
+``capabilities_used`` *deliberately* — "so a degraded capability surfaces as
+degraded, NOT as ``used`` (anti-theater #1019)" — and emits the third list
+alongside. The loss is at the READER hop, which is why these tests pin the
+TRAVERSAL (producer dict -> ``ModeResult`` -> report) and never the presence
+of the field at the producer (already covered by ``test_unified_pipeline.py``).
+
+Measured shapes (R810, on ``main``), which decide who may claim a ledger:
+
+===========================  =====  ========  =======
+runner                       used   degraded  missing
+===========================  =====  ========  =======
+pipeline                     yes    yes       yes
+conversational               yes    yes       yes
+hierarchical_bridge          no     no        no
+hierarchical_delegation      no     no        no
+conversation_deterministic   no     no        no
+===========================  =====  ========  =======
+
+Hence the ``None`` vs ``[]`` convention (same as CG #1540): ``None`` = "this
+mode emits no ledger" -> ``n/a``; ``[]`` = "ledger emitted, nothing degraded"
+-> ``0``. An absent ledger is not an empty one.
+
+JVM/LLM-free: the orchestrators are patched at their definition site.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[4]
+_SCRIPTS_DIR = str(_PROJECT_ROOT / "scripts")
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+
+import compare_orchestration_modes as harness  # noqa: E402
+
+
+def _drive_pipeline(producer_result: dict) -> harness.ModeResult:
+    """Push a producer dict through the REAL pipeline runner (hop 1)."""
+
+    async def fake_run(**kwargs):
+        return producer_result
+
+    async def _go():
+        with patch(
+            "argumentation_analysis.orchestration.unified_pipeline"
+            ".run_unified_analysis",
+            side_effect=fake_run,
+        ):
+            return await harness.run_pipeline_mode("text", "corpus_A", "standard")
+
+    return asyncio.run(_go())
+
+
+def _drive_conversational(producer_result: dict) -> harness.ModeResult:
+    """Push a producer dict through the REAL conversational runner (hop 1)."""
+
+    async def fake_run(**kwargs):
+        return producer_result
+
+    async def _go():
+        with patch(
+            "argumentation_analysis.orchestration.conversational_orchestrator"
+            ".run_conversational_analysis",
+            side_effect=fake_run,
+        ):
+            return await harness.run_conversational_mode("text", "corpus_A")
+
+    return asyncio.run(_go())
+
+
+class TestDegradedLedgerTraversesTheReaderHop:
+    """A capability that ran degraded must be NAMED, end to end.
+
+    These are the tests that go red before the fix. Each one pins a distinct
+    hop, so a partial fix cannot make all of them green.
+    """
+
+    def test_producer_declared_degradation_reaches_the_artefact(self) -> None:
+        """The whole traversal, with NO reference to the new field.
+
+        This is the control that proves the DEFECT rather than the newness of
+        a field: every other test here names ``capabilities_degraded`` on
+        ``ModeResult``, so before the fix they fail on a missing kwarg — which
+        demonstrates only that the attribute does not exist yet. This one feeds
+        the runner a producer dict of exactly the shape ``unified_pipeline``
+        already emits today, runs the real reader chain (runner ->
+        ``ModeResult`` -> report), and requires the capability's NAME to come
+        out the far end.
+
+        ⚠ It deliberately does NOT compare two reports for inequality. That
+        was the first draft, and it was an assertion that cannot fail:
+        ``generate_report`` stamps ``Generated: {datetime.now().isoformat()}``
+        (``:1701``), so two reports built from *identical* input are already
+        unequal — measured. Such a control is green for any inputs whatsoever.
+        """
+        report = harness.generate_report(
+            [
+                _drive_pipeline(
+                    {
+                        "summary": {"completed": 15, "total": 15},
+                        "state_snapshot": {"fallacy_count": 10},
+                        "capabilities_used": ["hierarchical_fallacy_detection"],
+                        "capabilities_degraded": ["neural_fallacy_detection"],
+                        "capabilities_missing": [],
+                    }
+                )
+            ]
+        )
+        assert "neural_fallacy_detection" in report, (
+            "#1749: the producer declared a capability as degraded and the "
+            "artefact never mentions it. A reader counts 1 used / 0 missing "
+            "and concludes full coverage on a run that was wrong by exactly "
+            "one capability — the instrument that exists to detect this defect "
+            "elsewhere is blind to it in its own output."
+        )
+
+    def test_pipeline_runner_carries_the_degraded_ledger(self) -> None:
+        """Hop 1a: producer dict -> ``ModeResult`` (pipeline)."""
+        result = _drive_pipeline(
+            {
+                "summary": {"completed": 15, "total": 15},
+                "state_snapshot": {"fallacy_count": 10, "argument_count": 4},
+                "capabilities_used": ["hierarchical_fallacy_detection"],
+                "capabilities_degraded": ["neural_fallacy_detection"],
+                "capabilities_missing": [],
+            }
+        )
+        assert result.capabilities_degraded == ["neural_fallacy_detection"], (
+            "#1749: the pipeline runner dropped ``capabilities_degraded``. A "
+            "capability that RAN and returned nothing is in neither ``used`` "
+            "nor ``missing`` — dropping the third list makes it invisible, and "
+            "the report then claims full coverage on a truncated ledger."
+        )
+
+    def test_conversational_runner_carries_the_degraded_ledger(self) -> None:
+        """Hop 1b: producer dict -> ``ModeResult`` (conversational).
+
+        The defect blinds BOTH ledger-emitting modes, so both runners need the
+        control — fixing only the pipeline would leave the conversational row
+        silently truncated.
+        """
+        result = _drive_conversational(
+            {
+                "phases": ["a", "b"],
+                "state_snapshot": {},
+                "conversation_log": [],
+                "capabilities_used": ["fact_extraction"],
+                "capabilities_degraded": ["formal_translation"],
+                "capabilities_missing": [],
+            }
+        )
+        assert result.capabilities_degraded == ["formal_translation"], (
+            "#1749: the conversational runner dropped ``capabilities_degraded`` "
+            f"(got {result.capabilities_degraded!r})."
+        )
+
+    def test_report_names_the_degraded_capability(self) -> None:
+        """Hop 2: ``ModeResult`` -> report. The DoD's literal requirement.
+
+        Not "a degraded count appears" — the NAME must appear, because the
+        corrective action differs per capability (configure an endpoint vs
+        wire a provider).
+        """
+        report = harness.generate_report(
+            [
+                harness.ModeResult(
+                    mode="pipeline_standard",
+                    corpus_id="corpus_A",
+                    success=True,
+                    duration_seconds=1.0,
+                    phases_completed=15,
+                    phases_total=15,
+                    capabilities_used=["hierarchical_fallacy_detection"],
+                    capabilities_degraded=["neural_fallacy_detection"],
+                    capabilities_missing=[],
+                    scope_of_work="pipeline",
+                ),
+            ]
+        )
+        assert "neural_fallacy_detection" in report, (
+            "#1749: the degraded capability is not named anywhere in the "
+            "report. It ran and produced nothing; a reader of this artefact "
+            "cannot see that."
+        )
+
+    def test_report_shows_the_three_states_together(self) -> None:
+        """The third list is rendered BESIDE the other two, same visibility.
+
+        "14 used / 1 degraded / 0 missing" is readable; "14 used / 0 missing"
+        with a footnote is not — that is how the state got lost in the first
+        place.
+        """
+        report = harness.generate_report(
+            [
+                harness.ModeResult(
+                    mode="pipeline_standard",
+                    corpus_id="corpus_A",
+                    success=True,
+                    duration_seconds=1.0,
+                    phases_completed=15,
+                    phases_total=15,
+                    capabilities_used=["a", "b"],
+                    capabilities_degraded=["c"],
+                    capabilities_missing=[],
+                    scope_of_work="pipeline",
+                ),
+            ]
+        )
+        assert "2 used / 1 degraded / 0 missing" in report, (
+            "#1749: the three capability states are not rendered together as a "
+            "single ledger line. Found instead:\n"
+            + "\n".join(ln for ln in report.splitlines() if "used" in ln)
+        )
+
+
+class TestAbsentLedgerIsNotAnEmptyLedger:
+    """DoD item 3 — a mode that emits NO ledger renders ``n/a``, never ``0``.
+
+    Same convention as CG #1540 / #1740: a value read from an absent field is
+    indistinguishable from a measured zero unless the two render differently.
+    ``hierarchical_bridge`` / ``hierarchical_delegation`` /
+    ``conversation_deterministic`` emit none of the three keys (measured on
+    their return dicts), so "0 degraded" would be a fabricated measurement.
+    """
+
+    def test_a_mode_with_no_ledger_renders_n_a(self) -> None:
+        report = harness.generate_report(
+            [
+                harness.ModeResult(
+                    mode="hierarchical_delegation",
+                    corpus_id="corpus_A",
+                    success=True,
+                    duration_seconds=1.0,
+                    phases_completed=4,
+                    phases_total=5,
+                    scope_of_work="delegation",
+                ),
+            ]
+        )
+        ledger_lines = [ln for ln in report.splitlines() if "capabilities" in ln]
+        assert any("n/a" in ln for ln in ledger_lines), (
+            "#1749 DoD-3: a mode emitting no capability ledger must render "
+            "``n/a``, not a fabricated ``0 degraded``. Ledger lines found:\n"
+            + "\n".join(ledger_lines)
+        )
+        assert not any(
+            "0 degraded" in ln for ln in ledger_lines
+        ), "#1749 DoD-3: ``0 degraded`` asserts a measurement never made here."
+
+    def test_an_emitted_empty_ledger_renders_zero(self) -> None:
+        """The counterpart control: ``[]`` really does mean "none degraded".
+
+        Without this, "fix" could mean rendering ``n/a`` everywhere, which
+        destroys the distinction rather than restoring it.
+        """
+        report = harness.generate_report(
+            [
+                harness.ModeResult(
+                    mode="pipeline_standard",
+                    corpus_id="corpus_A",
+                    success=True,
+                    duration_seconds=1.0,
+                    phases_completed=15,
+                    phases_total=15,
+                    capabilities_used=["a"],
+                    capabilities_degraded=[],
+                    capabilities_missing=[],
+                    scope_of_work="pipeline",
+                ),
+            ]
+        )
+        assert "1 used / 0 degraded / 0 missing" in report, (
+            "#1749: an EMITTED empty ledger must read ``0 degraded`` — the "
+            "mode looked and found none. Collapsing it to ``n/a`` loses the "
+            "very distinction this issue restores."
+        )
+
+
+class TestTheThreeStatesStayDistinct:
+    """Anti-pendule, transcribed as controls rather than prose.
+
+    These stay GREEN before and after the fix. Without them, "correcting"
+    #1749 could mean folding the third state into one of the other two — which
+    is exactly the defect, with a different sign.
+    """
+
+    def test_degraded_is_not_folded_into_used(self) -> None:
+        """Anti-pendule 1: a degraded capability must NOT count as used.
+
+        The producer removes it from ``used`` on purpose (#1019). Putting it
+        back would make the harness report theatre as coverage.
+        """
+        result = _drive_pipeline(
+            {
+                "summary": {"completed": 15, "total": 15},
+                "state_snapshot": {},
+                "capabilities_used": ["a"],
+                "capabilities_degraded": ["degraded_one"],
+                "capabilities_missing": [],
+            }
+        )
+        assert "degraded_one" not in result.capabilities_used, (
+            "#1749 anti-pendule: a degraded capability was folded back into "
+            "``capabilities_used``. The producer excludes it deliberately."
+        )
+
+    def test_degraded_is_not_folded_into_missing(self) -> None:
+        """Anti-pendule 2: "ran and returned nothing" != "no provider".
+
+        The two call for opposite corrections (configure the environment vs
+        wire a provider), so merging them destroys the actionable content.
+        """
+        result = _drive_pipeline(
+            {
+                "summary": {"completed": 15, "total": 15},
+                "state_snapshot": {},
+                "capabilities_used": ["a"],
+                "capabilities_degraded": ["degraded_one"],
+                "capabilities_missing": ["absent_one"],
+            }
+        )
+        assert result.capabilities_missing == ["absent_one"], (
+            "#1749 anti-pendule: the degraded capability leaked into "
+            f"``capabilities_missing`` (got {result.capabilities_missing!r})."
+        )
+        assert "absent_one" not in (result.capabilities_degraded or []), (
+            "#1749 anti-pendule: a missing capability leaked into the degraded "
+            "ledger."
+        )
+
+    def test_a_producer_that_stops_emitting_degrades_to_n_a_not_zero(self) -> None:
+        """The safe side, at the runner hop.
+
+        If the producer ever stops emitting the key, the runner must land on
+        ``None`` ("no ledger") rather than a ``[]`` default that would assert
+        "looked, found none" — the phantom-key defect this file exists for.
+        """
+        result = _drive_pipeline(
+            {
+                "summary": {"completed": 15, "total": 15},
+                "state_snapshot": {},
+                "capabilities_used": ["a"],
+                "capabilities_missing": [],
+            }
+        )
+        assert result.capabilities_degraded is None, (
+            "#1749: an absent ``capabilities_degraded`` key must yield None "
+            "(renders ``n/a``), never a ``[]`` default that fabricates "
+            f"'looked, found none'. Got {result.capabilities_degraded!r}."
+        )


### PR DESCRIPTION
Le pipeline rend **trois** états de capacité — `used` / `degraded` / `missing`. Le harnais de comparaison n'en lisait que **deux**. Une capacité qui a tourné et n'a rien rendu n'apparaissait ni dans l'une ni dans l'autre : un lecteur comptait « 14 utilisées / 0 manquante » et concluait à une couverture complète sur un run faux d'exactement une capacité.

Le producteur est **correct** et le documente — `_collect_degraded_capabilities` (`unified_pipeline.py:55-99`) retire les dégradées de `capabilities_used` *délibérément*, « *so a degraded capability surfaces as degraded, NOT as `used`* » (#1019), et émet la troisième liste à côté. **La perte est au saut de lecture**, ce que les tests épinglent : ils suivent la traversée `dict producteur → ModeResult → rapport` et jamais la présence du champ chez le producteur (déjà couverte par `test_unified_pipeline.py`).

## Le correctif

- `ModeResult.capabilities_degraded: Optional[List[str]] = None`. **`None` ≠ `[]`** (même convention que `state_fill_rate`, CG #1540) : `None` = « ce mode n'émet pas de registre » ⇒ `n/a` ; `[]` = « registre émis, rien de dégradé » ⇒ `0`. Un registre absent n'est pas un registre vide.
- Les **deux** runners porteurs de registre le lisent (`run_pipeline_mode`, `run_conversational_mode`), **sans défaut `[]`** : une clé absente atterrit sur `None`, jamais sur un `[]` qui affirmerait « j'ai regardé, il n'y en a pas ». C'est le défaut de clé-fantôme qui a déjà mordu ce fichier deux fois (CB #1528 item 3, #1560).
- `_capability_ledger_lines()` rend les trois états **sur une ligne**, avec les **noms** des dégradées — l'action corrective est par capacité (configurer un endpoint vs câbler un fournisseur), un compte nu dirait qu'il y a un problème sans dire quoi en faire.

## La table qui décide qui peut revendiquer un registre

Mesurée sur les dicts de retour, pas reprise du body de l'issue :

| runner | `used` | `degraded` | `missing` |
|---|---|---|---|
| `pipeline` | ✅ | ✅ | ✅ |
| `conversational` | ✅ | ✅ | ✅ |
| `hierarchical_bridge` | ❌ | ❌ | ❌ |
| `hierarchical_delegation` | ❌ | ❌ | ❌ |
| `conversation_deterministic` | ❌ | ❌ | ❌ |

⚠ **Correction à mon propre body d'issue** : j'y supposais le bridge porteur du registre. Il ne l'est pas — son dict de retour porte 8 clés et aucune des trois. Son `result.get("capabilities_used", [])` lit donc une clé jamais émise. Défaut distinct, déposé en **#1756** (il ne fausse aucun chiffre publié aujourd'hui — `perimeter_is_exhaustive` le protège depuis #1753 — mais #1749 le rend *lisible*, et son bon rendu y tient par coïncidence).

## Contrôles rouge-avant-fix — et leur tri

10 tests. Le tri compte plus que le compte : **un test qui échoue sur un kwarg manquant prouve que le champ est neuf, pas que le défaut existe.**

| | avant le fix | ce que ça prouve |
|---|---|---|
| `test_producer_declared_degradation_reaches_the_artefact` | 🔴 **assertion atteinte** | le défaut : le nom déclaré par le producteur n'atteint pas l'artefact |
| `test_a_mode_with_no_ledger_renders_n_a` | 🔴 **assertion atteinte** | aucune ligne de registre n'existe |
| 7 autres | 🔴 signature (`TypeError` / `AttributeError`) | le champ est neuf — **rien de plus** |
| `test_degraded_is_not_folded_into_used` | 🟢 **vert avant ET après** | l'anti-pendule tient déjà ; sans lui, « corriger » pourrait vouloir dire aplatir |

### ⚠ Le premier contrôle était infalsifiable — et c'est le contrôle lui-même qui l'a montré

La première version comparait deux rapports (dégradé vs propre) et exigeait qu'ils **diffèrent**. Elle est passée au vert sur `main` non corrigé. Sonde sur l'instrument, **même entrée deux fois** :

```
SAME INPUT, two reports equal?  False
Generated: 2026-08-14T19:37:07.878020
Generated: 2026-08-14T19:37:19.707800
```

`generate_report` estampille `datetime.now().isoformat()` (`:1701`) ⇒ **deux rapports construits sur une entrée identique sont déjà inégaux**. L'assertion était verte pour n'importe quelles entrées. Remplacée par une exigence falsifiable (le **nom** sort en bout de chaîne). La leçon est dans le docstring du test pour que le prochain lecteur ne la refasse pas.

## Anti-pendule (transcrits en tests)

- **Ne pas** remettre les dégradées dans `capabilities_used` — le producteur les en retire exprès ; les y remettre ferait compter le théâtre comme de la couverture (`test_degraded_is_not_folded_into_used`).
- **Ne pas** les ranger dans `capabilities_missing` — « a tourné et n'a rien rendu » et « aucun fournisseur » appellent des corrections **opposées** (`test_degraded_is_not_folded_into_missing`).
- **Ne pas** rendre `n/a` partout : un registre émis vide vaut bien `0 degraded` (`test_an_emitted_empty_ledger_renders_zero`). Sans ce contre-contrôle, « corriger » pourrait détruire la distinction au lieu de la restaurer.
- **Ne pas** traiter `neural_detect` à 0,00 s comme le défaut : c'est le fail-loud qui **fonctionne**. Le défaut est qu'on ne le voyait pas.

## Tests

**Périmètre nommé** — les 8 fichiers de test qui nomment le module (`grep -rl compare_orchestration_modes tests/`), pas le seul répertoire où j'ai trouvé le premier. `black` et `flake8` propres.

## Conséquence sur les résultats publiés

Le caveat que je portais sur #1735 se lève : les tableaux cross-mode distingueront désormais exécuté-réel d'exécuté-dégradé. Les chiffres de `sweep_1735_R808_A` restent valides — ils étaient incomplets, pas faux.

Instrument, pas politique. Famille #1019 · voisin de #1753 (même fichier, saut de lecture) et #1756 (déposé en le construisant).

Closes #1749

🤖 Generated with [Claude Code](https://claude.com/claude-code)
