### PR TITLE
fix(steering): an off-casting designation leaves a readable trace entry (#1751)

### DIFF
--- a/argumentation_analysis/core/shared_state.py
+++ b/argumentation_analysis/core/shared_state.py
@@ -59,6 +59,36 @@ class DesignationRecord:
     delta_summary: Optional[str] = None
 
 
+def record_unresolved_designation(
+    state: Any,
+    requested_agent: str,
+    present_agents: List[str],
+    selection_path: str = "",
+) -> None:
+    """Guarded entry point for :meth:`UnifiedAnalysisState.record_designation_unresolved`.
+
+    #1751. The three selectors that can absorb a designation
+    (``DelegatingSelectionStrategy``, ``BalancedParticipationStrategy``,
+    ``conversational_orchestrator._select_next_agent``) only ever type-check the
+    ``RhetoricalAnalysisState`` **base**, which carries no deliberation trace.
+    Recording is therefore best-effort: on a state without the trace this is a
+    no-op and selection proceeds exactly as before. Making it mandatory would
+    turn every non-conversational caller into an ``AttributeError`` — a louder
+    absorption is not worth a new crash site.
+    """
+    recorder = getattr(state, "record_designation_unresolved", None)
+    if recorder is None:
+        return
+    try:
+        recorder(
+            requested_agent=requested_agent,
+            present_agents=present_agents,
+            selection_path=selection_path,
+        )
+    except Exception:  # pragma: no cover - never let bookkeeping break selection
+        state_logger.debug("record_designation_unresolved failed", exc_info=True)
+
+
 class RhetoricalAnalysisState:
     """Représente l'état partagé d'une analyse rhétorique collaborative."""
 
@@ -633,8 +663,16 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
             open record is for a different agent and is left open).
         """
         for record in reversed(self.deliberation_trace):
-            if record.get("record_type") == "cap_breach":
-                continue  # audit marker, not a designation
+            if record.get("record_type") is not None:
+                # #1751: skip ANY marker, not just ``cap_breach``. A genuine
+                # DesignationRecord carries no ``record_type`` at all (asdict of
+                # the dataclass), so testing for a marker positively keeps this
+                # loop correct for every marker type added later. The previous
+                # ``== "cap_breach"`` exclusion list would have let a
+                # ``designation_unresolved`` marker — which has no
+                # ``designated_agent`` — match the "open record" branch and
+                # block the backfill of the real record underneath it.
+                continue
             if record.get("state_fingerprint_after") is None:
                 if record.get("designated_agent") != agent:
                     return False  # open record exists, but for another agent
@@ -690,6 +728,63 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
             turn,
             cap_kind,
             detail,
+        )
+
+    def record_designation_unresolved(
+        self,
+        requested_agent: str,
+        present_agents: List[str],
+        turn: Optional[int] = None,
+        selection_path: str = "",
+    ) -> None:
+        """Record a PM designation that named an agent absent from the room.
+
+        #1751. The conversational ``AgentGroupChat`` is built **per phase** with
+        the 3-4 agents of ``phase_cfg["agents"]``, while the PM is prompted with
+        a map of 8 and told no sequence is imposed. Designating an agent outside
+        its phase used to log an ERROR and fall through to the default agent —
+        which, the PM being first in every casting, is the PM itself. The turn
+        that followed was indistinguishable from an honoured one.
+
+        The weaker reading — "the DesignationRecord stays open, so the trace
+        already says it" — does not hold: an open record is *equally* the
+        signature of an agent that has not spoken **yet** and of a run cut by a
+        cap. This marker is what separates the three.
+
+        Fail-loud without fail-fast (``feedback_no_fallback_fail_loud``): the
+        selection still returns someone, so one hallucinated agent name cannot
+        abort a run — but it can no longer pass for steering that happened.
+
+        Args:
+            requested_agent: Exact name the PM asked for.
+            present_agents: Roster actually in the room. This is the material a
+                re-prompt hands back to the PM, and what tells a reader "wrong
+                room" rather than "typo".
+            turn: Pipeline-global turn index (auto: len(trace)+1).
+            selection_path: Which selector absorbed it ("delegating",
+                "balanced", "round_robin") — the three share the shape, not the
+                fallback, so the corrective action differs.
+        """
+        if turn is None:
+            turn = len(self.deliberation_trace) + 1
+        self.deliberation_trace.append(
+            {
+                "record_type": "designation_unresolved",
+                "requested_agent": requested_agent,
+                "present_agents": list(present_agents),
+                "turn": turn,
+                "selection_path": selection_path,
+                "state_fingerprint_before": self._designation_fingerprint(),
+            }
+        )
+        state_logger.warning(
+            "[#1751] Désignation non résolue tour %s: '%s' absent de la salle "
+            "%s (sélecteur=%s) — le tour qui suit n'est PAS une désignation "
+            "honorée.",
+            turn,
+            requested_agent,
+            list(present_agents),
+            selection_path or "?",
         )
 
     def set_source_metadata(self, metadata: Dict[str, str]) -> None:

--- a/argumentation_analysis/core/strategies.py
+++ b/argumentation_analysis/core/strategies.py
@@ -32,7 +32,7 @@ from semantic_kernel.agents.strategies.termination.termination_strategy import (
 )
 
 # Importer la classe d'état
-from .shared_state import RhetoricalAnalysisState
+from .shared_state import RhetoricalAnalysisState, record_unresolved_designation
 
 # Type hinting
 if TYPE_CHECKING:
@@ -199,6 +199,16 @@ class DelegatingSelectionStrategy(SelectionStrategy):
                     )
                     return designated_agent
                 else:
+                    # #1751: a log line is not an effect. The turn that follows
+                    # is the DEFAULT agent — the PM, first in every phase
+                    # casting — so without a trace entry an absorbed
+                    # designation is indistinguishable from an honoured one.
+                    record_unresolved_designation(
+                        self._analysis_state,
+                        requested_agent=designated_agent_name,
+                        present_agents=list(self._agents_map.keys()),
+                        selection_path="delegating",
+                    )
                     self._logger.error(
                         f"[{self._instance_id}] Agent désigné '{designated_agent_name}' INTROUVABLE! Poursuite avec fallback."
                     )
@@ -387,6 +397,15 @@ class BalancedParticipationStrategy(SelectionStrategy):
                     self._adjust_imbalance_budget(designated_agent.name)
                     return designated_agent
                 else:
+                    # #1751: sibling of the DelegatingSelectionStrategy site —
+                    # same shape, different fallback (participation balancing).
+                    # The issue named one site; grepping the shape found three.
+                    record_unresolved_designation(
+                        self._analysis_state,
+                        requested_agent=designated_agent_name,
+                        present_agents=list(self._agents_map.keys()),
+                        selection_path="balanced",
+                    )
                     self._logger.error(
                         f"[{self._instance_id}] Agent désigné '{designated_agent_name}' INTROUVABLE! Poursuite avec équilibrage."
                     )

--- a/argumentation_analysis/orchestration/conversational_orchestrator.py
+++ b/argumentation_analysis/orchestration/conversational_orchestrator.py
@@ -43,6 +43,7 @@ from argumentation_analysis.core.llm_service import create_llm_service
 from argumentation_analysis.core.shared_state import (
     RhetoricalAnalysisState,
     UnifiedAnalysisState,
+    record_unresolved_designation,
 )
 from argumentation_analysis.core.state_manager_plugin import StateManagerPlugin
 from argumentation_analysis.orchestration.trace_analyzer import (
@@ -994,9 +995,21 @@ async def _run_conversational_analysis_inner(
 
         phase_name = phase_cfg["name"]
         phase_agent_names = phase_cfg["agents"]
-        phase_agents = [
-            agent_by_name[n] for n in phase_agent_names if n in agent_by_name
-        ]
+        phase_agents, phase_agents_missing = _resolve_phase_agents(
+            agent_by_name, phase_agent_names
+        )
+        if phase_agents_missing:
+            # #1751 item 3: name them. A phase that runs with 2 of its 4 agents
+            # is not the phase that was configured, and the PM is steering in
+            # the shrunken room without being told.
+            logger.warning(
+                "[#1751] Phase '%s': %d agent(s) du casting absents du roster "
+                "et retirés de la salle: %s (présents: %s)",
+                phase_name,
+                len(phase_agents_missing),
+                phase_agents_missing,
+                [getattr(a, "name", "?") for a in phase_agents],
+            )
 
         if not phase_agents:
             logger.warning(f"No agents available for phase '{phase_name}', skipping")
@@ -1539,15 +1552,21 @@ async def _run_conversational_analysis_inner(
             "exhausted": budget_exhausted,
             "max_wall_seconds": max_wall_seconds,
             "wall_clock_bounded": wall_clock_bounded,
-            "deliberation_turn_count": sum(
-                1
-                for r in getattr(state, "deliberation_trace", [])
-                if r.get("record_type") != "cap_breach"
-            ),
+            "deliberation_turn_count": _deliberation_turn_count(state),
             "cap_breaches": [
                 r
                 for r in getattr(state, "deliberation_trace", [])
                 if r.get("record_type") == "cap_breach"
+            ],
+            # #1751: designations the PM emitted for an agent absent from its
+            # phase room. Surfaced next to the caps because it is the same kind
+            # of fact: the run did not do what the trace appears to say. A
+            # non-empty list means the chief was contradicted by the casting,
+            # not that it changed its mind.
+            "designations_unresolved": [
+                r
+                for r in getattr(state, "deliberation_trace", [])
+                if r.get("record_type") == "designation_unresolved"
             ],
         },
         "status": (
@@ -1779,6 +1798,39 @@ _RE_PROMPT_FEEDBACK = (
 )
 
 
+def _deliberation_turn_count(state: Any) -> int:
+    """Number of genuine PM designations in the deliberation trace (#1751).
+
+    A DesignationRecord carries **no** ``record_type`` (it is the ``asdict`` of
+    the dataclass); every non-designation entry declares one. Counting by
+    allow-list — "a designation is a record with no marker" — instead of by
+    exclusion list ("everything that is not a ``cap_breach``") is what keeps
+    this number honest when a marker type is added: the previous form would
+    have silently counted each ``designation_unresolved`` as one more
+    deliberation turn, inflating the very metric #1751 exists to correct.
+    """
+    return sum(
+        1
+        for r in getattr(state, "deliberation_trace", [])
+        if r.get("record_type") is None
+    )
+
+
+def _resolve_phase_agents(
+    agent_by_name: Dict[str, Any], phase_agent_names: List[str]
+) -> Tuple[List[Any], List[str]]:
+    """Resolve a phase casting, returning the agents AND the names that missed.
+
+    #1751 scope item 3. The comprehension this replaces dropped any unknown
+    name silently, so a phase configured with four agents could run with two
+    and say nothing. The room the PM is steering in is exactly what this issue
+    is about: it has to be reported, not inferred.
+    """
+    resolved = [agent_by_name[n] for n in phase_agent_names if n in agent_by_name]
+    missing = [n for n in phase_agent_names if n not in agent_by_name]
+    return resolved, missing
+
+
 def _validate_state_growth(
     fingerprint_before: tuple[int, ...],
     fingerprint_after: tuple[int, ...],
@@ -1818,7 +1870,16 @@ def _select_next_agent(
                 logger.debug(f"  PM designated agent: {designated}")
                 return agent
 
-        # Designated agent not in this phase, fall through to round-robin
+        # Designated agent not in this phase, fall through to round-robin.
+        # #1751: third absorption site, and the quietest of the three — DEBUG.
+        # Round-robin then hands the floor to whoever is next in the casting,
+        # which reads downstream as an ordinary turn.
+        record_unresolved_designation(
+            state,
+            requested_agent=designated,
+            present_agents=[getattr(a, "name", "?") for a in agents],
+            selection_path="round_robin",
+        )
         logger.debug(
             f"  PM designated '{designated}' but not in phase agents, using round-robin"
         )

--- a/tests/unit/argumentation_analysis/orchestration/test_designation_absorption_1751.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_designation_absorption_1751.py
@@ -1,0 +1,371 @@
+"""#1751 — an off-casting PM designation must never be silently absorbed.
+
+The conversational PM gets a free-steering mandate and a map of 8 agents, but
+it never sits in a room of 8: ``conversational_orchestrator.phase_configs``
+freezes three phases with a hard-coded casting of 3-4 agents each, and the
+``AgentGroupChat`` is built per phase with that casting alone. When the PM
+designates an agent outside its room, the selection strategy logs and falls
+through to the default agent — which, the PM being first in every casting, is
+**the PM itself**. The designation is recorded in the deliberation trace, so
+the trace says "I convene X" while the execution shows the PM taking the floor
+again.
+
+Measured on ``sweep_1735_R808_A`` / corpus_A: 13 designations, **2 absorbed**
+(``InformalAgent``, ``CounterAgent``), both emitted from the phase-2 room.
+
+## Three sites, not the one the issue named
+
+The issue named ``core/strategies.py:195-204``. Grepping the *shape* rather
+than the line turns up three:
+
+===========================================  =========================  =======
+site                                         falls back to              log
+===========================================  =========================  =======
+``DelegatingSelectionStrategy.next``         default agent (= the PM)   ERROR
+``BalancedParticipationStrategy.next``       participation balancing    ERROR
+``conversational_orchestrator._select_...``  round-robin                DEBUG
+===========================================  =========================  =======
+
+## What these tests assert — and what they refuse to assert
+
+The DoD requires an assertion on the **effect**, not on the log. A log line is
+not an effect: nothing downstream reads it, and asserting on ``caplog`` would
+have passed against a fix that only reworded the message.
+
+They also refuse the weaker reading "an absorbed designation leaves its record
+open, so the trace already carries the information". It does not discriminate:
+a record left open is *equally* the signature of (a) an absorbed designation,
+(b) a designation whose agent simply has not spoken yet, and (c) a run cut by
+the wall-clock cap before the agent returned. Three causes, one signature —
+:class:`TestAbsorbedIsDistinguishableFromPending` pins exactly that.
+"""
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _agent(name: str) -> MagicMock:
+    agent = MagicMock()
+    agent.name = name
+    return agent
+
+
+def _state(text: str = "Texte argumentatif de test."):
+    """The state the conversational path actually runs on.
+
+    The deliberation trace (and the whole designation-record API) lives on
+    ``UnifiedAnalysisState``, NOT on its ``RhetoricalAnalysisState`` base — the
+    selection strategies only type-check the base, so the recording call has to
+    stay optional. :func:`test_base_state_without_a_trace_still_selects` is the
+    control for that.
+    """
+    from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+
+    return UnifiedAnalysisState(text)
+
+
+def _unresolved(state) -> list:
+    """The unresolved-designation markers in a state's deliberation trace."""
+    return [
+        r
+        for r in getattr(state, "deliberation_trace", [])
+        if r.get("record_type") == "designation_unresolved"
+    ]
+
+
+# The phase-2 casting of the real ``phase_configs``, which is where both
+# measured absorptions were emitted from.
+PHASE_2_CASTING = ["ProjectManager", "FormalAgent", "QualityAgent"]
+
+
+class TestOffCastingDesignationLeavesAnObservableEffect:
+    """The defect: designating an absent agent produces nothing readable."""
+
+    def test_delegating_strategy_records_an_unresolved_marker(self):
+        from argumentation_analysis.core.strategies import (
+            DelegatingSelectionStrategy,
+        )
+
+        state = _state()
+        agents = [_agent(n) for n in PHASE_2_CASTING]
+        strategy = DelegatingSelectionStrategy(agents, state)
+
+        state.designate_next_agent("InformalAgent")  # not in the phase-2 room
+        selected = asyncio.run(strategy.next(agents, []))
+
+        # The run is not aborted — the PM still takes the floor.
+        assert selected.name == "ProjectManager"
+        # ...but the floor it takes is no longer indistinguishable from an
+        # honoured turn.
+        markers = _unresolved(state)
+        assert len(markers) == 1, (
+            "an off-casting designation must leave a readable trace entry, "
+            f"got {state.deliberation_trace!r}"
+        )
+
+    def test_the_marker_names_the_request_and_the_room(self):
+        """A count says there is a problem; the corrective action needs names."""
+        from argumentation_analysis.core.strategies import (
+            DelegatingSelectionStrategy,
+        )
+
+        state = _state()
+        agents = [_agent(n) for n in PHASE_2_CASTING]
+        strategy = DelegatingSelectionStrategy(agents, state)
+
+        state.designate_next_agent("CounterAgent")
+        asyncio.run(strategy.next(agents, []))
+
+        marker = _unresolved(state)[0]
+        assert marker["requested_agent"] == "CounterAgent"
+        # The roster actually present is what a re-prompt would have to hand
+        # back to the PM, and what tells a reader "wrong room", not "typo".
+        assert sorted(marker["present_agents"]) == sorted(PHASE_2_CASTING)
+
+    def test_balanced_strategy_absorbs_the_same_way(self):
+        """Sibling site — same shape, same silence, different fallback."""
+        from argumentation_analysis.core.strategies import (
+            BalancedParticipationStrategy,
+        )
+
+        state = _state()
+        agents = [_agent(n) for n in PHASE_2_CASTING]
+        strategy = BalancedParticipationStrategy(
+            agents, state, default_agent_name="ProjectManager"
+        )
+
+        state.designate_next_agent("InformalAgent")
+        asyncio.run(strategy.next(agents, []))
+
+        assert len(_unresolved(state)) == 1
+
+    def test_round_robin_path_absorbs_the_same_way(self):
+        """Third site: the non-AgentGroupChat path, at DEBUG level."""
+        from argumentation_analysis.orchestration.conversational_orchestrator import (
+            _select_next_agent,
+        )
+
+        state = _state()
+        agents = [_agent(n) for n in PHASE_2_CASTING]
+
+        state.designate_next_agent("InformalAgent")
+        selected = _select_next_agent(state, agents, turn=0)
+
+        assert selected in agents  # round-robin still yields someone
+        assert len(_unresolved(state)) == 1
+
+
+class TestHonouredDesignationIsUnaffected:
+    """Anti-pendulum — GREEN before the fix and after.
+
+    Without this half, "fixing" the absorption could mean marking every
+    designation, or refusing designations altogether. Both would be worse than
+    the defect: the PM's steering is the thing #1751 is trying to restore, not
+    remove.
+    """
+
+    def test_honoured_designation_returns_the_designated_agent(self):
+        from argumentation_analysis.core.strategies import (
+            DelegatingSelectionStrategy,
+        )
+
+        state = _state()
+        agents = [_agent(n) for n in PHASE_2_CASTING]
+        strategy = DelegatingSelectionStrategy(agents, state)
+
+        state.designate_next_agent("FormalAgent")  # in the room
+        selected = asyncio.run(strategy.next(agents, []))
+
+        assert selected.name == "FormalAgent"
+
+    def test_honoured_designation_records_no_marker(self):
+        from argumentation_analysis.core.strategies import (
+            DelegatingSelectionStrategy,
+        )
+
+        state = _state()
+        agents = [_agent(n) for n in PHASE_2_CASTING]
+        strategy = DelegatingSelectionStrategy(agents, state)
+
+        state.designate_next_agent("QualityAgent")
+        asyncio.run(strategy.next(agents, []))
+
+        assert _unresolved(state) == []
+
+    def test_no_designation_at_all_records_no_marker(self):
+        """Absence of a designation is not a failed designation."""
+        from argumentation_analysis.core.strategies import (
+            DelegatingSelectionStrategy,
+        )
+
+        state = _state()
+        agents = [_agent(n) for n in PHASE_2_CASTING]
+        strategy = DelegatingSelectionStrategy(agents, state)
+
+        asyncio.run(strategy.next(agents, []))
+
+        assert _unresolved(state) == []
+
+    def test_base_state_without_a_trace_still_selects(self):
+        """A state that carries no trace must not become a crash site.
+
+        ``RhetoricalAnalysisState`` (the base the strategies type-check) has no
+        deliberation trace at all. Recording is therefore best-effort: the
+        selection must behave exactly as before on such a state. Without this,
+        "make the absorption loud" would turn every non-conversational caller
+        of the strategy into an ``AttributeError``.
+        """
+        from argumentation_analysis.core.shared_state import RhetoricalAnalysisState
+        from argumentation_analysis.core.strategies import (
+            DelegatingSelectionStrategy,
+        )
+
+        state = RhetoricalAnalysisState("t")
+        agents = [_agent(n) for n in PHASE_2_CASTING]
+        strategy = DelegatingSelectionStrategy(agents, state)
+
+        state.designate_next_agent("InformalAgent")
+        selected = asyncio.run(strategy.next(agents, []))
+
+        assert selected.name == "ProjectManager"
+
+
+class TestAbsorbedIsDistinguishableFromPending:
+    """The defect stated exactly: two different situations, one trace.
+
+    Both states below end with a designation whose agent has not spoken. In one
+    the agent was absent from the room (absorbed, and never coming); in the
+    other it is present and simply has not had its turn yet. Before the fix the
+    two traces are **byte-identical**, so no reader can tell "the chief was
+    contradicted" from "the chief is waiting".
+    """
+
+    @staticmethod
+    def _trace_after_designating(target: str, casting: list) -> list:
+        from argumentation_analysis.core.strategies import (
+            DelegatingSelectionStrategy,
+        )
+
+        state = _state()
+        agents = [_agent(n) for n in casting]
+        strategy = DelegatingSelectionStrategy(agents, state)
+        # The PM motivates, then designates — the real order (CONV-C #1334).
+        state.record_designation(
+            agent=target,
+            motivation="Motivation identique dans les deux branches.",
+            trigger="deepening",
+        )
+        state.designate_next_agent(target)
+        asyncio.run(strategy.next(agents, []))
+        return state.deliberation_trace
+
+    def test_the_two_traces_differ_by_exactly_the_marker(self):
+        absorbed = self._trace_after_designating("InformalAgent", PHASE_2_CASTING)
+        pending = self._trace_after_designating("FormalAgent", PHASE_2_CASTING)
+
+        # Guard against a tautology: the DesignationRecord carries no clock and
+        # no uuid, so the only thing that may differ is the designated name and
+        # the marker itself. Neutralise the name so the comparison is about the
+        # marker alone.
+        def _normalised(trace):
+            out = []
+            for record in trace:
+                record = dict(record)
+                record.pop("designated_agent", None)
+                record.pop("requested_agent", None)
+                out.append(record)
+            return out
+
+        assert _normalised(absorbed) != _normalised(pending), (
+            "an absorbed designation and a merely-pending one produce the same "
+            "trace — nothing downstream can tell them apart"
+        )
+        assert len(absorbed) == len(pending) + 1
+        assert absorbed[-1]["record_type"] == "designation_unresolved"
+
+
+class TestTheMarkerDoesNotCorruptItsReaders:
+    """A new record type is a new hop for every reader of the trace.
+
+    ``deliberation_turn_count`` used to count every record that was not a
+    ``cap_breach`` — an exclusion list that silently absorbs each marker type
+    added after it. These two tests are the reason the reader was flipped to an
+    allow-list (a designation is a record carrying **no** ``record_type``).
+    """
+
+    def test_marker_is_not_counted_as_a_deliberation_turn(self):
+        from argumentation_analysis.orchestration.conversational_orchestrator import (
+            _deliberation_turn_count,
+        )
+
+        state = _state()
+        state.record_designation(agent="FormalAgent", motivation="m", trigger="initial")
+        assert _deliberation_turn_count(state) == 1
+
+        state.record_designation_unresolved(
+            requested_agent="InformalAgent", present_agents=PHASE_2_CASTING
+        )
+        state.record_cap_breach(cap_kind="wall_clock", turn=1, detail="d")
+
+        assert (
+            _deliberation_turn_count(state) == 1
+        ), "markers must not inflate the published turn count"
+
+    def test_marker_does_not_block_backfill_of_an_open_designation(self):
+        """A marker sitting on top of an open record must be stepped over."""
+        state = _state()
+        state.record_designation(agent="FormalAgent", motivation="m", trigger="initial")
+        state.record_designation_unresolved(
+            requested_agent="InformalAgent", present_agents=PHASE_2_CASTING
+        )
+
+        assert state.backfill_last_designation_for("FormalAgent") is True
+        designations = [
+            r for r in state.deliberation_trace if r.get("record_type") is None
+        ]
+        assert designations[0]["state_fingerprint_after"] is not None
+
+
+class TestPhaseCastingDropIsVisible:
+    """Scope item 3: a phase name absent from ``agent_by_name`` is dropped.
+
+    ``phase_agents = [agent_by_name[n] for n in phase_agent_names if n in
+    agent_by_name]`` silently shrinks the room. A phase that runs with 2 of its
+    4 agents is not the phase that was configured, and nothing said so.
+    """
+
+    def test_missing_phase_agents_are_named(self):
+        from argumentation_analysis.orchestration.conversational_orchestrator import (
+            _resolve_phase_agents,
+        )
+
+        agent_by_name = {"ProjectManager": _agent("ProjectManager")}
+        resolved, missing = _resolve_phase_agents(
+            agent_by_name, ["ProjectManager", "QualityAgent", "FormalAgent"]
+        )
+
+        assert [a.name for a in resolved] == ["ProjectManager"]
+        assert sorted(missing) == ["FormalAgent", "QualityAgent"]
+
+
+@pytest.mark.parametrize("target", ["InformalAgent", "CounterAgent"])
+def test_the_two_absorptions_measured_on_corpus_a_are_now_visible(target):
+    """End-to-end on the exact pair observed in ``sweep_1735_R808_A``.
+
+    Both were emitted from the phase-2 room. This is the run-level statement of
+    the defect, kept separate from the unit tests so a change in the phase
+    casting shows up here rather than silently weakening them.
+    """
+    from argumentation_analysis.core.strategies import DelegatingSelectionStrategy
+
+    state = _state()
+    agents = [_agent(n) for n in PHASE_2_CASTING]
+    strategy = DelegatingSelectionStrategy(agents, state)
+
+    state.designate_next_agent(target)
+    asyncio.run(strategy.next(agents, []))
+
+    markers = _unresolved(state)
+    assert [m["requested_agent"] for m in markers] == [target]


### PR DESCRIPTION
Closes #1751 — **partiellement**. Ce qui n'est pas livré est nommé plus bas, avec la raison de l'ordre choisi.

## Le défaut

Le PM conversationnel reçoit une carte de 8 agents et un mandat explicite de conduite libre (« aucune séquence n'est imposée »). Il ne siège jamais dans une salle de 8 : `phase_configs` fige **3 phases** avec un casting **codé en dur de 3-4 agents**, et l'`AgentGroupChat` est reconstruit par phase avec ce casting seul. Désigner un agent hors de sa salle tombait sur l'agent par défaut — et le PM étant premier dans chaque casting, **l'agent par défaut est le PM lui-même**. Le tour qui suivait était *indiscernable d'un tour honoré* : la trace dit « je convoque X », l'exécution montre le chef reprenant la parole.

Mesuré sur `sweep_1735_R808_A` / corpus_A : **13 désignations, 2 absorbées** (`InformalAgent`, `CounterAgent`), toutes deux émises depuis la salle de phase 2.

## L'issue nommait un site. Il y en a trois.

L'issue pointait `core/strategies.py:195-204`. En grepant la **forme** plutôt que la ligne :

| Site | Repli | Log |
|---|---|---|
| `DelegatingSelectionStrategy.next` | agent par défaut (= le PM) | ERROR |
| `BalancedParticipationStrategy.next` | équilibrage de participation | ERROR |
| `conversational_orchestrator._select_next_agent` | round-robin | DEBUG |

Trois répliques du même silence, trois replis différents — donc trois actions correctives différentes en aval. Le marqueur porte `selection_path` pour cette raison.

## Ce que ce PR livre

`UnifiedAnalysisState.record_designation_unresolved`, appelée aux trois sites via un point d'entrée module-level **gardé** : les sélecteurs ne type-checkent que la base `RhetoricalAnalysisState`, qui ne porte aucune trace de délibération. L'enregistrement est donc best-effort — sur un état sans trace c'est un no-op et la sélection se déroule exactement comme avant. **Une absorption plus bruyante ne vaut pas un nouveau site de crash** ; `test_base_state_without_a_trace_still_selects` est le contrôle de ça.

Le marqueur nomme l'agent demandé, **le roster réellement présent** (c'est la matière qu'un re-prompt rendrait au PM, et ce qui dit « mauvaise salle » plutôt que « faute de frappe »), et le sélecteur qui a absorbé. Il est exposé sur le dict de résultat, à côté des `cap_breaches` — même nature de fait : *le run n'a pas fait ce que la trace semble dire*.

**Fail-loud sans fail-fast** : la sélection rend toujours quelqu'un, donc un nom d'agent halluciné ne peut pas avorter un run — mais il ne peut plus passer pour du steering qui a eu lieu.

## Deux lecteurs retournés dans la même passe

Un nouveau type d'enregistrement est **un nouveau saut pour chaque lecteur de la trace**. Un `DesignationRecord` authentique ne porte **aucun** `record_type` (c'est l'`asdict` de la dataclass) ; tout le reste en déclare un. Les deux lecteurs testaient par **liste d'exclusion** (`!= "cap_breach"`), ce qui absorbe silencieusement chaque type ajouté après :

- `deliberation_turn_count` aurait compté chaque nouveau marqueur comme **un tour de délibération de plus** — gonflant précisément la métrique que #1751 existe pour corriger ;
- `backfill_last_designation_for` aurait fait **matcher le marqueur** (qui n'a pas de `designated_agent`) sur la branche « enregistrement ouvert » et **bloqué le backfill** du vrai enregistrement en dessous.

Les deux sont passés en **liste d'autorisation** (« une désignation est un enregistrement sans marqueur »), chacun avec son test dédié dans `TestTheMarkerDoesNotCorruptItsReaders`. Aucun autre lecteur de `deliberation_trace` n'existe dans le dépôt (vérifié par grep sur `argumentation_analysis/`, `scripts/`, `api/`, `interface_web/`).

Le **drop de casting de phase** est également rapporté : la compréhension qui résolvait `phase_cfg["agents"]` laissait tomber les noms inconnus en silence, donc une phase configurée avec 4 agents pouvait tourner avec 2 sans rien dire — or la salle dans laquelle le PM conduit est exactement le sujet de cette issue.

## Tests — rouge avant le fix, trié par *pourquoi* c'est rouge

Baseline mesurée avant d'écrire une ligne de production : **10 rouges / 4 verts**.

| Classe | n | Ce que ça prouve |
|---|---|---|
| **Rouge comportemental** (assertion atteinte) | 6 | Le défaut. C'est la seule classe qui prouve quelque chose. |
| **Rouge structurel** (`AttributeError`/`ImportError` — l'API n'existe pas encore) | 4 | Que l'API est neuve, rien de plus. |
| **Vert avant ET après** (anti-pendule) | 4 | Qu'« honorer une désignation » n'a pas été cassé en réparant l'absorption. |

La classe anti-pendule est là parce que « réparer » l'absorption pouvait vouloir dire marquer *toute* désignation, ou refuser les désignations. Les deux seraient pires que le défaut : le steering du PM est ce que #1751 cherche à **restaurer**, pas à retirer.

Deux assertions que ces tests **refusent** de faire :

1. **Sur le log.** La DoD demande l'effet ; une assertion `caplog` serait passée contre un fix qui n'aurait que reformulé le message.
2. **Sur l'enregistrement resté ouvert.** « La trace le dit déjà, l'enregistrement reste ouvert » ne discrimine pas : un enregistrement ouvert est **également** la signature (a) d'une désignation absorbée, (b) d'un agent qui n'a simplement pas encore parlé, (c) d'un run coupé par le cap wall-clock. Trois causes, une signature — `TestAbsorbedIsDistinguishableFromPending` épingle exactement ça.

## Ce qui n'est PAS livré ici

- **Scope item 2** — donner au PM le casting réel de sa phase dans le prompt de tour (aujourd'hui son prompt liste les 8, statiquement).
- **DoD items 3-4** — la re-mesure à budget suffisant et la présence d'une invocation `analyze_*` hors-cascade dans la trace.

**L'ordre est délibéré, pas un raccourci** : l'item 1 est l'**instrument** qui rend l'effet de l'item 2 mesurable. Sans marqueur, « le PM désigne mieux » ne se lit dans aucun artefact — on ne pourrait que constater un décompte de tours inchangé et en tirer la conclusion qu'on veut. Et la re-mesure a son propre pré-requis, indépendant : le budget. Deux tours de suite le budget a été deviné trop petit (180 s puis 900 s — `conversational` a fini à 900,02 s sur 2 phases /3). Re-mesurer avant d'avoir calibré aurait produit un chiffre de plus qui ne mesure que la coupure.

## Vérifications

- `black --check` + `flake8` : propres sur les 4 fichiers.
- Périmètre de test : `tests/unit/argumentation_analysis/orchestration/` (complet) + `test_strategies*.py` + `test_shared_state*.py` + `test_ra6_pm_designation.py` + `test_conv_c_*_1334.py` + `test_phase_config_convergence_553.py` + `tests/unit/core/test_rhetorical_analysis_core.py`.
- Privacy : le marqueur ne porte que des **noms d'agents** (`InformalAgent`, `ProjectManager`…) — aucun contenu de corpus, aucun identifiant de source.

🤖 Coordinator ai-01 — R812
