### PR TITLE
fix(dung): attacks are derived from the text and id-validated (#1698)

### DIFF
--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -3717,6 +3717,94 @@ def _structured_arg_cause(context: Dict[str, Any], capability: str) -> Optional[
     return cause if isinstance(cause, str) else None
 
 
+# #1698: the derived Dung attack graph is memoised in the pipeline context so
+# the four axes that consume it translate ONCE. Not a micro-optimisation: four
+# independent translations of the same text could disagree, and one analysis
+# carrying four different attack graphs would be an incoherence no reader could
+# see. The cached entry carries the inventory it was derived for, so a caller
+# that changes ``arguments`` between axes gets a fresh derivation rather than a
+# graph over the wrong nodes.
+_DUNG_ATTACKS_DERIVED_KEY = "_dung_attacks_derived"
+
+
+async def _translate_dung_attacks_once(
+    input_text: str, arguments: List[str]
+) -> Tuple[List[List[str]], str, str]:
+    """Run the #1698 Dung attack translator, returning ``(pairs, cause, error)``."""
+    try:
+        from argumentation_analysis.orchestration.structured_arg_translator import (
+            translate_to_dung_attacks,
+        )
+
+        outcome = await translate_to_dung_attacks(input_text, arguments)
+    except Exception as e:  # import / unexpected — never fatal to the run
+        logger.warning(
+            "Dung attack translator unavailable (%s) — empty graph, "
+            "translator_failed (#1698).",
+            type(e).__name__,
+        )
+        return [], "translator_failed", type(e).__name__
+    relations = outcome.relations if isinstance(outcome.relations, list) else []
+    return relations, outcome.cause, outcome.error
+
+
+async def _derive_dung_attacks(
+    input_text: str,
+    arguments: List[str],
+    context: Dict[str, Any],
+    *,
+    capability: str,
+) -> List[List[str]]:
+    """Genuine, id-validated attack pairs for a Dung-family axis (#1698).
+
+    Replaces ``_generate_attacks_from_args`` on the four axes that had no
+    arbiter. That producer has exactly two branches and both mint a **source
+    outside the inventory** (``fallacy_{i}_{label}`` / ``CA: {text}``), so the
+    frame received edges that connect nothing: measured ``BOTH_in = 0`` on
+    3/3 real corpora, every acceptance semantics returning the whole inventory
+    and ``conflict_free`` containing all of it. Nothing could ever be rejected
+    — under formal authority.
+
+    **No fallback.** When the translator yields nothing the graph is empty and
+    the reason is propagated into the context (``no_genuine_relations`` /
+    ``translator_unconfigured`` / ``translator_failed``), never replaced by
+    fabricated edges. An empty attack graph is a truthful input: every argument
+    stands because none was *shown* to be attacked — the same subtraction
+    #1629 applied to the modulo fallback.
+
+    Anti-pendule: the attacker is never promoted to a node. A ``fallacy_*``
+    node would be an unattacked argument that always wins, turning "0 rejected
+    over 8 nodes" into "everything rejected over 37 nodes" — the symmetrical
+    false green.
+
+    The derived pairs are deliberately NOT written to ``context["attacks"]``:
+    eight other call sites read that key, and silently re-feeding them would
+    make it impossible to attribute any change in extensions to this fix.
+    """
+    key = tuple(str(a) for a in arguments)
+    cached = context.get(_DUNG_ATTACKS_DERIVED_KEY)
+    if not (isinstance(cached, tuple) and len(cached) == 4 and cached[0] == key):
+        relations, cause, error = await _translate_dung_attacks_once(
+            input_text, arguments
+        )
+        cached = (key, relations, cause, error)
+        context[_DUNG_ATTACKS_DERIVED_KEY] = cached
+    _, relations, cause, error = cached
+    _propagate_structured_arg_cause(context, capability, cause, error)
+    # Unconditional (#1706 instrument): a line that only prints when there is
+    # something to report cannot distinguish "no attack in the text" from "the
+    # translator was never reached".
+    logger.info(
+        "Dung attack graph for %s (#1698): %d id-validated edge(s), cause=%s%s. "
+        "No synthetic fallback — an empty graph means none was derived.",
+        capability,
+        len(relations),
+        cause,
+        f" ({error})" if error else "",
+    )
+    return list(relations)
+
+
 async def _invoke_bipolar(input_text: str, context: Dict[str, Any]) -> Dict[str, Any]:
     """Invoke bipolar argumentation handler with JVM fallback."""
     args = context.get("arguments") or _extract_arguments_from_context(
@@ -4315,7 +4403,10 @@ async def _invoke_probabilistic(
     args = context.get("arguments") or _extract_arguments_from_context(
         input_text, context
     )
-    attacks = context.get("attacks") or _generate_attacks_from_args(args, context)
+    # #1698: id-validated attacks derived from the text, no synthetic fallback.
+    attacks = context.get("attacks") or await _derive_dung_attacks(
+        input_text, args, context, capability="probabilistic_argumentation"
+    )
     probs = context.get("probabilities") or {a: 0.5 for a in args}
 
     try:
@@ -4733,7 +4824,10 @@ async def _invoke_social(input_text: str, context: Dict[str, Any]) -> Dict[str, 
     args = context.get("arguments") or _extract_arguments_from_context(
         input_text, context
     )
-    attacks = context.get("attacks") or _generate_attacks_from_args(args, context)
+    # #1698: id-validated attacks derived from the text, no synthetic fallback.
+    attacks = context.get("attacks") or await _derive_dung_attacks(
+        input_text, args, context, capability="social_argumentation"
+    )
     votes = context.get("votes", {})
     if votes:
         votes = {k: tuple(v) if isinstance(v, list) else v for k, v in votes.items()}
@@ -4806,7 +4900,10 @@ async def _invoke_eaf(input_text: str, context: Dict[str, Any]) -> Dict[str, Any
     args = context.get("arguments") or _extract_arguments_from_context(
         input_text, context
     )
-    attacks = context.get("attacks") or _generate_attacks_from_args(args, context)
+    # #1698: id-validated attacks derived from the text, no synthetic fallback.
+    attacks = context.get("attacks") or await _derive_dung_attacks(
+        input_text, args, context, capability="epistemic_argumentation"
+    )
     # EAF expects Dict[agent, List[arg]] beliefs, NOT float probabilities.
     # Shape/validate; None lets the handler default to "all believed" (valid
     # non-fabricated baseline, #1019).
@@ -7586,8 +7683,14 @@ async def _invoke_dung_extensions(
     # 1. Extract arguments from upstream phases
     arguments = _extract_arguments_from_context(input_text, context)
 
-    # 2. Build attack relations from fallacies and counter-arguments
-    attacks = _generate_attacks_from_args(arguments, context)
+    # 2. Build attack relations from the text, cited by id (#1698). Every edge
+    #    has both endpoints in ``arguments``; the previous producer minted
+    #    sources that were never nodes, so the frame was inert on 3/3 corpora.
+    #    ``context["attacks"]`` is deliberately NOT consulted here — this site
+    #    has never read it, and making it do so is a separate decision.
+    attacks = await _derive_dung_attacks(
+        input_text, arguments, context, capability="dung_extensions"
+    )
 
     # I5 #1430: compare mode — run every available backend on the same AF and
     # surface agreement / disagreement (never auto-reconciled). Short-circuits

--- a/argumentation_analysis/orchestration/structured_arg_translator.py
+++ b/argumentation_analysis/orchestration/structured_arg_translator.py
@@ -263,6 +263,23 @@ async def _llm_extract_relations(
             '{"attacks": [{"attackers": ["argN"], "target": "argM", '
             '"rationale": "one short sentence"}]}'
         )
+    elif relation_kind == "dung_attacks":
+        task = (
+            "Identify ATTACK relations among these arguments: an attack is a "
+            "pair (source, target) where the source argument DEFEATS the target "
+            "— it rebuts the target's conclusion or undermines a premise the "
+            "target rests on. Cite source AND target by id; every id must be "
+            "present in the inventory. The attacker must itself be one of the "
+            "listed arguments: name the argument that carries the objection, "
+            "never the name of a fallacy or of a counter-argument that is not "
+            "in the list. Report an attack ONLY when the text genuinely "
+            "presents the source as defeating the target — do NOT connect "
+            "unrelated arguments."
+        )
+        shape = (
+            '{"attacks": [{"source": "argN", "target": "argM", '
+            '"rationale": "one short sentence"}]}'
+        )
     elif relation_kind == "weighted_attacks":
         task = (
             "Identify WEIGHTED ATTACKS among these arguments: a weighted attack "
@@ -618,6 +635,52 @@ def _validate_setaf_attacks(
     return out
 
 
+def _validate_dung_attacks(
+    data: Dict[str, Any], arg_by_id: Dict[str, str]
+) -> List[List[str]]:
+    """Validate LLM pairwise attack proposals against the real inventory (#1698).
+
+    A Dung attack is the degenerate SetAF case — a single attacker and a target
+    — so this is :func:`_validate_setaf_attacks` with an attacker set of size
+    one, returning the ``[source, target]`` pair shape the Dung-family handlers
+    consume (identical to what ``_generate_attacks_from_args`` returned).
+
+    Both endpoints must be inventory members. That is the whole point of #1698:
+    the producer this replaces minted ``fallacy_{i}_{label}`` and ``CA: {text}``
+    sources, neither of which is ever a node of the frame, so every edge landed
+    outside the graph and nothing could ever be rejected. Here an edge naming
+    any unknown id is dropped (anti-théâtre #1019) — never salvaged by promoting
+    the attacker to a node, which would make it an unattacked argument that
+    always wins.
+
+    Self-attacks are dropped (not a genuine relation between two arguments).
+    Ids are re-mapped to canonical argument text so the frame connects real
+    nodes. Dedup on ``(source, target)``; direction is preserved, never
+    symmetrised — ``a`` attacking ``b`` does not make ``b`` attack ``a``.
+    """
+    raw = data.get("attacks", []) if isinstance(data, dict) else []
+    if not isinstance(raw, list):
+        return []
+    seen: set[Tuple[str, str]] = set()
+    out: List[List[str]] = []
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        src_id = str(item.get("source", "")).strip()
+        tgt_id = str(item.get("target", "")).strip()
+        if src_id not in arg_by_id or tgt_id not in arg_by_id:
+            continue  # fabricated / malformed → dropped (anti-théâtre #1019)
+        if src_id == tgt_id:
+            continue  # self-attack is not a genuine relation
+        src, tgt = arg_by_id[src_id], arg_by_id[tgt_id]
+        key = (src, tgt)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append([src, tgt])
+    return out
+
+
 def _validate_weighted_attacks(
     data: Dict[str, Any], arg_by_id: Dict[str, str]
 ) -> List[Tuple[str, str, float]]:
@@ -917,12 +980,60 @@ async def translate_to_weighted_attacks(
     return TranslationResult(relations=[], cause=CAUSE_NO_GENUINE_RELATIONS)
 
 
+async def translate_to_dung_attacks(
+    input_text: str, arguments: List[str]
+) -> TranslationResult:
+    """Derive genuine pairwise attacks from the text + arguments (#1698).
+
+    The sixth sibling of this family, and the one that feeds the **central**
+    Dung frame — the one whose extensions back every "this argument does not
+    survive" statement in a conclusion.
+
+    Returns a ``TranslationResult`` whose ``relations`` is a list of
+    ``[source, target]`` pairs of canonical argument texts, validated against
+    the real inventory. See :func:`translate_to_bipolar_supports` for the
+    ``cause`` contract (#1608).
+
+    Unlike its five siblings this axis has **no** honest-absent gate entry —
+    ``_STRUCTURED_ARG_INPUT_KEYS`` covers the five structured formalisms only,
+    and #1698 does not touch it. The cause is still propagated into the
+    pipeline context by the caller, so an empty attack graph carries *why* it
+    is empty instead of being indistinguishable from "no attacks in the text".
+    """
+    arg_by_id, _ = _build_inventory(arguments)
+    if not arg_by_id:
+        return TranslationResult(relations=[], cause=CAUSE_NO_GENUINE_RELATIONS)
+    try:
+        data = await _llm_extract_relations(input_text, arguments, "dung_attacks")
+    except TranslatorUnconfigured:
+        return TranslationResult(relations=[], cause=CAUSE_TRANSLATOR_UNCONFIGURED)
+    except Exception as e:  # network / parse / budget — never fatal to the run
+        logger.warning(
+            "Dung attacks translator failed (%s) — staying absent.",
+            type(e).__name__,
+        )
+        return TranslationResult(
+            relations=[], cause=CAUSE_TRANSLATOR_FAILED, error=type(e).__name__
+        )
+    attacks = _validate_dung_attacks(data, arg_by_id)
+    _log_translation_yield("Dung", data, ("attacks",), len(attacks))
+    if attacks:
+        logger.info(
+            "Dung translator: derived %d genuine attack(s) from text — both "
+            "endpoints are inventory members by construction (#1698).",
+            len(attacks),
+        )
+        return TranslationResult(relations=attacks, cause=CAUSE_EVALUATED)
+    return TranslationResult(relations=[], cause=CAUSE_NO_GENUINE_RELATIONS)
+
+
 __all__ = [
     "translate_to_bipolar_supports",
     "translate_to_aba_contraries",
     "translate_to_aspic_rules",
     "translate_to_setaf_attacks",
     "translate_to_weighted_attacks",
+    "translate_to_dung_attacks",
     "TranslationResult",
     "TranslatorUnconfigured",
     "CAUSE_EVALUATED",
@@ -939,4 +1050,5 @@ __all__ = [
     "_unique_rule_name",
     "_validate_setaf_attacks",
     "_validate_weighted_attacks",
+    "_validate_dung_attacks",
 ]

--- a/tests/unit/argumentation_analysis/orchestration/test_dung_aspic_wiring.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_dung_aspic_wiring.py
@@ -1,7 +1,8 @@
 """Tests for Dung/ASPIC framework wiring into pipeline and conversational modes (#286).
 
 Validates:
-- _invoke_dung_extensions uses extract_arguments and generate_attacks helpers
+- _invoke_dung_extensions uses extract_arguments, and derives its attacks with the
+  id-validated translator (#1698) rather than minting ``fallacy_*`` sources
 - _python_dung_fallback raises RuntimeError (fail-loud stub, FP-22 #1249)
 - _write_dung_extensions_to_state stores actual attacks and arguments
 - _generate_attacks_from_args matches fallacies to arguments by text content
@@ -14,6 +15,30 @@ Validates:
 import asyncio
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
+
+
+@pytest.fixture(autouse=True)
+def _translator_stays_offline():
+    """#1698: ``_invoke_dung_extensions`` now derives its attacks from the text.
+
+    This file tests *wiring*, not derivation. Without this fixture every test
+    reaching the invoke makes a real LLM call that no assertion reads — measured
+    at ~4 s each, 8.2 s -> 40.6 s for the file. The default derives no relation
+    (the honest empty graph, which is what these tests' contexts describe);
+    tests needing a specific graph patch the same symbol themselves and their
+    inner patch wins.
+    """
+
+    async def _no_relations(input_text, arguments, relation_kind):
+        return {}
+
+    with patch(
+        "argumentation_analysis.orchestration.structured_arg_translator."
+        "_llm_extract_relations",
+        _no_relations,
+    ):
+        yield
+
 
 # ============================================================
 # Test: _invoke_dung_extensions uses helper functions
@@ -61,19 +86,31 @@ class TestInvokeDungExtensions:
         assert "impots" in args_passed[0].lower() or "impots" in args_passed[0]
 
     @pytest.mark.asyncio
-    async def test_generates_attacks_from_fallacies(self):
-        """Dung function uses _generate_attacks_from_args for cross-KB."""
+    async def test_attacks_are_id_validated_never_minted_from_fallacies(self):
+        """#1698: the frame receives edges whose BOTH endpoints are nodes.
+
+        This test used to assert the opposite — that a ``fallacy_*`` source
+        reached the reasoner — which is exactly the defect #1698 measured on 3
+        real corpora: ``BOTH_in = 0``, so no attack constrained anything and
+        every acceptance semantics returned the whole inventory. The edge was
+        real as an *observation* and inert as an *input*.
+
+        ``_invoke_dung_extensions`` now derives attacks with the id-validated
+        translator (the sixth sibling of the bipolar/ABA/ASPIC/SetAF/weighted
+        family), so a fallacy detection no longer mints a node that does not
+        exist. The fallacy payload is kept in the context on purpose: it is the
+        input that used to produce the fabricated edge.
+        """
         from argumentation_analysis.orchestration.unified_pipeline import (
             _invoke_dung_extensions,
         )
 
+        arguments = [
+            "Ce regime est le meilleur car le professeur le dit",
+            "Les etudes montrent le contraire",
+        ]
         context = {
-            "phase_extract_output": {
-                "arguments": [
-                    {"text": "Ce regime est le meilleur car le professeur le dit"},
-                    {"text": "Les etudes montrent le contraire"},
-                ]
-            },
+            "phase_extract_output": {"arguments": [{"text": a} for a in arguments]},
             "phase_hierarchical_fallacy_output": {
                 "fallacies": [
                     {
@@ -89,26 +126,37 @@ class TestInvokeDungExtensions:
             },
         }
 
+        async def _fake_llm(input_text, args, relation_kind):
+            # arg2 attacks arg1 — both are inventory members.
+            return {"attacks": [{"source": "arg2", "target": "arg1"}]}
+
         with patch(
-            "argumentation_analysis.agents.core.logic.af_handler.AFHandler"
-        ) as mock_af:
-            mock_handler = MagicMock()
-            mock_handler.analyze_multi_semantics.return_value = {
-                "extensions": {},
-            }
-            mock_af.return_value = mock_handler
-
+            "argumentation_analysis.orchestration.structured_arg_translator."
+            "_llm_extract_relations",
+            _fake_llm,
+        ):
             with patch(
-                "argumentation_analysis.agents.core.logic.tweety_initializer.TweetyInitializer"
-            ) as mock_init:
-                mock_init.return_value = MagicMock()
-                result = await _invoke_dung_extensions("test text", context)
+                "argumentation_analysis.agents.core.logic.af_handler.AFHandler"
+            ) as mock_af:
+                mock_handler = MagicMock()
+                mock_handler.analyze_multi_semantics.return_value = {
+                    "extensions": {},
+                }
+                mock_af.return_value = mock_handler
 
-        # Attacks should have been generated from the fallacy
+                with patch(
+                    "argumentation_analysis.agents.core.logic.tweety_initializer.TweetyInitializer"
+                ) as mock_init:
+                    mock_init.return_value = MagicMock()
+                    await _invoke_dung_extensions("test text", context)
+
         call_args = mock_handler.analyze_multi_semantics.call_args
+        args_passed = call_args[0][0]
         attacks_passed = call_args[0][1]  # Second positional arg = attacks
-        assert len(attacks_passed) > 0
-        assert any("fallacy" in str(a).lower() for a in attacks_passed)
+        assert attacks_passed == [[arguments[1], arguments[0]]]
+        assert not [a for a in attacks_passed if "fallacy" in str(a).lower()]
+        # The attacker is a node of the frame — it was not promoted into one.
+        assert list(args_passed) == arguments
 
     @pytest.mark.asyncio
     async def test_returns_multi_semantics(self):

--- a/tests/unit/argumentation_analysis/orchestration/test_dung_attack_translator_1698.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_dung_attack_translator_1698.py
@@ -1,0 +1,539 @@
+"""#1698 — the Dung attack graph gets a translator, so its edges land on it.
+
+Measured defect (issue #1698, 3 real corpora): every attack the central Dung
+frame received had a target inside the argument inventory and a source
+**outside** it — ``BOTH_in = 0`` on 3/3. The frame therefore behaved as *n*
+isolated arguments: ``conflict_free`` returned the whole inventory and every
+acceptance semantics returned one extension of size ``|arguments|``. Nothing
+was ever rejected, under formal authority.
+
+The cause is the producer, not the reasoner. ``_generate_attacks_from_args``
+has exactly two branches and both mint a **fabricated** source::
+
+    attacks.append([f"fallacy_{i}_{label}", target_arg])   # invoke_callables:3207
+    attacks.append([f"CA: {text[:50]}", arg])              # invoke_callables:3224
+
+Neither source is an inventory member, so ``BOTH_in = 0`` is the only value
+this producer *can* yield — independently of the corpus.
+
+The fix is a **sixth sibling** of an existing family of five, not an invention:
+``structured_arg_translator`` already derives relations from the text, makes the
+model cite them **by id** (``arg1``..``argN``) and drops any relation naming an
+id outside the inventory. That is ``BOTH_in`` by construction, with nothing
+fabricated. It was wired on bipolar / ABA / ASPIC / SetAF / weighted and absent
+from Dung, social, probabilistic and EAF.
+
+What these tests assert, and what they refuse to assert
+-------------------------------------------------------
+* They assert on **the graph that reaches the reasoner** (captured at the
+  handler call), never on a log line. A ``caplog`` assertion would pass against
+  a fix that only reworded a message.
+* ``BOTH_in > 0`` is expressed as ``_retained_attacks`` returning the submitted
+  edges — the same membership test the issue's probe ran on the real states.
+* They do **not** assert that something is rejected: a corpus where nothing is
+  defeated is a legitimate result. It is the structural *impossibility* of a
+  rejection that is the defect. The rejection is measured on real corpora
+  (DoD item 2), not here.
+
+Anti-pendules under test (both were green before this change and must stay
+green — they are guards, not deliverables):
+* the attacker is **never** added to the argument inventory (a fallacy node
+  would be an unattacked argument that always wins: "0 rejected on 8 nodes"
+  would become "everything rejected on 37 nodes", the symmetrical false green);
+* an attack graph supplied by the caller is never overridden.
+
+Privacy HARD: synthetic atoms only (``Alpha`` / ``Beta`` / ``Gamma``), no corpus
+tokens, no LLM call, no JVM.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from typing import Any, Dict, List
+
+import pytest
+
+from argumentation_analysis.orchestration.structured_arg_translator import (
+    CAUSE_EVALUATED,
+    CAUSE_NO_GENUINE_RELATIONS,
+    CAUSE_TRANSLATOR_FAILED,
+    CAUSE_TRANSLATOR_UNCONFIGURED,
+    TranslatorUnconfigured,
+    _validate_dung_attacks,
+    translate_to_dung_attacks,
+)
+
+# ``asyncio_mode = auto`` (pytest.ini) — no per-test asyncio marker needed.
+
+
+# --------------------------------------------------------------------------
+# Helpers
+# --------------------------------------------------------------------------
+
+
+def _patch_llm(monkeypatch, payload: Dict[str, Any]) -> None:
+    """Redirect the internal LLM call to return ``payload`` (no network)."""
+
+    async def _fake(input_text: str, arguments: List[str], relation_kind: str):
+        return payload
+
+    monkeypatch.setattr(
+        "argumentation_analysis.orchestration.structured_arg_translator."
+        "_llm_extract_relations",
+        _fake,
+    )
+
+
+def _patch_llm_raising(monkeypatch, exc: BaseException) -> None:
+    async def _fake(input_text: str, arguments: List[str], relation_kind: str):
+        raise exc
+
+    monkeypatch.setattr(
+        "argumentation_analysis.orchestration.structured_arg_translator."
+        "_llm_extract_relations",
+        _fake,
+    )
+
+
+def _fake_module(name: str, **attrs: Any) -> types.ModuleType:
+    mod = types.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(mod, key, value)
+    return mod
+
+
+def _inject_fake_handlers(monkeypatch) -> List[Dict[str, Any]]:
+    """Inject fake Tweety handlers for the 4 orphan axes; record their inputs.
+
+    Returns the shared call log: one ``{"axis", "arguments", "attacks"}`` entry
+    per handler invocation. This is the *effect* under test — the graph that
+    actually reached the reasoner.
+    """
+    calls: List[Dict[str, Any]] = []
+
+    class _FakeTweetyInitializer:
+        pass
+
+    monkeypatch.setitem(
+        sys.modules,
+        "argumentation_analysis.agents.core.logic.tweety_initializer",
+        _fake_module(
+            "argumentation_analysis.agents.core.logic.tweety_initializer",
+            TweetyInitializer=_FakeTweetyInitializer,
+        ),
+    )
+
+    class _FakeAFHandler:
+        def __init__(self, initializer: Any) -> None:
+            self.initializer = initializer
+
+        def analyze_multi_semantics(self, arguments, attacks, semantics):
+            calls.append({"axis": "dung", "arguments": arguments, "attacks": attacks})
+            return {"extensions": {sem: [list(arguments)] for sem in semantics}}
+
+    monkeypatch.setitem(
+        sys.modules,
+        "argumentation_analysis.agents.core.logic.af_handler",
+        _fake_module(
+            "argumentation_analysis.agents.core.logic.af_handler",
+            AFHandler=_FakeAFHandler,
+            SEMANTICS_REASONERS={"grounded": None, "preferred": None},
+        ),
+    )
+
+    class _FakeSocialHandler:
+        def __init__(self, initializer: Any) -> None:
+            self.initializer = initializer
+
+        def analyze_social_framework(self, args, attacks, votes):
+            calls.append({"axis": "social", "arguments": args, "attacks": attacks})
+            return {"extensions": [], "statistics": {}}
+
+    monkeypatch.setitem(
+        sys.modules,
+        "argumentation_analysis.agents.core.logic.social_handler",
+        _fake_module(
+            "argumentation_analysis.agents.core.logic.social_handler",
+            SocialHandler=_FakeSocialHandler,
+        ),
+    )
+
+    class _FakeEAFHandler:
+        def __init__(self, initializer: Any) -> None:
+            self.initializer = initializer
+
+        def analyze_epistemic_framework(self, args, attacks, beliefs, semantics):
+            calls.append({"axis": "eaf", "arguments": args, "attacks": attacks})
+            return {"extensions": [], "statistics": {}}
+
+    monkeypatch.setitem(
+        sys.modules,
+        "argumentation_analysis.agents.core.logic.eaf_handler",
+        _fake_module(
+            "argumentation_analysis.agents.core.logic.eaf_handler",
+            EAFHandler=_FakeEAFHandler,
+        ),
+    )
+
+    class _FakeProbabilisticHandler:
+        def analyze_probabilistic_framework(self, args, attacks, probs):
+            calls.append(
+                {"axis": "probabilistic", "arguments": args, "attacks": attacks}
+            )
+            return {"extensions": [], "statistics": {}}
+
+    monkeypatch.setitem(
+        sys.modules,
+        "argumentation_analysis.agents.core.logic.probabilistic_handler",
+        _fake_module(
+            "argumentation_analysis.agents.core.logic.probabilistic_handler",
+            ProbabilisticHandler=_FakeProbabilisticHandler,
+        ),
+    )
+    return calls
+
+
+# The inventory every wiring test runs on, plus a fallacy detection that the
+# synthetic producer resolves — so ``_generate_attacks_from_args`` really does
+# mint ``["fallacy_0_ad_hominem", "Alpha"]`` if it is still reached.
+_ARGUMENTS = ["Alpha", "Beta", "Gamma"]
+
+
+def _context_that_feeds_the_synthetic_producer() -> Dict[str, Any]:
+    return {
+        "phase_extract_output": {"arguments": list(_ARGUMENTS)},
+        "phase_hierarchical_fallacy_output": {
+            "fallacies": [{"type": "ad_hominem", "target_argument": "arg_1"}]
+        },
+    }
+
+
+# The four orphan axes, with the capability name each records its cause under.
+_AXES = [
+    ("dung", "_invoke_dung_extensions", "dung_extensions"),
+    ("social", "_invoke_social", "social_argumentation"),
+    ("eaf", "_invoke_eaf", "epistemic_argumentation"),
+    ("probabilistic", "_invoke_probabilistic", "probabilistic_argumentation"),
+]
+
+
+async def _run_axis(axis_fn_name: str, ctx: Dict[str, Any]) -> Any:
+    from argumentation_analysis.orchestration import invoke_callables
+
+    fn = getattr(invoke_callables, axis_fn_name)
+    return await fn("source text", ctx)
+
+
+# --------------------------------------------------------------------------
+# 1. The validator — the anti-théâtre guard, id by id
+# --------------------------------------------------------------------------
+
+
+class TestValidateDungAttacks:
+    def test_keeps_valid_pairs_mapped_to_canonical_text(self):
+        arg_by_id = {"arg1": "Alpha", "arg2": "Beta", "arg3": "Gamma"}
+        data = {
+            "attacks": [
+                {"source": "arg2", "target": "arg1", "rationale": "r"},
+                {"source": "arg3", "target": "arg2", "rationale": "r"},
+            ]
+        }
+        assert _validate_dung_attacks(data, arg_by_id) == [
+            ["Beta", "Alpha"],
+            ["Gamma", "Beta"],
+        ]
+
+    def test_drops_the_pair_whose_source_is_outside_the_inventory(self):
+        """The exact shape the synthetic producer mints — and the defect."""
+        arg_by_id = {"arg1": "Alpha", "arg2": "Beta"}
+        data = {
+            "attacks": [
+                {"source": "fallacy_0_ad_hominem", "target": "arg1"},
+                {"source": "CA: some counter", "target": "arg2"},
+            ]
+        }
+        assert _validate_dung_attacks(data, arg_by_id) == []
+
+    def test_drops_the_pair_whose_target_is_outside_the_inventory(self):
+        arg_by_id = {"arg1": "Alpha", "arg2": "Beta"}
+        data = {"attacks": [{"source": "arg1", "target": "arg9"}]}
+        assert _validate_dung_attacks(data, arg_by_id) == []
+
+    def test_drops_self_attack(self):
+        arg_by_id = {"arg1": "Alpha"}
+        data = {"attacks": [{"source": "arg1", "target": "arg1"}]}
+        assert _validate_dung_attacks(data, arg_by_id) == []
+
+    def test_dedups_on_source_and_target(self):
+        arg_by_id = {"arg1": "Alpha", "arg2": "Beta"}
+        data = {
+            "attacks": [
+                {"source": "arg1", "target": "arg2"},
+                {"source": "arg1", "target": "arg2", "rationale": "again"},
+            ]
+        }
+        assert _validate_dung_attacks(data, arg_by_id) == [["Alpha", "Beta"]]
+
+    def test_direction_is_preserved_not_symmetrised(self):
+        arg_by_id = {"arg1": "Alpha", "arg2": "Beta"}
+        data = {
+            "attacks": [
+                {"source": "arg1", "target": "arg2"},
+                {"source": "arg2", "target": "arg1"},
+            ]
+        }
+        assert _validate_dung_attacks(data, arg_by_id) == [
+            ["Alpha", "Beta"],
+            ["Beta", "Alpha"],
+        ]
+
+    def test_tolerates_malformed_payloads(self):
+        arg_by_id = {"arg1": "Alpha", "arg2": "Beta"}
+        assert _validate_dung_attacks({}, arg_by_id) == []
+        assert _validate_dung_attacks({"attacks": []}, arg_by_id) == []
+        assert _validate_dung_attacks({"attacks": "nope"}, arg_by_id) == []
+        assert _validate_dung_attacks({"attacks": [None, 3, "x"]}, arg_by_id) == []
+        assert _validate_dung_attacks([], arg_by_id) == []  # type: ignore[arg-type]
+
+
+# --------------------------------------------------------------------------
+# 2. The translator — the same discriminated cause contract as its 5 siblings
+# --------------------------------------------------------------------------
+
+
+class TestDungTranslatorCauseContract:
+    async def test_empty_llm_output_is_no_genuine_relations(self, monkeypatch):
+        _patch_llm(monkeypatch, {"attacks": []})
+        out = await translate_to_dung_attacks("text", ["Alpha", "Beta"])
+        assert out.relations == []
+        assert out.cause == CAUSE_NO_GENUINE_RELATIONS
+
+    async def test_all_fabricated_dropped_is_still_no_genuine_relations(
+        self, monkeypatch
+    ):
+        _patch_llm(
+            monkeypatch,
+            {"attacks": [{"source": "phantom", "target": "ghost"}]},
+        )
+        out = await translate_to_dung_attacks("text", ["Alpha", "Beta"])
+        assert out.relations == []
+        assert out.cause == CAUSE_NO_GENUINE_RELATIONS
+
+    async def test_genuine_pairs_are_evaluated(self, monkeypatch):
+        _patch_llm(
+            monkeypatch,
+            {
+                "attacks": [
+                    {"source": "arg2", "target": "arg1"},
+                    {"source": "arg1", "target": "arg9"},  # dropped (unknown)
+                ]
+            },
+        )
+        out = await translate_to_dung_attacks("text", ["Alpha", "Beta"])
+        assert out.relations == [["Beta", "Alpha"]]
+        assert out.cause == CAUSE_EVALUATED
+
+    async def test_empty_inventory_short_circuits_without_calling_the_llm(
+        self, monkeypatch
+    ):
+        called = {"n": 0}
+
+        async def _fake(input_text, arguments, relation_kind):
+            called["n"] += 1
+            return {"attacks": [{"source": "arg1", "target": "arg2"}]}
+
+        monkeypatch.setattr(
+            "argumentation_analysis.orchestration.structured_arg_translator."
+            "_llm_extract_relations",
+            _fake,
+        )
+        out = await translate_to_dung_attacks("text", [])
+        assert out.relations == []
+        assert out.cause == CAUSE_NO_GENUINE_RELATIONS
+        assert called["n"] == 0
+
+    async def test_unconfigured_is_not_collapsed_onto_no_relations(self, monkeypatch):
+        _patch_llm_raising(monkeypatch, TranslatorUnconfigured("no key"))
+        out = await translate_to_dung_attacks("text", ["Alpha", "Beta"])
+        assert out.relations == []
+        assert out.cause == CAUSE_TRANSLATOR_UNCONFIGURED
+
+    async def test_a_raising_call_reports_translator_failed_with_its_type(
+        self, monkeypatch
+    ):
+        _patch_llm_raising(monkeypatch, ValueError("boom"))
+        out = await translate_to_dung_attacks("text", ["Alpha", "Beta"])
+        assert out.relations == []
+        assert out.cause == CAUSE_TRANSLATOR_FAILED
+        assert out.error == "ValueError"
+
+
+# --------------------------------------------------------------------------
+# 3. The four orphan axes — measured on what reaches the reasoner
+# --------------------------------------------------------------------------
+
+
+class TestTheFabricatedGraphNoLongerReachesTheReasoner:
+    """THE defect. Red before the fix: the synthetic producer still runs and
+    hands the reasoner an edge whose source is not a node of the frame."""
+
+    @pytest.mark.parametrize("axis,fn_name,capability", _AXES)
+    async def test_nothing_is_submitted_when_no_genuine_relation_exists(
+        self, monkeypatch, axis, fn_name, capability
+    ):
+        calls = _inject_fake_handlers(monkeypatch)
+        _patch_llm(monkeypatch, {"attacks": []})  # translator finds nothing
+
+        ctx = _context_that_feeds_the_synthetic_producer()
+        await _run_axis(fn_name, ctx)
+
+        submitted = [c for c in calls if c["axis"] == axis]
+        assert len(submitted) == 1
+        assert submitted[0]["attacks"] == [], (
+            "an edge reached the reasoner although no genuine relation was "
+            "derived — the synthetic producer is still wired"
+        )
+
+    @pytest.mark.parametrize("axis,fn_name,capability", _AXES)
+    async def test_no_submitted_edge_has_a_source_outside_the_inventory(
+        self, monkeypatch, axis, fn_name, capability
+    ):
+        """The invariant, stated positively: sources are inventory members."""
+        calls = _inject_fake_handlers(monkeypatch)
+        _patch_llm(monkeypatch, {"attacks": [{"source": "arg2", "target": "arg1"}]})
+
+        ctx = _context_that_feeds_the_synthetic_producer()
+        await _run_axis(fn_name, ctx)
+
+        submitted = [c for c in calls if c["axis"] == axis][0]
+        inventory = {str(a) for a in submitted["arguments"]}
+        outside = [
+            edge
+            for edge in submitted["attacks"]
+            if str(edge[0]) not in inventory or str(edge[1]) not in inventory
+        ]
+        assert not outside, f"{len(outside)} edge(s) not grounded in the inventory"
+
+    @pytest.mark.parametrize("axis,fn_name,capability", _AXES)
+    async def test_a_genuine_relation_is_submitted_with_both_endpoints_in(
+        self, monkeypatch, axis, fn_name, capability
+    ):
+        """``BOTH_in > 0`` — the same membership test the #1698 probe ran."""
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _retained_attacks,
+        )
+
+        calls = _inject_fake_handlers(monkeypatch)
+        _patch_llm(monkeypatch, {"attacks": [{"source": "arg2", "target": "arg1"}]})
+
+        ctx = _context_that_feeds_the_synthetic_producer()
+        await _run_axis(fn_name, ctx)
+
+        submitted = [c for c in calls if c["axis"] == axis][0]
+        assert submitted["attacks"] == [["Beta", "Alpha"]]
+        both_in = _retained_attacks(submitted["arguments"], submitted["attacks"])
+        assert len(both_in) == 1
+
+    @pytest.mark.parametrize("axis,fn_name,capability", _AXES)
+    async def test_the_cause_is_discriminated_in_context(
+        self, monkeypatch, axis, fn_name, capability
+    ):
+        """An empty graph carries *why* it is empty — never a bare ``[]``."""
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _structured_arg_cause,
+        )
+
+        _inject_fake_handlers(monkeypatch)
+
+        _patch_llm(monkeypatch, {"attacks": []})
+        ctx = _context_that_feeds_the_synthetic_producer()
+        await _run_axis(fn_name, ctx)
+        assert _structured_arg_cause(ctx, capability) == CAUSE_NO_GENUINE_RELATIONS
+
+        _patch_llm_raising(monkeypatch, TranslatorUnconfigured("no key"))
+        ctx = _context_that_feeds_the_synthetic_producer()
+        await _run_axis(fn_name, ctx)
+        assert _structured_arg_cause(ctx, capability) == CAUSE_TRANSLATOR_UNCONFIGURED
+
+        _patch_llm_raising(monkeypatch, RuntimeError("boom"))
+        ctx = _context_that_feeds_the_synthetic_producer()
+        await _run_axis(fn_name, ctx)
+        assert _structured_arg_cause(ctx, capability) == CAUSE_TRANSLATOR_FAILED
+
+
+class TestTheDerivationIsSharedNotRepeated:
+    """The four axes reason over the same inventory, so they translate once.
+
+    Not an optimisation detail: four independent translations of the same text
+    could disagree, and four different Dung graphs inside one analysis would be
+    an incoherence no reader could see.
+    """
+
+    async def test_two_axes_in_one_context_translate_once(self, monkeypatch):
+        _inject_fake_handlers(monkeypatch)
+        calls = {"n": 0}
+
+        async def _fake(input_text, arguments, relation_kind):
+            calls["n"] += 1
+            return {"attacks": [{"source": "arg2", "target": "arg1"}]}
+
+        monkeypatch.setattr(
+            "argumentation_analysis.orchestration.structured_arg_translator."
+            "_llm_extract_relations",
+            _fake,
+        )
+        ctx = _context_that_feeds_the_synthetic_producer()
+        await _run_axis("_invoke_dung_extensions", ctx)
+        await _run_axis("_invoke_social", ctx)
+        assert calls["n"] == 1
+
+
+# --------------------------------------------------------------------------
+# 4. Anti-pendules — green before AND after (guards, not deliverables)
+# --------------------------------------------------------------------------
+
+
+class TestTheAttackerIsNeverPromotedToANode:
+    """Adding ``fallacy_*`` to ``arguments`` would turn "0 rejected on 8 nodes"
+    into "everything rejected on 37 nodes" — the symmetrical false green named
+    in the issue. The inventory submitted must stay the extracted one."""
+
+    @pytest.mark.parametrize("axis,fn_name,capability", _AXES)
+    async def test_the_submitted_inventory_is_exactly_the_extracted_one(
+        self, monkeypatch, axis, fn_name, capability
+    ):
+        calls = _inject_fake_handlers(monkeypatch)
+        _patch_llm(monkeypatch, {"attacks": [{"source": "arg2", "target": "arg1"}]})
+
+        ctx = _context_that_feeds_the_synthetic_producer()
+        await _run_axis(fn_name, ctx)
+
+        submitted = [c for c in calls if c["axis"] == axis][0]
+        assert list(submitted["arguments"]) == _ARGUMENTS
+        assert not [a for a in submitted["arguments"] if str(a).startswith("fallacy_")]
+
+
+class TestACallerSuppliedGraphIsNeverOverridden:
+    """``context["attacks"]`` keeps precedence on the three axes that honour it
+    (``_invoke_dung_extensions`` has never read that key and still does not —
+    changing that is a separate decision, not this fix)."""
+
+    @pytest.mark.parametrize(
+        "axis,fn_name",
+        [
+            ("social", "_invoke_social"),
+            ("eaf", "_invoke_eaf"),
+            ("probabilistic", "_invoke_probabilistic"),
+        ],
+    )
+    async def test_explicit_attacks_win(self, monkeypatch, axis, fn_name):
+        calls = _inject_fake_handlers(monkeypatch)
+        _patch_llm(monkeypatch, {"attacks": [{"source": "arg2", "target": "arg1"}]})
+
+        ctx = _context_that_feeds_the_synthetic_producer()
+        ctx["attacks"] = [["Gamma", "Beta"]]
+        await _run_axis(fn_name, ctx)
+
+        submitted = [c for c in calls if c["axis"] == axis][0]
+        assert submitted["attacks"] == [["Gamma", "Beta"]]


### PR DESCRIPTION
Closes #1698. Epic **#1644**.

## Le fait, et pourquoi il ne pouvait pas être autre chose

La mesure de #1698 sur 3 corpus réels : **100 % des *cibles* d'attaque se résolvaient dans l'inventaire d'arguments, 0 % des *sources*.** Le cadre de Dung se comportait donc comme *n* arguments isolés — `conflict_free` rendait l'inventaire entier, et **toutes** les sémantiques d'acceptation rendaient une extension unique de taille `|arguments|`. Rien ne pouvait être écarté, **sous autorité formelle**.

La cause n'est pas le raisonneur, c'est le **producteur**. `_generate_attacks_from_args` a exactement deux branches, et les deux fabriquent une source qui n'est pas un nœud (`fallacy_{i}_{label}` et `CA: {text[:50]}`, aujourd'hui `invoke_callables.py:3207` et `:3224`). `BOTH_in = 0` est donc la **seule** valeur qu'il puisse rendre, indépendamment du corpus. Ce n'est pas un défaut de qualité de détection : c'est une impossibilité structurelle.

## Le fix : un sixième frère, pas une invention

`structured_arg_translator` dérive déjà des relations depuis le texte, fait citer les identifiants par le modèle (`arg1..argN`) et **jette** toute relation nommant un id absent de l'inventaire — `BOTH_in` par construction. Il était câblé sur **5** axes (bipolar / ABA / ASPIC / SetAF / weighted) et absent des autres.

Une attaque de Dung est le cas dégénéré de SetAF (ensemble attaquant de taille 1). `_validate_dung_attacks` est donc `_validate_setaf_attacks` à cette arité, rendant la **même** forme de paire `[source, target]` que les handlers de la famille Dung consomment déjà — c'est-à-dire exactement ce que rendait `_generate_attacks_from_args`. Aucun handler n'est touché.

**Pas de repli.** Quand rien n'est dérivé, le graphe reste vide et porte une cause **discriminée** : `no_genuine_relations` / `translator_unconfigured` / `translator_failed`. La porte honnête-absent n'est pas touchée (cet axe n'a pas d'entrée dans `_STRUCTURED_ARG_INPUT_KEYS`, qui ne couvre que les cinq formalismes structurés).

**L'attaquant n'est jamais promu en nœud.** Un nœud `fallacy_*` serait un argument non-attaqué qui gagne toujours : « 0 écarté sur 8 » deviendrait « tout écarté sur 37 », le faux-vert symétrique. Un test l'épingle sur les 4 axes.

La dérivation est **mémoïsée par contexte** (l'entrée de cache porte l'inventaire pour lequel elle a été dérivée). Ce n'est pas une optimisation : quatre traductions indépendantes du même texte peuvent diverger, et une analyse portant quatre graphes de Dung différents serait une incohérence qu'aucun lecteur ne peut voir.

## L'inventaire des sites — corrigé, parce qu'il a été faux trois fois

Mon propre commentaire de dé-gatage disait **4** sites orphelins (lui-même une correction d'un « 2 » antérieur). En grepant la **forme** plutôt qu'en recopiant la liste, il y a **12** sites de production appelant `_generate_attacks_from_args`. Les voici tous, avec un verdict pour chacun — un dispatch qui nomme des sites porte le grep qui l'a produit.

| # | Site (tous dans `invoke_callables.py` sauf 12) | Verdict |
|---|---|---|
| 1 | `_invoke_dung_extensions` | **Câblé ici.** Le site que #1698 mesure |
| 2 | `_invoke_social` | **Câblé ici.** Rétention mesurée à 0 en R794 |
| 3 | `_invoke_probabilistic` | **Câblé ici.** Rétention **non mesurée** — voir réserve ci-dessous |
| 4 | `_invoke_eaf` | **Câblé ici.** Rétention **non mesurée** |
| 5 | `_invoke_setaf` (branche `else`, auj. `:4705`) | **Hors périmètre, déjà couvert** — la branche principale utilise `translate_to_setaf_attacks` ; le `else` est le repli quand le traducteur ne rend rien. À traiter avec les 4 autres replis de la famille, pas ici |
| 6 | `_invoke_weighted` (branche `else`, auj. `:4790`) | **Idem** — repli du traducteur pondéré |
| 7 | `_invoke_bipolar` (canal `attacks`, auj. `:3813`) | **Idem** — le bipolaire a son traducteur ; seul le canal `attacks` retombe sur le producteur |
| 8 | `_invoke_ranking` (auj. `:3664`) | **Non traité.** Axe de classement : un attaquant fabriqué y biaise un score, pas une extension. Défaut réel, effet différent, mesure différente |
| 9-10 | `_invoke_dialogue` pro / opp (auj. `:4456`, `:4459`) | **Non traité.** Le dialogue construit deux camps ; la sémantique d'une source fabriquée y est à examiner avant d'y toucher |
| 11 | compare multi-axes (auj. `:8736`) | **Non traité.** Site de comparaison, pas d'analyse |
| 12 | `adapters/dung_student_provider.py:233` | **Non traité.** Sanctuaire projet étudiant |

Les sites 8-12 restent à trancher : ils ne sont **pas** couverts par cette PR et ne sont pas silencieusement acceptés. Ce qui est livré est exactement la DoD (les 4 axes orphelins de la famille Dung), avec l'inventaire honnête à côté.

## Rouge-avant-fix, trié par *pourquoi* c'est rouge

37 tests nouveaux. Baseline exécutée avant le fix, sur une copie temporaire du fichier privée des imports des symboles neufs (sinon la collection échoue et **tous** rougissent structurellement, ce qui ne prouve rien) :

| Catégorie | N | Ce que ça vaut |
|---|---|---|
| **Rouge comportemental** (assertion atteinte = le défaut) | **17** | La preuve. Message décisif : `assert [['fallacy_0_...em', 'Alpha']] == []` — une arête a atteint le raisonneur alors qu'aucune relation n'avait été dérivée |
| Rouge structurel (API neuve, `ImportError`) | 13 | Ne prouve rien — les 2 classes qui importent les symboles neufs |
| Vert avant **et** après (anti-pendule) | 7 | Ce qui marchait continue de marcher |

Les tests de câblage patchent `_llm_extract_relations` — un symbole qui **existait déjà** — précisément pour que leurs rouges soient comportementaux et non structurels.

**Ce que ces tests refusent d'asserter :** (a) sur un log — une assertion `caplog` passerait contre un fix qui n'aurait que reformulé un message ; l'assertion porte sur **le graphe capté à l'appel du handler**, plus le test d'appartenance `BOTH_in` lui-même. (b) que quelque chose **est** écarté — un corpus où rien n'est défait est un résultat légitime ; c'est l'**impossibilité structurelle** d'un rejet qui était le défaut. Le contrôle est le rejet, pas l'arête : un graphe avec arêtes qui n'écarte toujours rien serait le même faux-vert avec plus de lignes.

## Périmètre

91 fichiers de test recensés ; les 14 qui exercent les 4 axes exécutés en entier.

**13 échecs, tous pré-existants sur `main` propre** (vérifié en stashant le diff) : `test_tweety_fallbacks.py` (JVM/Tweety indisponible — `RuntimeError: Ranking semantics (categorizer) unavailable`, `TypeError: No matching overloads found for ...AbstractBuilder.add`) et `test_capability_duality_invariant.py` ×2. **552 passed / 2 skipped.**

Un seul test du périmètre était cassé **par** ce changement : `test_dung_aspic_wiring.py::test_generates_attacks_from_fallacies`, qui assertait **le défaut lui-même** (`assert any("fallacy" in str(a).lower() for a in attacks_passed)`). Il est réécrit pour asserter le contrat inverse, et renommé pour le dire.

## Réserve honnête : la rétention n'a été mesurée que sur 2 des 4 axes

`BOTH_in = 0` a été mesuré en R794 sur `dung_extensions` et `social_reasoning`. Sur `probabilistic` et `eaf`, **je ne l'ai pas mesuré** — je les ai câblés parce qu'ils appelaient le même producteur, dont on sait qu'il ne peut rien rendre d'autre. Le changement est correct dans les deux cas : soit leurs handlers ignoraient les sources fabriquées (même situation que Dung), soit ils en créaient des nœuds fantômes — et alors c'est l'anti-pendule des « 37 nœuds » déjà réalisé, que ce fix supprime. Mais la mesure manque et est dite ici plutôt que supposée.

## Effet de bord mesuré : ~396 s d'attente réseau qu'aucune assertion ne lit

Ce câblage fait qu'un test unitaire touchant ces axes déclenche un vrai appel LLM. Mesuré sur le périmètre de 14 fichiers, arbre post-fix :

| Condition | Durée | Résultat |
|---|---|---|
| Tel quel | **419,76 s** | 13 failed / 552 passed / 2 skipped |
| Réseau fermé **au constructeur** (`patch("openai.AsyncOpenAI", side_effect=...)`) | **23,47 s** | **13 failed / 552 passed / 2 skipped — identique** |

Résultats **identiques** : ces ~396 s ne portent aucune couverture. Une mesure antérieure sur 13 fichiers donnait `main` 160,35 s → avec #1698 222,55 s (+62 s), mais la latence de gpt-5-mini varie assez pour qu'une paire de runs ne fixe pas la part imputable ; l'invariant solide est l'égalité des résultats réseau fermé. L'essentiel de ce coût **précède** cette PR (les 5 traducteurs déjà câblés). Fermer les variables d'environnement ne suffit pas — `pytest-dotenv` recharge `.env` par-dessus le process (leçon #1742) ; seul le constructeur tient.

Mitigé **dans le fichier que cette PR touche** (fixture `autouse` qui garde le traducteur hors-ligne : 40,6 s → 8,2 s) et **ticketé à part** plutôt que de faire passer un changement de politique de test dans un fix.

## DoD #1698

- [x] Un `translate_to_dung_attacks` id-validé, sur le modèle des cinq existants, câblé sur les 4 axes orphelins
- [ ] `BOTH_in > 0` sur les 3 corpus **et** au moins une sémantique qui écarte quelque chose, au moins une fois sur les trois — **à mesurer sur corpus réel après merge** (voir note ci-dessous)
- [x] Aucun repli sur `_generate_attacks_from_args` quand le traducteur ne rend rien : graphe vide + cause discriminée, porte honnête-absent intacte

**L'item 2 est une mesure, pas un code path** : il se lit sur un run réel, et le budget doit être calibré d'abord — il a été deviné trop petit deux tours de suite (180 s puis 900 s). La re-mesure est postée sur #1698 avec le budget qui l'a produite.

🤖 Coordinator ai-01 — R813
