### PR TITLE
fix(state): one name, one calculation for deliberation_turn_count (#1765)

### DIFF
--- a/argumentation_analysis/core/shared_state.py
+++ b/argumentation_analysis/core/shared_state.py
@@ -59,6 +59,26 @@ class DesignationRecord:
     delta_summary: Optional[str] = None
 
 
+def count_designation_turns(trace: Any) -> int:
+    """Number of genuine PM designations in a deliberation trace (#1765).
+
+    A :class:`DesignationRecord` carries **no** ``record_type`` (it is the
+    ``asdict`` of the dataclass); every non-designation entry declares one.
+    Counting by allow-list — "a designation is a record with no marker" —
+    instead of by exclusion list ("everything that is not a ``cap_breach``")
+    is what keeps this number honest when a marker type is added.
+
+    #1765: this is the single definition. #1751 flipped the orchestrator's
+    copy to the allow-list and left the state snapshot's copy on the exclusion
+    list, so the same field name reported two different numbers — and the
+    inflated one was the one handed to the agents (``get_current_state_snapshot``
+    defaults to ``summarize=True``). One name, one calculation, two callers.
+    """
+    return sum(
+        1 for r in trace or [] if isinstance(r, dict) and r.get("record_type") is None
+    )
+
+
 def record_unresolved_designation(
     state: Any,
     requested_agent: str,
@@ -397,12 +417,12 @@ class RhetoricalAnalysisState:
                 "next_agent_designated": self._next_agent_designated,
                 # CONV-C #1334: deliberation trace (count only in the summary;
                 # full records via the non-summarized snapshot / direct field).
-                # cap_breach markers are NOT designations — excluded from the
-                # count so the metric reflects PM conduction turns only.
-                "deliberation_turn_count": sum(
-                    1
-                    for r in getattr(self, "deliberation_trace", [])
-                    if r.get("record_type") != "cap_breach"
+                # #1765: allow-list, via the single definition. This snapshot is
+                # what ``get_current_state_snapshot`` hands the agents, so an
+                # exclusion list here made the PM read its own absorbed
+                # designations (#1751 markers) as conduction turns it had spent.
+                "deliberation_turn_count": count_designation_turns(
+                    getattr(self, "deliberation_trace", [])
                 ),
             }
         else:

--- a/argumentation_analysis/orchestration/conversational_orchestrator.py
+++ b/argumentation_analysis/orchestration/conversational_orchestrator.py
@@ -43,6 +43,7 @@ from argumentation_analysis.core.llm_service import create_llm_service
 from argumentation_analysis.core.shared_state import (
     RhetoricalAnalysisState,
     UnifiedAnalysisState,
+    count_designation_turns,
     record_unresolved_designation,
 )
 from argumentation_analysis.core.state_manager_plugin import StateManagerPlugin
@@ -1975,12 +1976,14 @@ def _deliberation_turn_count(state: Any) -> int:
     this number honest when a marker type is added: the previous form would
     have silently counted each ``designation_unresolved`` as one more
     deliberation turn, inflating the very metric #1751 exists to correct.
+
+    #1765: delegates to :func:`count_designation_turns`, the single definition.
+    #1751 flipped this reader and left the state snapshot's copy of the same
+    field name on the exclusion list — the trace has two readers, and only one
+    was walked. The ``getattr`` stays here: this reader is duck-typed (states
+    without a trace count zero rather than raising).
     """
-    return sum(
-        1
-        for r in getattr(state, "deliberation_trace", [])
-        if r.get("record_type") is None
-    )
+    return count_designation_turns(getattr(state, "deliberation_trace", []))
 
 
 def _resolve_phase_agents(

--- a/tests/unit/argumentation_analysis/orchestration/test_designation_absorption_1751.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_designation_absorption_1751.py
@@ -327,6 +327,60 @@ class TestTheMarkerDoesNotCorruptItsReaders:
         ]
         assert designations[0]["state_fingerprint_after"] is not None
 
+    def test_the_snapshot_reader_does_not_inflate_either(self):
+        """#1765 — the trace has TWO readers, and this class walked one.
+
+        The class docstring says "a new record type is a new hop for **every**
+        reader", but only ``_deliberation_turn_count`` was flipped to the
+        allow-list. The same field name in ``get_state_snapshot(summarize=True)``
+        stayed on the exclusion list, so every absorption counted as a
+        conduction turn there. That copy is the one the agents actually read:
+        ``StateManagerPlugin.get_current_state_snapshot`` is a kernel function
+        whose ``summarize`` defaults to ``True``. The PM asking where it stood
+        in its turn budget was handed a number inflated by its own failed
+        designations — the very events #1751 exists to surface.
+        """
+        state = _state()
+        state.record_designation(agent="FormalAgent", motivation="m", trigger="initial")
+        assert state.get_state_snapshot(summarize=True)["deliberation_turn_count"] == 1
+
+        state.record_designation_unresolved(
+            requested_agent="InformalAgent", present_agents=PHASE_2_CASTING
+        )
+        state.record_designation_unresolved(
+            requested_agent="CounterAgent", present_agents=PHASE_2_CASTING
+        )
+        state.record_cap_breach(cap_kind="wall_clock", turn=1, detail="d")
+
+        assert (
+            state.get_state_snapshot(summarize=True)["deliberation_turn_count"] == 1
+        ), "the snapshot handed to the agents must not count absorptions as turns"
+
+    def test_the_two_readers_agree(self):
+        """One name, one calculation (#1765).
+
+        Pins the relation rather than each side separately: two surfaces of one
+        state that are allowed to drift are exactly how #1751 half-landed.
+        """
+        from argumentation_analysis.orchestration.conversational_orchestrator import (
+            _deliberation_turn_count,
+        )
+
+        state = _state()
+        state.record_designation(agent="FormalAgent", motivation="m", trigger="initial")
+        state.record_designation_unresolved(
+            requested_agent="CounterAgent", present_agents=PHASE_2_CASTING
+        )
+        state.record_designation(
+            agent="QualityAgent", motivation="m", trigger="synergy"
+        )
+        state.record_cap_breach(cap_kind="wall_clock", turn=2, detail="d")
+
+        snapshot_count = state.get_state_snapshot(summarize=True)[
+            "deliberation_turn_count"
+        ]
+        assert snapshot_count == _deliberation_turn_count(state) == 2
+
 
 class TestPhaseCastingDropIsVisible:
     """Scope item 3: a phase name absent from ``agent_by_name`` is dropped.


### PR DESCRIPTION
Ferme #1765. Le champ `deliberation_turn_count` avait **deux écrivains aux sémantiques opposées**, et c'est le mauvais qui était montré aux agents.

## Le défaut

`conversational_orchestrator.py:1801` comptait en **liste d'autorisation** (`record_type is None` = vraie désignation). `shared_state.py:402` comptait encore en **liste d'exclusion** (`!= "cap_breach"`), donc y incluait chaque marqueur `designation_unresolved` de #1751.

#1751 a corrigé un lecteur et laissé l'autre. Sa propre docstring décrit pourtant exactement le défaut resté en place :

> *« the previous form would have silently counted each `designation_unresolved` as one more deliberation turn, inflating the very metric #1751 exists to correct. »*

## Mesuré, pas déduit

```
empty state                              orchestrator=0  snapshot=0
+1 GENUINE designation                   orchestrator=1  snapshot=1
+1 ABSORBED designation (#1751 marker)   orchestrator=1  snapshot=2   <-- DIVERGE
+1 more ABSORBED                         orchestrator=1  snapshot=3   <-- DIVERGE
```

Le snapshot gonflait d'exactement **+1 par absorption**.

## Pourquoi c'est un défaut de conduite et pas une métrique cosmétique

`StateManagerPlugin.get_current_state_snapshot` est une `@kernel_function` dont le paramètre `summarize` vaut **`True` par défaut** : l'appel naturel d'un agent rendait la version gonflée. Le PM qui demandait où il en était de son budget de tours recevait un compte enflé par ses **propres désignations ratées** — les événements que #1751 existe précisément pour rendre visibles. Plus la salle absorbait, plus le PM se croyait avancé.

## Le fix — un nom, un calcul

`count_designation_turns(trace)` devient la **définition unique** dans `shared_state.py` ; le snapshot l'utilise, et `_deliberation_turn_count` de l'orchestrateur y délègue (en gardant son `getattr` : ce lecteur est duck-typé et doit rendre 0 sur un état sans trace plutôt que lever).

## Pourquoi aucun test ne rougissait — et le test ajouté

Les deux gardes de la copie fautive (`test_conv_c_deliberation_trace_1334.py:64`, `test_conv_c_pm_conduction_1334.py:177`) ne posent **jamais** de `designation_unresolved`. L'assertion aurait échoué ; aucune fixture ne l'armait :

```bash
grep -rln "record_designation_unresolved" tests/ | xargs grep -l "get_state_snapshot"
# (vide avant cette PR)
```

Les deux tests ajoutés vivent dans la classe qui avait **nommé le principe sans parcourir le second saut** — `TestTheMarkerDoesNotCorruptItsReaders`, dont la docstring dit « a new record type is a new hop for **every** reader » alors qu'elle ne couvrait que `_deliberation_turn_count` :

- `test_the_snapshot_reader_does_not_inflate_either` — arme la clé omise (1 désignation réelle + 2 absorptions + 1 `cap_breach`), assertion sur le snapshot que lisent les agents ;
- `test_the_two_readers_agree` — épingle la **relation** entre les deux surfaces, pas chaque côté séparément : deux vues d'un même état autorisées à diverger sont exactement la façon dont #1751 a atterri à moitié.

**Contrôle rouge-avant-fix par substitution dégénérée** (pas un `ImportError`) : en remettant la liste d'exclusion dans le snapshot et en gardant les nouvelles assertions, les deux tests échouent — `2 failed in 4.99s`.

## Ce que cette PR ne fait PAS

- Elle ne renomme pas le champ. Son lecteur est le PM, qui a besoin d'un compte de désignations, pas d'une longueur de trace — c'est le nom qui était juste et le calcul qui était faux.
- Elle n'ajoute pas `designation_unresolved` à la liste d'exclusion : ce serait reconduire le défaut d'un cran, et le prochain type de marqueur le rouvrirait.
- Elle ne touche pas aux deux tests existants du snapshot : ils restent verts et vrais, ils ne mesuraient simplement rien sur ce point.

Refs #1751, #1760, #1334.

🤖 Coordinator ai-01 — R815
