### PR TITLE
feat(orchestration): #1760 steering room truth — 3 voies commutables + couple mesuré

### DIFF
--- a/argumentation_analysis/orchestration/conversational_orchestrator.py
+++ b/argumentation_analysis/orchestration/conversational_orchestrator.py
@@ -464,6 +464,120 @@ AGENT_CONFIG = {
     },
 }
 
+# ---------------------------------------------------------------------------
+# #1760 — steering room policies. The PM's capability map names 8 specialists,
+# but phase_configs freezes rooms of 3-4: the PM designates real, wired agents
+# that are simply not in the room it sits in (#1751 made that observable;
+# this is the fix side). The three "voies" of the issue are switchable here so
+# the choice is settled by comparative measurement, not on paper.
+# ---------------------------------------------------------------------------
+ROOM_POLICY_PHASE_CASTING = "phase_casting"  # status quo — baseline to beat
+ROOM_POLICY_TRUTH = "truth"  # voie 1: PM prompt names the actual phase roster
+ROOM_POLICY_REPROMPT = "reprompt"  # voie 2: hand the floor back on absorption
+ROOM_POLICY_ALL_AGENTS = "all_agents"  # voie 3: the room IS the full roster
+
+_ROOM_POLICIES = (
+    ROOM_POLICY_PHASE_CASTING,
+    ROOM_POLICY_TRUTH,
+    ROOM_POLICY_REPROMPT,
+    ROOM_POLICY_ALL_AGENTS,
+)
+
+# #1760 voie 2: per-phase cap on absorption re-prompts. A PM that re-designates
+# the same absent agent must not turn the cap into a private debate loop.
+_ABSORPTION_REPROMPT_LIMIT = 2
+
+
+def _pm_room_section(present_agents: List[str]) -> str:
+    """Voie 1 (#1760): the room line appended to the PM instructions each phase.
+
+    Pure function so the DoD test can assert on the constructed prompt: it must
+    name EXACTLY the phase roster — every present agent, and no absent one.
+    """
+    names = ", ".join(present_agents)
+    return (
+        "\n\nSALLE ACTUELLE — agents presents dans cette phase : " + names + ".\n"
+        "Designate uniquement parmi eux : les autres specialistes de ta carte ne "
+        "sont PAS dans la piece pour cette phase, une designation hors salle ne "
+        "peut pas aboutir."
+    )
+
+
+def _pm_instructions_with_room(budget_turns: int, present_agents: List[str]) -> str:
+    """Voie 1 (#1760): PM instructions + the room truth for the current phase.
+
+    Rebuilt from the AGENT_CONFIG template each phase (single source of truth)
+    so the room section never accumulates across phases. The capability map of
+    8 stays (anti-pendule: amputating it to kill impossible designations would
+    restore the very steering loss the mandate condemns).
+    """
+    base = AGENT_CONFIG["ProjectManager"]["instructions"].format(
+        budget_turns=budget_turns
+    )
+    return base + _pm_room_section(present_agents)
+
+
+def _apply_room_truth_to_pm(
+    pm_agent: Optional[Any], present_agents: List[str], budget_turns: int
+) -> None:
+    """Voie 1 (#1760): tell the PM, at phase entry, who is actually in the room.
+
+    Mutates ``instructions`` (SK agents are Pydantic with
+    ``validate_assignment=True`` and not frozen, so assignment is allowed and
+    read at each invoke). No-op when the PM is not in the created roster.
+    """
+    if pm_agent is None:
+        return
+    pm_agent.instructions = _pm_instructions_with_room(budget_turns, present_agents)
+
+
+def _resolve_room_agents(
+    room_policy: str, phase_agents: List[Any], all_agents: List[Any]
+) -> List[Any]:
+    """Voie 3 (#1760): under ``all_agents`` the room is the full roster.
+
+    The phase casting still exists (initial prompts still steer the phase
+    focus) — what changes is who can be designated and take the floor.
+    """
+    if room_policy == ROOM_POLICY_ALL_AGENTS:
+        return list(all_agents)
+    return phase_agents
+
+
+def _absorption_feedback(requested_agent: str, present_agents: List[str]) -> str:
+    """Voie 2 (#1760): the message handed back to the PM on absorption."""
+    return (
+        f"Ta designation de '{requested_agent}' n'a pas abouti : cet agent n'est "
+        f"pas dans la salle de cette phase. Agents presents : "
+        f"{', '.join(present_agents)}. Re-designe parmi les presents via "
+        f"designate_next_agent(nom_exact) et pose-lui ta question, ou poursuis "
+        f"avec un agent present."
+    )
+
+
+def _unresolved_designation_markers(state: Any) -> List[Dict[str, Any]]:
+    """#1751 markers currently in the state's deliberation trace."""
+    return [
+        r
+        for r in getattr(state, "deliberation_trace", [])
+        if isinstance(r, dict) and r.get("record_type") == "designation_unresolved"
+    ]
+
+
+def _fresh_absorbed_designation(
+    state: Any, unresolved_before: int
+) -> Optional[Dict[str, Any]]:
+    """The absorption marker recorded since ``unresolved_before`` was counted.
+
+    Returns the newest marker when the count grew this turn, else ``None``.
+    Used by voie 2 to re-prompt the PM exactly when its designation was
+    absorbed — a stale marker from an earlier turn must not re-fire.
+    """
+    markers = _unresolved_designation_markers(state)
+    if len(markers) <= unresolved_before:
+        return None
+    return markers[-1]
+
 
 def create_conversational_agents(
     kernel: sk.Kernel,
@@ -581,6 +695,7 @@ async def run_conversational_analysis(
     max_total_turns: Optional[int] = None,
     max_wall_seconds: Optional[float] = None,
     render_restitution: bool = False,
+    room_policy: str = ROOM_POLICY_PHASE_CASTING,
 ) -> Dict[str, Any]:
     """Run a full conversational analysis on the input text.
 
@@ -626,6 +741,17 @@ async def run_conversational_analysis(
             run the act-generation phases, so the acts are produced from the
             completed ``UnifiedAnalysisState`` (same renderer/acts as the
             pipeline path). Fail-loud-non-fatal: reporting never fails the run.
+        room_policy: #1760 — how the room the PM steers in relates to its
+            8-agent capability map. ``"phase_casting"`` (default) is the
+            status quo: the AgentGroupChat is built with the phase's hard-coded
+            casting alone and an off-room designation is absorbed (#1751
+            marker). ``"truth"`` appends the actual phase roster to the PM
+            instructions at each phase entry. ``"reprompt"`` hands the floor
+            back to the PM with the present roster when a designation is
+            absorbed (capped at ``_ABSORPTION_REPROMPT_LIMIT`` per phase).
+            ``"all_agents"`` builds the room with every created agent, so no
+            designation can be structurally impossible. The default stays the
+            baseline until the #1760 comparative measurement says otherwise.
 
     Returns dict with state snapshot, conversation history, and metrics.
     """
@@ -660,6 +786,7 @@ async def run_conversational_analysis(
             max_total_turns=max_total_turns,
             max_wall_seconds=max_wall_seconds,
             render_restitution=render_restitution,
+            room_policy=room_policy,
         )
 
 
@@ -772,9 +899,22 @@ async def _run_conversational_analysis_inner(
     max_total_turns: Optional[int] = None,
     max_wall_seconds: Optional[float] = None,
     render_restitution: bool = False,
+    room_policy: str = ROOM_POLICY_PHASE_CASTING,
 ) -> Dict[str, Any]:
     """Inner implementation of run_conversational_analysis, already inside llm_budget_scope."""
     start_time = time.time()
+
+    # #1760: a mistyped policy must fail loud, never silently run the baseline
+    # (anti-#1019 — an unknown value falling through to phase_casting would
+    # make a measurement row that claims to be a variant but is the control).
+    if room_policy not in _ROOM_POLICIES:
+        raise ValueError(
+            f"Unknown room_policy {room_policy!r}; expected one of "
+            f"{', '.join(_ROOM_POLICIES)}"
+        )
+    absorption_reprompt_limit = (
+        _ABSORPTION_REPROMPT_LIMIT if room_policy == ROOM_POLICY_REPROMPT else None
+    )
 
     # C1 #1500: wall-clock budget. Checked before each phase (coarse) and
     # threaded as an absolute deadline into _run_phase (per-turn, fine). On
@@ -1015,6 +1155,20 @@ async def _run_conversational_analysis_inner(
             logger.warning(f"No agents available for phase '{phase_name}', skipping")
             continue
 
+        # #1760: the room the AgentGroupChat is actually built with. Under
+        # ``all_agents`` it is the full created roster (voie 3); otherwise the
+        # phase casting (baseline / truth / reprompt all keep the casting).
+        room_agents = _resolve_room_agents(room_policy, phase_agents, all_agents)
+
+        # #1760 voie 1: at phase entry, the PM's prompt names exactly who is in
+        # the room — instead of the implicit "8" its capability map implies.
+        if room_policy == ROOM_POLICY_TRUTH:
+            _apply_room_truth_to_pm(
+                agent_by_name.get("ProjectManager"),
+                [a.name for a in room_agents],
+                max_total_turns,
+            )
+
         # Per-phase turn limit (falls back to global max_turns_per_phase),
         # further clamped to the remaining pipeline-global budget (§6).
         phase_max_turns = phase_cfg.get("max_turns", max_turns_per_phase)
@@ -1033,7 +1187,7 @@ async def _run_conversational_analysis_inner(
             trace.begin_phase(phase_name)
 
         phase_log = await _run_phase(
-            phase_agents,
+            room_agents,
             phase_cfg["initial_prompt"],
             max_turns=effective_max_turns,
             phase_name=phase_name,
@@ -1043,6 +1197,7 @@ async def _run_conversational_analysis_inner(
             reprompt_extractor=reprompt_extractor,
             deadline=wall.deadline,
             execution_path_recorder=phase_execution_paths,
+            absorption_reprompt_limit=absorption_reprompt_limit,
         )
         conversation_log.extend(phase_log)
 
@@ -1178,8 +1333,19 @@ async def _run_conversational_analysis_inner(
                 if reanalysis_agents:
                     reanalysis_added = True
                     phase_name = reanalysis_cfg["name"]
+                    # #1760: same room treatment as the macro-phases — the
+                    # conditional 4th room is a room too.
+                    reanalysis_room = _resolve_room_agents(
+                        room_policy, reanalysis_agents, all_agents
+                    )
+                    if room_policy == ROOM_POLICY_TRUTH:
+                        _apply_room_truth_to_pm(
+                            agent_by_name.get("ProjectManager"),
+                            [a.name for a in reanalysis_room],
+                            max_total_turns,
+                        )
                     logger.info(
-                        f"=== Phase: {phase_name} ({len(reanalysis_agents)} agents, "
+                        f"=== Phase: {phase_name} ({len(reanalysis_room)} agents, "
                         f"max {reanalysis_cfg['max_turns']} turns) ==="
                     )
 
@@ -1197,7 +1363,7 @@ async def _run_conversational_analysis_inner(
                         trace.begin_phase(phase_name)
 
                     phase_log = await _run_phase(
-                        reanalysis_agents,
+                        reanalysis_room,
                         reanalysis_cfg["initial_prompt"],
                         max_turns=reanalysis_effective,
                         phase_name=phase_name,
@@ -1207,6 +1373,7 @@ async def _run_conversational_analysis_inner(
                         reprompt_extractor=reprompt_extractor,
                         deadline=wall.deadline,
                         execution_path_recorder=phase_execution_paths,
+                        absorption_reprompt_limit=absorption_reprompt_limit,
                     )
                     conversation_log.extend(phase_log)
 
@@ -1999,6 +2166,7 @@ async def _run_phase(
     reprompt_extractor=None,
     deadline: Optional[float] = None,
     execution_path_recorder: Optional[List[str]] = None,
+    absorption_reprompt_limit: Optional[int] = None,
 ) -> List[Dict[str, Any]]:
     """Run a single conversational phase with a set of agents.
 
@@ -2021,6 +2189,15 @@ async def _run_phase(
     source (here), never deduced from metrics. The path is NOT added to the
     returned message list: polluting it would break C1 contracts that count on
     its exact length/content (``test_deadline_in_past_breaks_before_first_turn``).
+
+    ``absorption_reprompt_limit`` (#1760 voie 2): when set, a turn that opened
+    with an absorbed designation (a fresh ``designation_unresolved`` marker
+    recorded by the selection strategy, whose fallback speaker — the first
+    agent of the room — then took the floor) is followed by ONE re-prompt of
+    that fallback speaker carrying the present roster, up to ``limit`` times
+    per phase. Uses the growth re-prompt mechanism (direct ``agent.invoke`` on
+    a deep-copied history — ``chat.add_chat_message`` is forbidden while the
+    chat is active). ``None`` disables it (every policy except ``reprompt``).
     """
     messages: List[Dict[str, Any]] = []
     total_re_prompts = 0
@@ -2108,6 +2285,12 @@ async def _run_phase(
         # turn; each turn's delta is measured against the previous turn's state
         # (mirrors the round-robin path's fp_before/fp_after pattern).
         fp_before_tour = _get_growth_fingerprint(state)
+        # #1760 voie 2: baseline the unresolved-designation markers before the
+        # first turn, and remember the default speaker (the first agent of the
+        # room) — that is who an absorbed designation falls back to.
+        unresolved_before_turn = len(_unresolved_designation_markers(state))
+        default_speaker_name = getattr(agents[0], "name", None) if agents else None
+        absorption_re_prompts = 0
         # CB #1528 item 5: bound EACH __anext__ of the invocation to the
         # remaining budget. A function-calling agent chains ~12 LLM round-trips
         # inside a single chat.invoke() before yielding (measured R716/R717) —
@@ -2136,6 +2319,74 @@ async def _run_phase(
             # open). Pairs each motivated designation with the state delta it
             # produced, without a new measurement path.
             _backfill_designation_if_present(state, msg_entry["agent"])
+
+            # #1760 voie 2: if this turn opened with an absorbed designation
+            # (fresh marker recorded by the selection strategy, whose fallback
+            # speaker then took the floor), hand the floor BACK to the PM with
+            # the present roster. Same mechanism as the growth re-prompt below
+            # (direct agent.invoke on a deep-copied history). Capped per phase;
+            # a marker that is not fresh must not re-fire.
+            if absorption_reprompt_limit is not None:
+                fresh = _fresh_absorbed_designation(state, unresolved_before_turn)
+                if (
+                    fresh is not None
+                    and msg_entry["agent"] == default_speaker_name
+                    and absorption_re_prompts < absorption_reprompt_limit
+                ):
+                    if deadline is not None and time.time() >= deadline:
+                        logger.info(
+                            f"  [{phase_name}] Wall-clock deadline atteinte "
+                            f"avant l'absorption re-prompt — annulé."
+                        )
+                    else:
+                        feedback = _absorption_feedback(
+                            str(fresh.get("requested_agent", "?")),
+                            [a.name for a in agents],
+                        )
+                        absorbing_agent = _find_agent_by_name(
+                            agents, str(msg_entry["agent"])
+                        )
+                        if absorbing_agent is not None:
+                            abs_history = chat.history.model_copy(deep=True)
+                            abs_history.add_user_message(feedback)
+                            abs_content = ""
+                            _bump_sk_budget()
+                            try:
+                                async for abs_response in absorbing_agent.invoke(
+                                    abs_history  # type: ignore[arg-type]
+                                ):
+                                    if hasattr(abs_response, "content"):
+                                        abs_content += str(abs_response.content)
+                                    elif hasattr(abs_response, "value"):
+                                        abs_content += str(abs_response.value)
+                                    else:
+                                        abs_content += str(abs_response)
+                            except Exception as abs_exc:
+                                logger.warning(
+                                    f"  [{phase_name}] absorption re-prompt failed "
+                                    f"({type(abs_exc).__name__}: {abs_exc}); "
+                                    f"skipping remaining absorption re-prompts "
+                                    f"for this phase."
+                                )
+                                absorption_re_prompts = absorption_reprompt_limit
+                            if abs_content:
+                                messages.append(
+                                    {
+                                        "phase": phase_name,
+                                        "turn": turn,
+                                        "agent": msg_entry["agent"],
+                                        "content": (
+                                            abs_content[:500]
+                                            if abs_content
+                                            else "(empty)"
+                                        ),
+                                        "type": "absorption_reprompt",
+                                        "requested_agent": fresh.get("requested_agent"),
+                                        "path": "agent_group_chat",
+                                    }
+                                )
+                            absorption_re_prompts += 1
+                unresolved_before_turn = len(_unresolved_designation_markers(state))
 
             # Convergence check
             if _check_convergence(state, phase_name, messages):

--- a/scripts/compare_orchestration_modes.py
+++ b/scripts/compare_orchestration_modes.py
@@ -1063,6 +1063,7 @@ async def run_conversational_mode(
     text: str,
     corpus_id: str,
     max_wall_seconds: float = DEFAULT_WALL_SECONDS,
+    room_policy: str = "phase_casting",
 ) -> ModeResult:
     """Run conversational orchestrator (AgentGroupChat multi-agent).
 
@@ -1092,13 +1093,15 @@ async def run_conversational_mode(
 
     scope = (
         "AgentGroupChat multi-agent (3 macro-phases, "
-        f"wall-time-bounded at {max_wall_seconds:g}s)"
+        f"wall-time-bounded at {max_wall_seconds:g}s, room={room_policy})"
     )
     start = time.time()
     safety_net = _conversational_safety_net_timeout(max_wall_seconds)
     try:
         result = await asyncio.wait_for(
-            run_conversational_analysis(text=text, max_wall_seconds=max_wall_seconds),
+            run_conversational_analysis(
+                text=text, max_wall_seconds=max_wall_seconds, room_policy=room_policy
+            ),
             timeout=safety_net,
         )
     except asyncio.TimeoutError:
@@ -1211,6 +1214,20 @@ async def run_conversational_mode(
             # fallback so an absent field never reads as "agent_group_chat"
             # (anti-#1019 / leçon #1531: absent ≠ measured).
             "execution_path": result.get("execution_path", "round_robin_fallback"),
+            # #1760: the steering couple. A fix is judged on BOTH numbers —
+            # designations_unresolved must fall AND distinct agents having
+            # actually spoken must rise. The first alone goes to zero by
+            # forbidding designations, which is the false fix the DoD names.
+            "room_policy": room_policy,
+            "designations_emitted": budget.get("deliberation_turn_count"),
+            "designations_unresolved": len(budget.get("designations_unresolved") or []),
+            "distinct_speakers": sorted(
+                {
+                    m.get("agent")
+                    for m in conv_log
+                    if isinstance(m, dict) and m.get("agent")
+                }
+            ),
         },
     )
 
@@ -1959,6 +1976,7 @@ async def run_all(
     output_file: Optional[str] = None,
     dry_run: bool = False,
     max_wall_seconds: float = DEFAULT_WALL_SECONDS,
+    conv_room_policy: str = "phase_casting",
 ) -> List[ModeResult]:
     """Run selected modes on selected corpora.
 
@@ -2045,9 +2063,12 @@ async def run_all(
                 # runner (uniform signature ``runner(text, cid, max_wall_seconds=...)``).
                 # Pipeline applies the state-reference trick; conversational
                 # its internal bound (C1); hierarchical honest-degrades.
-                result = await runner(
-                    text, corpus_id, max_wall_seconds=max_wall_seconds
-                )
+                # #1760: the conversational room policy rides along for the
+                # steering measurement rows (ignored by every other runner).
+                runner_kwargs = {"max_wall_seconds": max_wall_seconds}
+                if mode == "conversational":
+                    runner_kwargs["room_policy"] = conv_room_policy
+                result = await runner(text, corpus_id, **runner_kwargs)
                 results.append(result)
                 if result.terminated_by_budget:
                     status = f"BUDGET BREACH ({result.duration_seconds:.2f}s)"
@@ -2152,6 +2173,17 @@ def main():
         ),
     )
     parser.add_argument(
+        "--conv-room-policy",
+        choices=("phase_casting", "truth", "reprompt", "all_agents"),
+        default="phase_casting",
+        help=(
+            "#1760 — conversational only: how the room the PM steers in "
+            "relates to its 8-agent capability map. phase_casting is the "
+            "baseline; the report's extra_metrics carries the steering couple "
+            "(designations_unresolved / distinct_speakers) for every value."
+        ),
+    )
+    parser.add_argument(
         "--depth-parity",
         action="store_true",
         help=(
@@ -2174,6 +2206,7 @@ def main():
                 output_file=args.output,
                 dry_run=args.dry_run,
                 max_wall_seconds=args.max_wall_seconds,
+                conv_room_policy=args.conv_room_policy,
             )
         )
     except ValueError as exc:

--- a/tests/scripts/test_compare_orchestration_modes_1480.py
+++ b/tests/scripts/test_compare_orchestration_modes_1480.py
@@ -1098,7 +1098,9 @@ class TestCBWallClockBudget1528:
                 mode="hierarchical_bridge", corpus_id=cid, success=True
             )
 
-        async def fake_conv(text, cid, max_wall_seconds=180.0):
+        async def fake_conv(
+            text, cid, max_wall_seconds=180.0, room_policy="phase_casting"
+        ):
             received["conversational"] = max_wall_seconds
             return mod.ModeResult(mode="conversational", corpus_id=cid, success=True)
 

--- a/tests/unit/argumentation_analysis/orchestration/test_conversational_orchestrator.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_conversational_orchestrator.py
@@ -607,6 +607,7 @@ class TestRunConversationalAnalysis:
             reprompt_extractor=None,
             deadline=None,
             execution_path_recorder=None,
+            absorption_reprompt_limit=None,
         ):
             phase_names_seen.append(phase_name)
             return [

--- a/tests/unit/argumentation_analysis/orchestration/test_steering_room_1760.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_steering_room_1760.py
@@ -1,0 +1,255 @@
+"""#1760 — the PM steers in a room whose description doesn't match it.
+
+``phase_configs`` freezes 3 macro-phases with a hard-coded casting of 3-4
+agents while ``AGENT_CONFIG["ProjectManager"]`` hands the PM a static map of
+8 and a free-steering mandate. The PM designates real, wired agents that are
+simply absent from the room it sits in — #1751 made the absorption
+observable (``designation_unresolved`` markers); this lane carries the fix.
+
+## Three voies, switchable, settled by measurement
+
+* ``truth`` — the PM prompt names the actual roster of the current phase.
+* ``reprompt`` — an absorbed designation hands the floor back to the PM with
+  the present roster (capped per phase).
+* ``all_agents`` — the room IS the full roster; no designation can be
+  structurally impossible.
+
+## What these tests assert — and refuse to assert
+
+The DoD's first test demands an assertion on the **constructed prompt**, not
+on the contents of ``AGENT_CONFIG``: a prompt that exists only as a config
+entry has never been shown to a model. Conversely the anti-pendule test
+demands a capability map that still names all eight specialists after the
+fix — amputating the map to kill impossible designations would restore the
+steering loss the mandate condemns ("restaurer la conduite est le but ; la
+restreindre serait pire que le défaut").
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from argumentation_analysis.orchestration.conversational_orchestrator import (
+    _absorption_feedback,
+    _apply_room_truth_to_pm,
+    _fresh_absorbed_designation,
+    _pm_instructions_with_room,
+    _pm_room_section,
+    _resolve_room_agents,
+    ROOM_POLICY_ALL_AGENTS,
+    ROOM_POLICY_PHASE_CASTING,
+    ROOM_POLICY_REPROMPT,
+    ROOM_POLICY_TRUTH,
+    run_conversational_analysis,
+)
+
+# The phase-2 casting of the real ``phase_configs`` — where both measured
+# absorptions of the R808 sweep were emitted from.
+PHASE_2_CASTING = ["ProjectManager", "FormalAgent", "QualityAgent"]
+
+# Every specialist the PM's capability map names. The room truth must not
+# amputate this list (anti-pendule).
+CAPABILITY_MAP_AGENTS = [
+    "ExtractAgent",
+    "InformalAgent",
+    "FormalAgent",
+    "QualityAgent",
+    "CounterAgent",
+    "DebateAgent",
+    "GovernanceAgent",
+    "JTMS",
+]
+
+
+def _agent(name: str) -> MagicMock:
+    agent = MagicMock()
+    agent.name = name
+    return agent
+
+
+def _state(text: str = "Texte argumentatif de test."):
+    from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+
+    return UnifiedAnalysisState(text)
+
+
+class TestRoomTruthNamesTheExactRoster:
+    """DoD #1: the constructed PM prompt names exactly the phase roster."""
+
+    def test_room_section_names_every_present_agent(self):
+        section = _pm_room_section(PHASE_2_CASTING)
+        for name in PHASE_2_CASTING:
+            assert name in section, f"{name} absent from the room section"
+
+    def test_room_section_names_no_absent_agent(self):
+        """ "Exactly" excludes the map-only specialists from the ROOM line."""
+        section = _pm_room_section(PHASE_2_CASTING)
+        absent = [
+            n for n in CAPABILITY_MAP_AGENTS if n not in PHASE_2_CASTING and n != "JTMS"
+        ]
+        for name in absent:
+            assert name not in section, (
+                f"{name} is not in this phase's room but the room section "
+                "names it — the prompt would describe the wrong room again"
+            )
+
+    def test_full_instructions_carry_the_room_and_keep_the_map(self):
+        """The room truth is additive: 8-capability map stays, roster is named."""
+        instructions = _pm_instructions_with_room(30, PHASE_2_CASTING)
+        for name in PHASE_2_CASTING:
+            assert name in instructions
+        # The capability map is NOT amputated down to the roster (anti-pendule:
+        # that would forbid the designations instead of steering them).
+        for name in CAPABILITY_MAP_AGENTS:
+            assert name in instructions, (
+                f"{name} vanished from the PM capability map — the fix amputated "
+                "the PM's steering knowledge instead of telling it the truth"
+            )
+
+    def test_room_section_does_not_accumulate_across_phases(self):
+        """Rebuilt from the template each phase — phase 2's room must replace
+        phase 1's, not stack on top of it."""
+        pm = _agent("ProjectManager")
+        pm.instructions = _pm_instructions_with_room(
+            30, ["ProjectManager", "ExtractAgent", "InformalAgent"]
+        )
+        _apply_room_truth_to_pm(pm, PHASE_2_CASTING, 30)
+        assert "ExtractAgent" in pm.instructions  # still on the capability map
+        room_start = pm.instructions.index("SALLE ACTUELLE")
+        room = pm.instructions[room_start:]
+        assert "ExtractAgent" not in room, "phase 1's room leaked into phase 2's"
+        assert pm.instructions.count("SALLE ACTUELLE") == 1
+
+    def test_apply_room_truth_to_pm_is_a_noop_without_a_pm(self):
+        _apply_room_truth_to_pm(None, PHASE_2_CASTING, 30)  # must not raise
+
+
+class TestHonouredDesignationStaysHonoured:
+    """DoD #2 (anti-pendule): green BEFORE the fix and green AFTER.
+
+    A fix that breaks honoured designations, or that empties the defect by
+    emptying the PM's steering, is the false fix.
+    """
+
+    def test_in_room_designation_is_still_selected(self):
+        """Pre-existing behaviour on main: a designation inside the room is
+        honoured by the selection strategy. Must survive every voie."""
+        from argumentation_analysis.core.strategies import (
+            DelegatingSelectionStrategy,
+        )
+
+        import asyncio
+
+        state = _state()
+        agents = [_agent(n) for n in PHASE_2_CASTING]
+        strategy = DelegatingSelectionStrategy(agents, state)
+
+        state.designate_next_agent("FormalAgent")
+        selected = asyncio.run(strategy.next(agents, []))
+
+        assert selected.name == "FormalAgent"
+        markers = [
+            r
+            for r in state.deliberation_trace
+            if r.get("record_type") == "designation_unresolved"
+        ]
+        assert markers == []
+
+    def test_capability_map_still_names_all_eight(self):
+        """The map is the PM's steering knowledge — pre-existing content that
+        the fix must not amputate."""
+        from argumentation_analysis.orchestration.conversational_orchestrator import (
+            AGENT_CONFIG,
+        )
+
+        instructions = AGENT_CONFIG["ProjectManager"]["instructions"]
+        for name in CAPABILITY_MAP_AGENTS:
+            assert name in instructions
+
+
+class TestAllAgentsRoom:
+    """Voie 3: the room IS the full roster — the defect becomes structurally
+    impossible, not merely discouraged."""
+
+    def test_policy_returns_the_full_roster(self):
+        phase = [_agent(n) for n in PHASE_2_CASTING]
+        every = [_agent(n) for n in CAPABILITY_MAP_AGENTS if n != "JTMS"]
+        room = _resolve_room_agents(ROOM_POLICY_ALL_AGENTS, phase, every)
+        assert [a.name for a in room] == [a.name for a in every]
+
+    def test_other_policies_keep_the_phase_casting(self):
+        phase = [_agent(n) for n in PHASE_2_CASTING]
+        every = [_agent(n) for n in CAPABILITY_MAP_AGENTS if n != "JTMS"]
+        for policy in (
+            ROOM_POLICY_PHASE_CASTING,
+            ROOM_POLICY_TRUTH,
+            ROOM_POLICY_REPROMPT,
+        ):
+            room = _resolve_room_agents(policy, phase, every)
+            assert [a.name for a in room] == PHASE_2_CASTING
+
+    def test_strategy_over_full_roster_honours_off_casting_designation(self):
+        """The measured defect (R808: CounterAgent designated from the
+        phase-2 room, absorbed) is structurally impossible over the full
+        roster: the designated agent IS in the room."""
+        from argumentation_analysis.core.strategies import (
+            DelegatingSelectionStrategy,
+        )
+
+        import asyncio
+
+        state = _state()
+        every = [_agent(n) for n in CAPABILITY_MAP_AGENTS if n != "JTMS"]
+        strategy = DelegatingSelectionStrategy(every, state)
+
+        state.designate_next_agent("CounterAgent")  # absent from phase-2 casting
+        selected = asyncio.run(strategy.next(every, []))
+
+        assert selected.name == "CounterAgent"
+        markers = [
+            r
+            for r in state.deliberation_trace
+            if r.get("record_type") == "designation_unresolved"
+        ]
+        assert markers == []
+
+
+class TestAbsorptionReprompt:
+    """Voie 2: the floor comes back to the PM with the present roster."""
+
+    def test_fresh_marker_is_returned_only_when_the_count_grew(self):
+        state = _state()
+        assert _fresh_absorbed_designation(state, 0) is None  # nothing yet
+
+        state.record_designation_unresolved(
+            requested_agent="CounterAgent",
+            present_agents=PHASE_2_CASTING,
+            selection_path="delegating",
+        )
+        fresh = _fresh_absorbed_designation(state, 0)
+        assert fresh is not None and fresh["requested_agent"] == "CounterAgent"
+        # A marker from an earlier turn must not re-fire the re-prompt.
+        assert _fresh_absorbed_designation(state, 1) is None
+
+    def test_feedback_names_the_request_and_the_present_roster(self):
+        feedback = _absorption_feedback("CounterAgent", PHASE_2_CASTING)
+        assert "CounterAgent" in feedback
+        for name in PHASE_2_CASTING:
+            assert name in feedback, (
+                f"{name} absent from the roster handed back to the PM — it "
+                "cannot re-designate among agents it is not told are present"
+            )
+
+
+class TestPolicyValidation:
+    def test_unknown_room_policy_fails_loud(self):
+        """Anti-#1019: a typo'd policy must not silently run the baseline and
+        pass itself off as a variant row."""
+        import asyncio
+
+        with pytest.raises(ValueError, match="room_policy"):
+            asyncio.run(
+                run_conversational_analysis(
+                    text="x", room_policy="room8"  # plausible typo
+                )
+            )


### PR DESCRIPTION
# #1760 — steering room truth: 3 voies commutables + couple mesuré

Le PM conduit dans une salle que son prompt décrit mal : `phase_configs` gèle
3 macro-phases avec un casting codé en dur de 3-4 agents, pendant que
`AGENT_CONFIG["ProjectManager"]` lui remet une carte statique de 8 et un
mandat de conduite libre. Les désignations hors-salle sont absorbées à 3
sites de repli (observables depuis #1751 via les marqueurs
`designation_unresolved` ; mesuré R808 : 13 désignations, 2 absorbées).

## Les trois voies — une seule rallonge, `room_policy`

| Voie | Mécanisme | Ce qu'elle change |
|---|---|---|
| `phase_casting` (défaut) | — | La baseline à battre. **Aucun changement de comportement sans opt-in.** |
| `truth` | `_pm_room_section` reconstruit les instructions du PM à chaque phase pour nommer **exactement** le roster présent | Le prompt dit la vérité ; la carte des 8 capacités reste **additive** (anti-pendule) |
| `reprompt` | Une désignation absorbée fraîche rend la parole à l'agent absorbant avec le roster présent (cap 2/phase) | Réutilise le mécanisme growth re-prompt (invoke direct sur copie profonde de l'historique) |
| `all_agents` | La salle EST le roster complet | Le défaut devient **structurellement impossible** |

Politique inconnue → `ValueError` fail-loud (#1019) : une variante typoée ne
peut pas se faire passer pour la ligne baseline.

## DoD 1 — le prompt construit nomme exactement le roster

`TestRoomTruthNamesTheExactRoster` : assertion sur le **prompt construit**
(`_pm_room_section` / `_pm_instructions_with_room`), pas sur le contenu de
`AGENT_CONFIG` — un prompt qui n'existe que comme entrée de config n'a jamais
été montré à un modèle. Rouge-avant-fix prouvé par stash : `ImportError` sur
main. La section salle est reconstruite à chaque phase (pas d'accumulation
inter-phases).

## DoD 2 — anti-pendule

`TestHonouredDesignationStaysHonoured` : une désignation **dans** la salle
reste honorée (vert avant ET après), et la carte des capacités nomme toujours
les 8 spécialistes. Amputer la carte pour tuer les désignations impossibles
restaurerait la perte de conduite que le mandat condamne.

## DoD 3 — mesure comparée à budget calibré

Budget calibré : **1800 s** (sonde préalable sur corpus_A : terminaison
naturelle à **322 s**, 4/4 phases, budget non contraignant — les budgets
180 s puis 900 s des tours précédents coupaient la course avant la fin).

Le harnais `compare_orchestration_modes.py` expose `--conv-room-policy` et
rapporte le **couple** par run dans `extra_metrics` :
`designations_unresolved` **ET** `distinct_speakers` — le compteur seul est
le faux fix (il tombe à zéro en interdisant les désignations).

### Résultat du sweep 4 politiques × corpus_A × 1800 s

| run | dur | unresolved | orateurs distincts | phases | fallacies | fill |
|---|---|---|---|---|---|---|
| sonde baseline (`phase_casting`) | 322 s | 1 | 1 (PM seul, 33 msg) | 4/4 | 3 | — |
| `phase_casting` | 349 s | 0 | 3 (Extract, Formal, PM) | 4/4 | 11 | 0.36 |
| `truth` | 321 s | 1 | 2 (PM, Quality) | 4/4 | 21 | 0.33 |
| `reprompt` | 377 s | 1 | 3 (Extract, PM, Quality) | 4/4 | 15 | 0.40 |
| `all_agents` | 417 s | 0 | 2 (Formal, PM) | 4/4 | 31 | 0.31 |

**Lecture honnête (n=1 par politique, LLM non-déterministe).** La baseline
elle-même a basculé entre 1 unresolved/1 orateur (sonde) et 0/3 (sweep) sur
deux runs identiques — le couple ne peut pas trancher seule à cette taille
d'échantillon, et je refuse de le prétendre. Ce qui est **structurel** :

- `all_agents` rend l'absorption **impossible par construction** (prouvé en
  unitaire sur le roster complet : la désignation hors-casting R808 y est
  honorée), et son run confirme 0 marqueur — le seul 0 **garanti**, pas
  tiré au sort. Coût : +68 s vs baseline sweep (ordre de grandeur inchangé,
  même budget 1800 s non contraignant).
- `truth` est une contrainte de prompt (advisory) : son run montre 1
  absorption subsistante — le modèle peut toujours désigner hors-salle en
  ignorant l'instruction. Elle donne la **meilleure loyauté descriptive**
  du prompt (le PM sait qui est présent), pas une garantie.
- `reprompt` émet le plus de désignations (6 vs 2) — le retour de parole
  après absorption en déclenche de nouvelles — et la meilleure fill rate
  (0.40), mais 1 absorption subsiste (cap 2/phase atteint sans être
  décisif sur ce run).

Le défaut étant maintenant **commutable et mesuré**, la décision de défaut
peut être re-mesurée à n>1 via `--conv-room-policy` sans nouveau code. Le
défaut du paramètre reste `phase_casting` (baseline) : basculer le défaut
sur n=1 serait le pendule inversé — mesurer, puis trancher.

## Tests

- 12 nouveaux tests unitaires (`test_steering_room_1760.py`) : roster exact,
  anti-pendule, résolution de politique, staleness du marqueur frais,
  fail-loud
- Suite #1751 inchangée : 27 passed ensemble
- Mypy : 0 nouvelle (baseline 42) ; black : propre
- Suite orchestration complète : en cours au dépôt (résultat en commentaire)

## Artefacts

- Rapports sweep (markdown + json par politique) : `evaluation/results/` (gitignored, agrégats seuls ici)

Closes #1760
