### PR TITLE
test(gate): close the family-(a) leak #1761 opened, and re-wire 4 inert mocks (#1591)

### DIFF
--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -7728,7 +7728,8 @@ async def _invoke_dung_extensions(
             )
 
             student_provider = DungStudentProvider()  # type: ignore[no-untyped-call]
-            # attacks is List[List[str]] from _generate_attacks_from_args;
+            # attacks is List[List[str]] from _derive_dung_attacks (#1698 —
+            # this site stopped reading _generate_attacks_from_args there);
             # compute_extensions expects List[Tuple[str, str]] — convert
             _typed_attacks = [(a[0], a[1]) for a in attacks if len(a) >= 2]
             result = await student_provider.compute_extensions(

--- a/tests/unit/argumentation_analysis/conftest.py
+++ b/tests/unit/argumentation_analysis/conftest.py
@@ -84,6 +84,36 @@ def mock_parse_args():
         yield mock
 
 
+@pytest.fixture
+def dung_attacks_offline():
+    """Stub the Dung attack derivation so a unit test does not reach the network.
+
+    Since #1698, ``_invoke_dung_extensions`` (and the social / probabilistic /
+    EAF axes) no longer mint their attack pairs locally: they derive them from
+    the text through the id-validated translator, i.e. through the LLM. A unit
+    test that exercises those axes without stubbing the derivation therefore
+    issues a real request — measured on ``7898d66b``: **+8 requests over 9
+    tests in 3 files** against the pre-#1761 tree, all of them family (a) of
+    the #1590 discriminator (the suite is byte-identical with the network
+    closed, so no assertion reads what the request returns).
+
+    Yields the patch so a test may give it genuine pairs
+    (``dung_attacks_offline.return_value = [["a", "b"]]``); the default is an
+    empty graph, which the axis treats as "nothing was *shown* to be attacked"
+    rather than as a failure.
+
+    Deliberately **not** autouse (#1591 anti-pendule): a test whose verdict
+    depends on a real derivation is family (b) and must keep failing when the
+    API is absent. Opt in per file or per class with
+    ``pytest.mark.usefixtures("dung_attacks_offline")``.
+    """
+    with patch(
+        "argumentation_analysis.orchestration.invoke_callables._derive_dung_attacks"
+    ) as stub:
+        stub.return_value = []
+        yield stub
+
+
 @pytest.fixture(autouse=True)
 def _shutdown_leaked_communication_threads():
     """Arrête les threads d'arrière-plan de communication fuyants après chaque test.

--- a/tests/unit/argumentation_analysis/orchestration/test_compare_dung_backends.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_compare_dung_backends.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 
 from typing import Any, Dict, List
 
+import pytest
+
 from argumentation_analysis.orchestration.invoke_callables import (
     _compare_dung_backends,
     _default_student_dung_backend,
@@ -211,10 +213,16 @@ class TestStructure:
 # -- wiring into _invoke_dung_extensions (I5 PR2) ----------------------------
 
 
+@pytest.mark.usefixtures("dung_attacks_offline")
 class TestDungCompareWiring:
     """dung_mode="compare" routes _invoke_dung_extensions through the
     multi-backend comparison, surfacing agreement (never reconciled) without a
-    JVM — the real backends are monkeypatched to deterministic fakes."""
+    JVM — the real backends are monkeypatched to deterministic fakes.
+
+    ``dung_attacks_offline`` keeps the "no real LLM" claim of this module true:
+    since #1698 the axis derives its attack graph from the text through the
+    translator, so without the stub these fakes would be fed over the network
+    (#1591 family (a) — nothing here reads the derived graph)."""
 
     async def test_compare_mode_routes_to_comparison(self, monkeypatch):
         from argumentation_analysis.orchestration import invoke_callables as ic

--- a/tests/unit/argumentation_analysis/orchestration/test_unified_pipeline.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_unified_pipeline.py
@@ -1315,6 +1315,7 @@ class TestInvokeCallables:
         )
         assert "modalities" in result
 
+    @pytest.mark.usefixtures("dung_attacks_offline")
     async def test_invoke_dung_extensions_error(self):
         """_invoke_dung_extensions returns honest-absent when handler unavailable (#1019, #1249).
 
@@ -1335,6 +1336,7 @@ class TestInvokeCallables:
         assert result.get("degraded") is True
         assert "extensions" in result
 
+    @pytest.mark.usefixtures("dung_attacks_offline")
     async def test_invoke_dung_extensions_no_arguments(self):
         """_invoke_dung_extensions generates default args when none provided."""
         from argumentation_analysis.orchestration.unified_pipeline import (

--- a/tests/unit/argumentation_analysis/test_dung_provider_selector.py
+++ b/tests/unit/argumentation_analysis/test_dung_provider_selector.py
@@ -55,8 +55,8 @@ class TestDungProviderConsumer:
             "argumentation_analysis.orchestration.invoke_callables._extract_arguments_from_context",
             return_value=["arg1", "arg2"],
         ), patch(
-            "argumentation_analysis.orchestration.invoke_callables._generate_attacks_from_args",
-            return_value=[["arg1", "arg2"]],
+            "argumentation_analysis.orchestration.invoke_callables._derive_dung_attacks",
+            new=AsyncMock(return_value=[["arg1", "arg2"]]),
         ):
             result = await _invoke_dung_extensions("Test argument", {})
 
@@ -85,8 +85,8 @@ class TestDungProviderConsumer:
             "argumentation_analysis.orchestration.invoke_callables._extract_arguments_from_context",
             return_value=["arg1", "arg2"],
         ), patch(
-            "argumentation_analysis.orchestration.invoke_callables._generate_attacks_from_args",
-            return_value=[["arg1", "arg2"]],
+            "argumentation_analysis.orchestration.invoke_callables._derive_dung_attacks",
+            new=AsyncMock(return_value=[["arg1", "arg2"]]),
         ), patch(
             "argumentation_analysis.adapters.dung_student_provider.DungStudentProvider",
             return_value=mock_provider,
@@ -99,6 +99,12 @@ class TestDungProviderConsumer:
         # Should have used the student provider
         assert result["provider"] == "abs_arg_dung_student"
         mock_provider.compute_extensions.assert_called_once()
+        # And the frame it received is the one this test injected. Until #1698
+        # the patch above named ``_generate_attacks_from_args``, which
+        # ``_invoke_dung_extensions`` had stopped calling: the provider was
+        # handed whatever the translator derived from "Test argument" over the
+        # network, and no assertion here could tell.
+        assert mock_provider.compute_extensions.call_args.args[1] == [("arg1", "arg2")]
 
     async def test_student_unavailable_falls_back(self):
         """When student provider is unavailable, should fall back to native."""
@@ -117,8 +123,8 @@ class TestDungProviderConsumer:
             "argumentation_analysis.orchestration.invoke_callables._extract_arguments_from_context",
             return_value=["arg1"],
         ), patch(
-            "argumentation_analysis.orchestration.invoke_callables._generate_attacks_from_args",
-            return_value=[],
+            "argumentation_analysis.orchestration.invoke_callables._derive_dung_attacks",
+            new=AsyncMock(return_value=[]),
         ), patch(
             "argumentation_analysis.adapters.dung_student_provider.DungStudentProvider",
             return_value=mock_provider,
@@ -142,8 +148,8 @@ class TestDungProviderConsumer:
             "argumentation_analysis.orchestration.invoke_callables._extract_arguments_from_context",
             return_value=["arg1"],
         ), patch(
-            "argumentation_analysis.orchestration.invoke_callables._generate_attacks_from_args",
-            return_value=[],
+            "argumentation_analysis.orchestration.invoke_callables._derive_dung_attacks",
+            new=AsyncMock(return_value=[]),
         ):
             result = await _invoke_dung_extensions(
                 "Test argument",

--- a/tests/unit/argumentation_analysis/workflows/test_formal_verification.py
+++ b/tests/unit/argumentation_analysis/workflows/test_formal_verification.py
@@ -355,7 +355,11 @@ class TestInvokeCallables:
         assert "logic_type" in result or "formulas" in result
 
     @pytest.mark.asyncio
+    @pytest.mark.usefixtures("dung_attacks_offline")
     async def test_invoke_dung_extensions_error_fallback(self):
+        # Without the stub this reaches the network: since #1698 the axis
+        # derives its attacks from the text, and neither branch of the
+        # assertion below reads the derived graph (#1591 family (a)).
         from argumentation_analysis.orchestration.unified_pipeline import (
             _invoke_dung_extensions,
         )


### PR DESCRIPTION
Closes the family-(a) LLM leak that **my own PR #1761 opened in the gate**, and restores four tests whose mock stopped being wired to anything.

## Ce que #1761 a cassé, mesuré

#1698 a changé le producteur : `_invoke_dung_extensions` ne fabrique plus ses arêtes localement, il les **dérive du texte** via le traducteur id-validé — donc via le LLM. Tout test unitaire qui exerce cet axe sans boucher la dérivation part sur le réseau.

Instrumentation httpx (celle de #1579/#1591 : on compte `AsyncClient.send` / `Client.send` par hôte et par nodeid), même périmètre de 26 fichiers, même sélecteur que le gate (`-m "not slow and not requires_api"`) :

| arbre | requêtes externes | tests fuyants | fichiers | verts |
|---|---|---|---|---|
| avant #1761 — `5e602e9c` | **7** | 3 | 1 | 698 |
| après #1761 — `7898d66b` | **15** | 12 | 4 | 735 |
| **cette PR** | **7** | **3** | **1** | **735** |

**+8 requêtes sur 9 tests dans 3 fichiers**, retirées. Le compte revient exactement à la ligne de base d'avant #1761, sans perdre un seul test. Toutes étaient de **famille (a)** au sens du discriminateur #1590 : réseau fermé, la suite est identique — donc aucune assertion ne lisait ce que la requête rendait.

## Le défaut derrière la fuite : un mock qui ne mockait plus rien

Les 4 tests de `test_dung_provider_selector.py` **patchaient `_generate_attacks_from_args`**. #1761 a retiré cet appel de `_invoke_dung_extensions` (remplacé par `_derive_dung_attacks`). Le patch est donc devenu **inerte** : le graphe que ces tests croyaient injecter n'arrivait jamais, et le provider recevait ce que le traducteur avait dérivé du texte `"Test argument"` sur le réseau.

Ils restaient **verts** — leurs assertions ne portaient que sur `result["provider"]` et sur `compute_extensions.assert_called_once()`, deux propriétés vraies dans les deux mondes. C'est la forme « resserrer n'est pas discriminer » du dernier commentaire de #1591 : une assertion qui ne peut pas distinguer le montage réel du montage prétendu.

Le fix pointe le patch sur la fonction réellement consultée, et **ajoute l'assertion qui manquait** :

```python
assert mock_provider.compute_extensions.call_args.args[1] == [("arg1", "arg2")]
```

**Contrôle rouge-avant-fix** : en remettant la seule cible de patch d'origine (`_generate_attacks_from_args`) et en gardant cette assertion, le test **échoue** (`1 failed in 6.17s`). L'assertion épingle donc bien la relation cassée, pas une tautologie.

## Le garde, et pourquoi il n'est pas `autouse`

Une fixture partagée `dung_attacks_offline` dans `tests/unit/argumentation_analysis/conftest.py`, **opt-in** (`pytest.mark.usefixtures`), qui bouche `_derive_dung_attacks` et rend un graphe vide par défaut (un test peut lui donner de vraies paires).

Anti-pendule, explicitement écrit dans sa docstring : la poser en `autouse` global serait **pire que le défaut**. Un test dont le verdict dépend d'une dérivation réelle est de famille (b) et **doit** continuer d'échouer quand l'API est absente ; un garde global le rendrait vert sans qu'il mesure quoi que ce soit. C'est le refus déjà posé en #1583 (« ne pas répondre en marquant le reste `requires_api` en bloc »).

## Ce que cette PR ne fait PAS

- **Les 3 requêtes résiduelles restent** : `test_unified_pipeline.py::TestRunUnifiedAnalysis` ×3. Elles **précèdent** #1761 et ont une autre cause (elles lancent le pipeline complet, pas l'axe seul). Elles appartiennent au résiduel ouvert de #1591 ; les traiter ici mélangerait deux causes dans une mesure.
- `test_formal_verification.py:364` porte `assert "semantics" in result or "error" in result` — un `or` qui ne peut pas échouer. Hermétisé ici, **pas resserré** : c'est un autre défaut, il mérite sa propre mesure.
- Aucune politique globale sur `tests/unit/` : la fixture ne s'applique qu'aux sites qui la demandent, tous nommés dans le diff.

## Périmètre exécuté

`242 passed, 10 deselected` sur les 4 fichiers touchés ; `735 passed, 2 skipped, 11 deselected` sur les 26 fichiers du périmètre d'axes. `flake8` propre sur les 5 fichiers ; les hunks `black` restants sont **antérieurs** à ce diff (lint CI en `continue-on-error`, déjà non conforme sur ces 2 fichiers avant cette PR — vérifié sur `HEAD`).

Un commentaire de `invoke_callables.py:7731` citait encore `_generate_attacks_from_args` pour un site qui lit maintenant `_derive_dung_attacks` — dérive documentaire de #1761, corrigée.

Refs #1591, #1698, #1761. Ferme le doublon #1762.

🤖 Coordinator ai-01 — R814
