### PR TITLE
feat(dung): #1698 sixth id-validated translator + genuine-first wiring on the 4 orphan axes

### DIFF
--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -3244,6 +3244,58 @@ def _generate_attacks_from_args(
     return attacks
 
 
+async def _dung_attacks_genuine_first(
+    input_text: str,
+    arguments: List[str],
+    context: Dict[str, Any],
+    capability: str,
+) -> List[List[str]]:
+    """Derive a Dung-family attack graph genuine-first (#1698).
+
+    Same contract as the five id-validated translator wirings: a caller who
+    supplies genuine attacks (``context["attacks"]``) is never overridden.
+    Otherwise the sixth translator (:func:`translate_to_dung_attacks`) derives
+    binary attacks from the text, validated so BOTH endpoints are inventory
+    members — ``BOTH_in`` by construction, no fabricated node. When the
+    translator arbitrated and found nothing (``no_genuine_relations``), the
+    graph is EMPTY (#1629 soustraction, same as SetAF/weighted): the synthetic
+    :func:`_generate_attacks_from_args` cites fabricated sources
+    (``fallacy_*`` / ``CA:``) that the handler drops at its inventory guard,
+    so running it after an arbitration would substitute an inert echo for the
+    arbitration's answer — and mixing producers in one list would make every
+    edge unattributable. The synthetic producer stands ONLY when no answer was
+    obtained (``translator_failed`` / ``translator_unconfigured``), preserving
+    the pre-#1698 behaviour of a caller-less, translator-less run.
+    """
+    existing = context.get("attacks")
+    if existing:
+        return existing
+    try:
+        from argumentation_analysis.orchestration.structured_arg_translator import (
+            translate_to_dung_attacks,
+        )
+
+        outcome = await translate_to_dung_attacks(input_text, arguments)
+    except Exception as e:
+        logger.warning(
+            "%s: Dung translator raised (%s) — translator_failed, synthetic "
+            "producer stands.",
+            capability,
+            type(e).__name__,
+        )
+        _propagate_structured_arg_cause(
+            context, capability, "translator_failed", type(e).__name__
+        )
+        return _generate_attacks_from_args(arguments, context)
+    _propagate_structured_arg_cause(context, capability, outcome.cause, outcome.error)
+    if outcome.relations:
+        context["attacks"] = outcome.relations
+        return outcome.relations
+    if outcome.cause == "no_genuine_relations":
+        return []
+    return _generate_attacks_from_args(arguments, context)
+
+
 # --- Input-shaping helpers for dormant Dung-family reasoners (#1169 W1) ---
 #
 # These map spectacular's canonical context (arguments: List[str],
@@ -4315,7 +4367,10 @@ async def _invoke_probabilistic(
     args = context.get("arguments") or _extract_arguments_from_context(
         input_text, context
     )
-    attacks = context.get("attacks") or _generate_attacks_from_args(args, context)
+    # Genuine-first (#1698): caller > id-validated translator > synthetic.
+    attacks = await _dung_attacks_genuine_first(
+        input_text, args, context, "probabilistic_argumentation"
+    )
     probs = context.get("probabilities") or {a: 0.5 for a in args}
 
     try:
@@ -4733,7 +4788,10 @@ async def _invoke_social(input_text: str, context: Dict[str, Any]) -> Dict[str, 
     args = context.get("arguments") or _extract_arguments_from_context(
         input_text, context
     )
-    attacks = context.get("attacks") or _generate_attacks_from_args(args, context)
+    # Genuine-first (#1698): caller > id-validated translator > synthetic.
+    attacks = await _dung_attacks_genuine_first(
+        input_text, args, context, "social_argumentation"
+    )
     votes = context.get("votes", {})
     if votes:
         votes = {k: tuple(v) if isinstance(v, list) else v for k, v in votes.items()}
@@ -4806,7 +4864,10 @@ async def _invoke_eaf(input_text: str, context: Dict[str, Any]) -> Dict[str, Any
     args = context.get("arguments") or _extract_arguments_from_context(
         input_text, context
     )
-    attacks = context.get("attacks") or _generate_attacks_from_args(args, context)
+    # Genuine-first (#1698): caller > id-validated translator > synthetic.
+    attacks = await _dung_attacks_genuine_first(
+        input_text, args, context, "epistemic_argumentation"
+    )
     # EAF expects Dict[agent, List[arg]] beliefs, NOT float probabilities.
     # Shape/validate; None lets the handler default to "all believed" (valid
     # non-fabricated baseline, #1019).
@@ -7586,8 +7647,11 @@ async def _invoke_dung_extensions(
     # 1. Extract arguments from upstream phases
     arguments = _extract_arguments_from_context(input_text, context)
 
-    # 2. Build attack relations from fallacies and counter-arguments
-    attacks = _generate_attacks_from_args(arguments, context)
+    # 2. Build attack relations genuine-first: caller > translator > synthetic
+    # (#1698 — the four orphan Dung-family axes get the sixth translator).
+    attacks = await _dung_attacks_genuine_first(
+        input_text, arguments, context, "dung_extensions"
+    )
 
     # I5 #1430: compare mode — run every available backend on the same AF and
     # surface agreement / disagreement (never auto-reconciled). Short-circuits

--- a/argumentation_analysis/orchestration/structured_arg_translator.py
+++ b/argumentation_analysis/orchestration/structured_arg_translator.py
@@ -278,6 +278,22 @@ async def _llm_extract_relations(
             '{"attacks": [{"source": "argN", "target": "argM", "weight": 0.8, '
             '"rationale": "one short sentence"}]}'
         )
+    elif relation_kind == "dung_attacks":
+        task = (
+            "Identify ATTACKS among these arguments in the sense of Dung's "
+            "abstract argumentation: an attack is a pair (source, target) where "
+            "the source argument, taken ALONE, gives a reason AGAINST the target "
+            "argument — rebuts its conclusion or undermines its premise. This is "
+            "ordinary pairwise defeat, one attacker against one target (NOT a "
+            "joint/collective attack, NOT weighted). Cite source AND target by "
+            "id; every id must be present in the inventory. Report an attack "
+            "ONLY when the text genuinely presents the source as undermining "
+            "the target — do NOT connect unrelated arguments."
+        )
+        shape = (
+            '{"attacks": [{"source": "argN", "target": "argM", '
+            '"rationale": "one short sentence"}]}'
+        )
     else:
         raise ValueError(f"unknown relation_kind: {relation_kind!r}")
 
@@ -663,6 +679,43 @@ def _validate_weighted_attacks(
     return out
 
 
+def _validate_dung_attacks(
+    data: Dict[str, Any], arg_by_id: Dict[str, str]
+) -> List[List[str]]:
+    """Validate LLM Dung attack proposals against the real inventory.
+
+    A Dung attack is a binary ``(source, target)`` pair: both ids must be in
+    the inventory and distinct (self-attack is not a genuine relation). A pair
+    citing any unknown id is dropped — never salvaged, never auto-added as a
+    node (anti-théâtre #1019: a fabricated node is an unattacked argument that
+    wins under every semantics, the symmetrical false-green of #1698). Ids are
+    re-mapped to canonical argument text so the framework connects real nodes.
+    Returns ``[source_text, target_text]`` pairs. Dedup on ``(source, target)``
+    keeps the first occurrence.
+    """
+    raw = data.get("attacks", []) if isinstance(data, dict) else []
+    if not isinstance(raw, list):
+        return []
+    seen: set[Tuple[str, str]] = set()
+    out: List[List[str]] = []
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        src_id = str(item.get("source", "")).strip()
+        tgt_id = str(item.get("target", "")).strip()
+        if src_id not in arg_by_id or tgt_id not in arg_by_id:
+            continue  # fabricated / malformed → dropped (anti-théâtre)
+        if src_id == tgt_id:
+            continue  # self-attack is not a genuine relation
+        src, tgt = arg_by_id[src_id], arg_by_id[tgt_id]
+        key = (src, tgt)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append([src, tgt])
+    return out
+
+
 async def translate_to_bipolar_supports(
     input_text: str, arguments: List[str]
 ) -> TranslationResult:
@@ -917,12 +970,54 @@ async def translate_to_weighted_attacks(
     return TranslationResult(relations=[], cause=CAUSE_NO_GENUINE_RELATIONS)
 
 
+async def translate_to_dung_attacks(
+    input_text: str, arguments: List[str]
+) -> TranslationResult:
+    """Derive genuine binary Dung attacks from the text + arguments (#1698).
+
+    The sixth id-validated translator: a Dung attack is a ``[source, target]``
+    pair where BOTH endpoints are inventory members (validated by id, canonical
+    argument texts) — so ``BOTH_in`` holds by construction and no node is ever
+    fabricated. Not reusing ``_validate_setaf_attacks``: a SetAF joint attack
+    (N attackers jointly defeat a target) is not decomposable into N binary
+    attacks — the joint attack only exists as a set — so unfolding SetAF
+    proposals into Dung pairs would fabricate edges the model never proposed.
+    See :func:`translate_to_bipolar_supports` for the ``cause`` contract
+    (#1608).
+    """
+    arg_by_id, _ = _build_inventory(arguments)
+    if not arg_by_id:
+        return TranslationResult(relations=[], cause=CAUSE_NO_GENUINE_RELATIONS)
+    try:
+        data = await _llm_extract_relations(input_text, arguments, "dung_attacks")
+    except TranslatorUnconfigured:
+        return TranslationResult(relations=[], cause=CAUSE_TRANSLATOR_UNCONFIGURED)
+    except Exception as e:  # network / parse / budget — never fatal to the run
+        logger.warning(
+            "Dung attacks translator failed (%s) — staying absent.",
+            type(e).__name__,
+        )
+        return TranslationResult(
+            relations=[], cause=CAUSE_TRANSLATOR_FAILED, error=type(e).__name__
+        )
+    attacks = _validate_dung_attacks(data, arg_by_id)
+    _log_translation_yield("Dung", data, ("attacks",), len(attacks))
+    if attacks:
+        logger.info(
+            "Dung translator: derived %d genuine binary attack(s) from text.",
+            len(attacks),
+        )
+        return TranslationResult(relations=attacks, cause=CAUSE_EVALUATED)
+    return TranslationResult(relations=[], cause=CAUSE_NO_GENUINE_RELATIONS)
+
+
 __all__ = [
     "translate_to_bipolar_supports",
     "translate_to_aba_contraries",
     "translate_to_aspic_rules",
     "translate_to_setaf_attacks",
     "translate_to_weighted_attacks",
+    "translate_to_dung_attacks",
     "TranslationResult",
     "TranslatorUnconfigured",
     "CAUSE_EVALUATED",
@@ -939,4 +1034,5 @@ __all__ = [
     "_unique_rule_name",
     "_validate_setaf_attacks",
     "_validate_weighted_attacks",
+    "_validate_dung_attacks",
 ]

--- a/scripts/measure_1698_dung_translator.py
+++ b/scripts/measure_1698_dung_translator.py
@@ -1,0 +1,333 @@
+"""#1698 measurement — the sixth translator renders Dung attacks on real corpora.
+
+DoD (issue #1698, R811 dispatch):
+
+  1. ``BOTH_in > 0`` on 3 corpora — the id-validated ``translate_to_dung_attacks``
+     keeps at least one attack whose BOTH endpoints are inventory members,
+     per corpus (real prose windows, production pipeline path end to end).
+  2. At least one Dung semantics EXCLUDES something at least once across the
+     three corpora — the real criterion (a framework that decided), NOT an
+     edge count. An extension set whose union omits at least one inventory
+     argument is an exclusion.
+  3. Honest causes: each run records the discriminated cause the wiring wrote
+     (``evaluated`` / ``no_genuine_relations`` / ``translator_failed`` /
+     ``translator_unconfigured``) — absence of rejection on one corpus is a
+     legitimate result.
+
+Dissociative control (R807 lesson): corpus_B offset 0 is a table of contents,
+not prose (49 dates, ~2 sentences per window). The translator is expected to
+find nothing there — a zero on the TOC window against non-zeros on the prose
+windows shows the measurement reads CONTENT, not a mechanical artifact.
+
+Method: single production path per run — real ``_invoke_fact_extraction`` for
+the inventory, then the REAL ``_invoke_dung_extensions`` whose #1698 wiring
+runs the translator internally (raw proposals captured by wrapping
+``_llm_extract_relations``; BOTH_in also recomputed independently from the
+raw ids vs the inventory). No prompt variant, no validator relaxation.
+
+Privacy HARD: corpus content loads in-memory; the artifact lands under
+evaluation/results/real_analysis/ (GITIGNORED). Console output carries opaque
+IDs only (corpus_A/B/C, arg indices).
+
+Usage:
+    conda run -n projet-is-roo-new --no-capture-output python scripts/measure_1698_dung_translator.py
+    conda run -n projet-is-roo-new --no-capture-output python scripts/measure_1698_dung_translator.py --n 3
+"""
+
+import argparse
+import asyncio
+import json
+import os
+import re
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+os.chdir(Path(__file__).parent.parent)
+
+_env_path = Path(__file__).parent.parent / ".env"
+if _env_path.exists():
+    with open(_env_path, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line and not line.startswith("#") and "=" in line:
+                key, _, val = line.partition("=")
+                os.environ.setdefault(key.strip(), val.strip())
+
+from argumentation_analysis.core.utils.crypto_utils import derive_encryption_key
+from argumentation_analysis.core.io_manager import load_extract_definitions
+from argumentation_analysis.orchestration import structured_arg_translator as tr
+from argumentation_analysis.orchestration.invoke_callables import (
+    _invoke_dung_extensions,
+    _invoke_fact_extraction,
+)
+
+DATASET_PATH = Path("argumentation_analysis/data/extract_sources.json.gz.enc")
+CORPUS_SRC_IDX = {"A": 11, "B": 3, "C": 2}
+RESULTS_DIR = Path("argumentation_analysis/evaluation/results/real_analysis")
+
+# Real-prose windows. B offset 30000 jumps past the table of contents (R807:
+# the first 3000 chars of corpus_B are a TOC — 49 dates, ~2 sentences — and
+# are NOT argumentative prose). C offset 10400 is the production window used
+# by the #1710 ground truth. A offset 0 is prose from the start.
+WINDOWS = {"A": 0, "B": 30000, "C": 10400}
+CONTROL_WINDOW = {"corpus": "B", "offset": 0}  # TOC dissociative control
+
+_DATE_RE = re.compile(r"\b(19|20)\d{2}\b")
+
+# Raw proposals captured before validation (ids re-checked against the
+# inventory here, independently of the production validator).
+_raw_llm: Dict[str, Dict[str, Any]] = {}
+_orig_llm = tr._llm_extract_relations
+
+
+async def _capture_llm(
+    input_text: str, arguments: List[str], relation_kind: str
+) -> Dict[str, Any]:
+    data = await _orig_llm(input_text, arguments, relation_kind)
+    _raw_llm[relation_kind] = data if isinstance(data, dict) else {}
+    return data
+
+
+tr._llm_extract_relations = _capture_llm
+
+
+def load_corpus_text(label: str, offset: int, max_chars: int = 3000) -> str:
+    key = derive_encryption_key(os.environ["TEXT_CONFIG_PASSPHRASE"])
+    defs = load_extract_definitions(DATASET_PATH, key)
+    entry = defs[CORPUS_SRC_IDX[label]]
+    text = entry.get("full_text", "") or ""
+    return text[offset : offset + max_chars]
+
+
+def fingerprint(text: str) -> Dict[str, int]:
+    """Structural fingerprint — TOC detection BEFORE any famine diagnosis (R807)."""
+    sentences = [s for s in re.split(r"[.!?]+", text) if len(s.strip()) > 10]
+    return {
+        "chars": len(text),
+        "sentences_gt10": len(sentences),
+        "year_tokens": len(_DATE_RE.findall(text)),
+    }
+
+
+def inventory_texts(extraction: Dict[str, Any]) -> List[str]:
+    args = extraction.get("arguments", [])
+    out = []
+    for a in args:
+        if isinstance(a, dict) and a.get("text"):
+            out.append(str(a["text"]))
+        elif a:
+            out.append(str(a))
+    return out
+
+
+def both_in_from_raw(arguments: List[str]) -> Dict[str, int]:
+    """Recompute BOTH_in from the RAW proposals, independent of the validator."""
+    data = _raw_llm.get("dung_attacks", {})
+    arg_by_id, _ = tr._build_inventory(arguments)
+    proposals = data.get("attacks", []) if isinstance(data, dict) else []
+    raw = src_in = tgt_in = both = 0
+    for rel in proposals:
+        if not isinstance(rel, dict):
+            continue
+        raw += 1
+        s = str(rel.get("source", ""))
+        t = str(rel.get("target", ""))
+        s_ok = s in arg_by_id
+        t_ok = t in arg_by_id
+        src_in += int(s_ok)
+        tgt_in += int(t_ok)
+        both += int(s_ok and t_ok and s != t)
+    return {"raw": raw, "src_in": src_in, "tgt_in": tgt_in, "both_in": both}
+
+
+def exclusions(result: Dict[str, Any], arguments: List[str]) -> List[Dict[str, Any]]:
+    """Semantics that EXCLUDE at least one inventory argument (the real criterion).
+
+    Reads ``all_extensions`` — the per-semantics dict the Dung site builds
+    ({sem: {"extensions": [[…]], "count": N, …}} or ``{"error": …}``).
+    NB: ``result["extensions"]`` is NOT that dict — it is the PRIMARY
+    semantics' ENRICHED payload ({extensions, count, sizes, all_members});
+    iterating it (first version of this script) yields the garbage keys
+    "extensions"/"sizes"/"all_members" as pseudo-semantics.
+
+    A semantics excludes when the union of its extensions omits at least one
+    argument (an attacked argument no extension accepts). Error-shaped entries
+    are filtered out, not counted as zeros.
+    """
+    out: List[Dict[str, Any]] = []
+    all_ext = result.get("all_extensions")
+    if not isinstance(all_ext, dict):
+        return out
+    for sem, payload in all_ext.items():
+        if not isinstance(payload, dict) or "error" in payload:
+            continue  # semantics not computed
+        ext_lists = payload.get("extensions")
+        if not isinstance(ext_lists, list):
+            continue
+        accepted = set()
+        for extension in ext_lists:
+            if isinstance(extension, list):
+                accepted.update(str(a) for a in extension)
+        excluded = [a for a in arguments if a not in accepted]
+        if excluded:
+            out.append(
+                {
+                    "semantics": sem,
+                    "n_extensions": len(ext_lists),
+                    "n_excluded": len(excluded),
+                    "excluded_idx": [
+                        arguments.index(a) for a in excluded
+                    ],  # opaque index only
+                }
+            )
+    return out
+
+
+async def one_run(label: str, offset: int, draw: int) -> Dict[str, Any]:
+    text = load_corpus_text(label, offset)
+    fp = fingerprint(text)
+    _raw_llm.clear()
+
+    extraction = await _invoke_fact_extraction(text, {"_state_object": None})
+    arguments = inventory_texts(extraction)
+    record: Dict[str, Any] = {
+        "corpus": f"corpus_{label}",
+        "offset": offset,
+        "draw": draw,
+        "fingerprint": fp,
+        "extraction_status": extraction.get("extraction_status"),
+        "n_arguments": len(arguments),
+    }
+    if not arguments:
+        record.update(
+            {
+                "cause": "no_inventory",
+                "raw": 0,
+                "both_in": 0,
+                "retained": 0,
+                "exclusions": [],
+            }
+        )
+        return record
+
+    ctx: Dict[str, Any] = {
+        "_state_object": None,
+        "phase_extract_output": {"arguments": arguments},
+    }
+    result = await _invoke_dung_extensions(text, ctx)
+    counts = both_in_from_raw(arguments)
+    attacks = result.get("attacks", [])
+    record.update(
+        {
+            "cause": ctx.get("_structured_arg_cause:dung_extensions"),
+            "raw": counts["raw"],
+            "src_in": counts["src_in"],
+            "tgt_in": counts["tgt_in"],
+            "both_in_independent": counts["both_in"],
+            "retained": len(attacks) if isinstance(attacks, list) else 0,
+            "attacks_submitted": result.get("attacks_submitted"),
+            "attacks_retained": result.get("attacks_retained"),
+            "degraded": result.get("degraded"),
+            "semantics_computed": sorted(
+                k
+                for k, v in (result.get("all_extensions") or {}).items()
+                if isinstance(v, dict) and "count" in v
+            ),
+            "exclusions": exclusions(result, arguments),
+        }
+    )
+    return record
+
+
+async def main_async(n: int) -> None:
+    # DoD2 needs the real Tweety reasoner — without a live JVM every Dung run
+    # degrades ("AFHandler instantiated before JVM is ready") and no semantics
+    # is ever computed, making the exclusion criterion unobservable (measured:
+    # first run of this script, all-degraded). Idempotent; degrades honestly
+    # to degraded=True runs if the JDK is unavailable.
+    try:
+        from argumentation_analysis.core.jvm_setup import initialize_jvm
+
+        jvm_ok = bool(initialize_jvm())
+        if jvm_ok:
+            # initialize_jvm() starts the JVM only; AFHandler additionally
+            # requires the Tweety CLASSES to be loaded
+            # (is_jvm_ready = started AND _classes_loaded — measured: JVM up
+            # alone still degrades every run). Same call as
+            # unified_pipeline's #529 warmup.
+            from argumentation_analysis.agents.core.logic.tweety_initializer import (
+                TweetyInitializer,
+            )
+
+            TweetyInitializer().ensure_jvm_and_components_are_ready()
+    except Exception as e:
+        jvm_ok = False
+        print(f"[1698] JVM init failed ({type(e).__name__}) — Dung runs will degrade")
+    print(f"[1698] JVM initialized: {jvm_ok}")
+
+    runs: List[Dict[str, Any]] = []
+    for label, offset in WINDOWS.items():
+        for draw in range(1, n + 1):
+            t0 = time.time()
+            rec = await one_run(label, offset, draw)
+            rec["wall_s"] = round(time.time() - t0, 1)
+            runs.append(rec)
+            print(
+                f"[1698] {rec['corpus']}@{rec['offset']} draw{draw}: "
+                f"args={rec['n_arguments']} raw={rec.get('raw')} "
+                f"both_in={rec.get('both_in_independent', 0)} "
+                f"retained={rec.get('retained', 0)} cause={rec.get('cause')} "
+                f"excl={[(e['semantics'], e['n_excluded']) for e in rec.get('exclusions', [])]} "
+                f"({rec['wall_s']}s)"
+            )
+    # Dissociative control: corpus_B offset 0 = TOC (expect no attacks).
+    ctrl = await one_run(CONTROL_WINDOW["corpus"], CONTROL_WINDOW["offset"], 1)
+    ctrl["control"] = "toc_window"
+    runs.append(ctrl)
+    print(
+        f"[1698] CONTROL {ctrl['corpus']}@{ctrl['offset']} (TOC): "
+        f"fp={ctrl['fingerprint']} args={ctrl['n_arguments']} "
+        f"raw={ctrl.get('raw')} both_in={ctrl.get('both_in_independent', 0)} "
+        f"cause={ctrl.get('cause')}"
+    )
+
+    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    artifact = RESULTS_DIR / f"measure_1698_dung_translator_{ts}.json"
+    with open(artifact, "w", encoding="utf-8") as f:
+        json.dump({"generated": ts, "n_draws": n, "runs": runs}, f, indent=2)
+
+    # Aggregate verdict (opaque IDs only).
+    prose = [r for r in runs if r.get("control") is None]
+    per_corpus_both = {
+        c: max(
+            (r.get("both_in_independent", 0) for r in prose if r["corpus"] == c),
+            default=0,
+        )
+        for c in (f"corpus_{k}" for k in WINDOWS)
+    }
+    any_exclusion = [
+        (r["corpus"], e["semantics"], e["n_excluded"])
+        for r in prose
+        for e in r.get("exclusions", [])
+    ]
+    print("\n=== #1698 aggregate ===")
+    print(f"BOTH_in>0 per corpus (max over draws): {per_corpus_both}")
+    print(
+        f"DoD1 (BOTH_in>0 on 3 corpora): {all(v > 0 for v in per_corpus_both.values())}"
+    )
+    print(
+        f"DoD2 (>=1 semantics excludes >=1 arg, >=1 corpus): {bool(any_exclusion)} -> {any_exclusion[:8]}"
+    )
+    print(f"artifact: {artifact}")
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--n", type=int, default=2, help="draws per corpus (default 2)")
+    a = ap.parse_args()
+    asyncio.run(main_async(a.n))

--- a/tests/unit/argumentation_analysis/orchestration/test_dung_aspic_wiring.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_dung_aspic_wiring.py
@@ -62,7 +62,9 @@ class TestInvokeDungExtensions:
 
     @pytest.mark.asyncio
     async def test_generates_attacks_from_fallacies(self):
-        """Dung function uses _generate_attacks_from_args for cross-KB."""
+        """Dung synthetic path: _generate_attacks_from_args fires when the
+        translator yields NO answer (#1698 genuine-first: caller > translator
+        > synthetic — a translator failure keeps the pre-#1698 behaviour)."""
         from argumentation_analysis.orchestration.unified_pipeline import (
             _invoke_dung_extensions,
         )
@@ -102,7 +104,15 @@ class TestInvokeDungExtensions:
                 "argumentation_analysis.agents.core.logic.tweety_initializer.TweetyInitializer"
             ) as mock_init:
                 mock_init.return_value = MagicMock()
-                result = await _invoke_dung_extensions("test text", context)
+                # #1698: no answer from the translator (translator_failed) —
+                # the synthetic producer stands. An ARBITRATED answer would
+                # replace it (see test_dung_translator_wiring_1698.py).
+                with patch(
+                    "argumentation_analysis.orchestration.structured_arg_translator."
+                    "translate_to_dung_attacks",
+                    side_effect=RuntimeError("no answer"),
+                ):
+                    result = await _invoke_dung_extensions("test text", context)
 
         # Attacks should have been generated from the fallacy
         call_args = mock_handler.analyze_multi_semantics.call_args

--- a/tests/unit/argumentation_analysis/orchestration/test_dung_translator_wiring_1698.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_dung_translator_wiring_1698.py
@@ -1,0 +1,318 @@
+"""#1698 — the four orphan Dung-family axes derive attacks via the
+id-validated translator, never from the synthetic generator.
+
+Measured history (issue #1698): ``_generate_attacks_from_args`` has exactly two
+branches and both mint a FABRICATED source (``fallacy_{i}_{label}`` /
+``CA: {…}``) while targets are always inventory members — so ``BOTH_in = 0``
+was the only result that producer could ever render, on every corpus, for
+Dung/social/probabilistic/EAF (the four axes with no translator). SetAF and
+weighted already go through id-validated translators; this PR gives the four
+orphans the same sixth brother (``translate_to_dung_attacks``).
+
+Contracts pinned here (each red-before-fix was EXECUTED on the pre-fix tree;
+see the PR for the triage):
+
+1. ``test_translator_edges_reach_the_handler`` (RED before, per axis) —
+   id-validated pairs derived from the text reach the handler's attack
+   argument. Before: the submitted graph was the synthetic producer's output
+   (empty with no fallacies in context) — an assertion about the SUBMITTED
+   GRAPH, not a signature change.
+2. ``test_arbitrated_empty_yields_empty_graph_and_cause`` (RED before) — when
+   the translator ran and found nothing (``no_genuine_relations``), the graph
+   submitted is empty AND the discriminated cause is written into the pipeline
+   context. Before: no cause key was ever written for these axes.
+3. ``test_no_synthetic_source_survives_an_arbitration`` (RED before) — the
+   anti-pendule: with fallacies in context and the arbitrator answering
+   "none", NO ``fallacy_*`` edge is submitted. Before: the synthetic producer
+   minted them.
+4. Counter-controls, GREEN before AND after (forbid the false fix):
+   - ``test_caller_provided_attacks_pass_through`` — genuine caller input is
+     never overridden (the 3 axes that already honoured ``context["attacks"]``).
+   - ``test_honest_absent_door_untouched`` — JVM-down still returns the
+     degraded honest-absent dict on the Dung axis.
+
+The behavioural verdict (``BOTH_in > 0`` + a semantics that excludes
+something, on the 3 real corpora) is NOT testable hermetically — it needs the
+Tweety reasoner — and lives in the #1698 measurement script + its real-run
+artifacts (gitignored).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import contextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+INVOKE = "argumentation_analysis.orchestration.invoke_callables"
+LOGIC = "argumentation_analysis.agents.core.logic"
+
+_ARGS = [
+    "Claim alpha: the tram line will save the district money",
+    "Claim beta: the tram line will cost far more than it returns",
+    "Claim gamma: the district budget already runs a deficit",
+]
+# arg9 does not exist in the 3-argument inventory → dropped at validation.
+_LLM_VALID = (
+    '{"attacks": [{"source": "arg1", "target": "arg2", "rationale": "r"}, '
+    '{"source": "arg9", "target": "arg1", "rationale": "fabricated id"}]}'
+)
+_LLM_EMPTY = '{"attacks": []}'
+_EXPECTED_PAIR = [_ARGS[0], _ARGS[1]]
+
+# axis key in the pipeline context → (invoke fn, handler module, handler class,
+# analyze method name, needs TweetyInitializer, runs _annotate_attack_retention)
+_AXES = {
+    "dung_extensions": (
+        "_invoke_dung_extensions",
+        "af_handler",
+        "AFHandler",
+        "analyze_multi_semantics",
+    ),
+    "probabilistic_argumentation": (
+        "_invoke_probabilistic",
+        "probabilistic_handler",
+        "ProbabilisticHandler",
+        "analyze_probabilistic_framework",
+    ),
+    "social_argumentation": (
+        "_invoke_social",
+        "social_handler",
+        "SocialHandler",
+        "analyze_social_framework",
+    ),
+    "epistemic_argumentation": (
+        "_invoke_eaf",
+        "eaf_handler",
+        "EAFHandler",
+        "analyze_epistemic_framework",
+    ),
+}
+
+# The three axes that already honoured caller-provided attacks before this PR
+# (the Dung site did not — it is out of the green-before counter-control).
+_PASSTHROUGH_AXES = (
+    "probabilistic_argumentation",
+    "social_argumentation",
+    "epistemic_argumentation",
+)
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def _resp(payload: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=payload))]
+    )
+
+
+@contextmanager
+def _translator_llm(payload: str):
+    """Patch the LLM call the translator performs.
+
+    ``_llm_extract_relations`` lazy-imports its helpers FROM invoke_callables
+    at call time (lesson #1742: patch the site of definition, not a facade),
+    so patching these module attributes reaches the translator.
+    """
+    with (
+        patch(f"{INVOKE}._get_openai_client", return_value=(MagicMock(), "m")),
+        patch(f"{INVOKE}._get_determinism_params", return_value={}),
+        patch(
+            f"{INVOKE}._guarded_chat_completion",
+            new=AsyncMock(return_value=_resp(payload)),
+        ),
+        patch(
+            f"{INVOKE}._parse_json_from_llm",
+            side_effect=lambda raw: __import__("json").loads(raw),
+        ),
+    ):
+        yield
+
+
+@contextmanager
+def _handler_capturing(axis_key: str, handler_output: dict | None = None):
+    """Patch the axis's Tweety handler; yield the capture of `attacks`."""
+    _, mod_name, cls, method = _AXES[axis_key]
+    handler = MagicMock()
+    getattr(handler, method).return_value = dict(handler_output or {})
+    with (
+        patch(f"{LOGIC}.{mod_name}.{cls}", return_value=handler),
+        patch(
+            f"{LOGIC}.tweety_initializer.TweetyInitializer", return_value=MagicMock()
+        ),
+    ):
+        yield handler
+
+
+def _submitted_attacks(axis_key: str, handler: MagicMock):
+    _, _, _, method = _AXES[axis_key]
+    args = getattr(handler, method).call_args[0]
+    return args[1]  # (arguments, ATTACKS, ...) in every one of the four sites
+
+
+def _base_context(**extra) -> dict:
+    """Context carrying the inventory where EVERY site reads it.
+
+    The three sibling sites read top-level ``context["arguments"]`` first; the
+    Dung site reads ONLY ``_extract_arguments_from_context`` (phase outputs,
+    never the top-level key — measured pre-fix: a top-level-only context made
+    the Dung graph run over ``["corpus-text-placeholder"]``). Providing both
+    exercises each site through its real argument door.
+    """
+    ctx = {
+        "arguments": list(_ARGS),
+        "phase_extract_output": {"arguments": list(_ARGS)},
+        "_state_object": None,
+    }
+    ctx.update(extra)
+    return ctx
+
+
+def _invoke(axis_key: str, context: dict) -> dict:
+    from importlib import import_module
+
+    mod = import_module(INVOKE)
+    fn = getattr(mod, _AXES[axis_key][0])
+    return _run(fn("corpus-text-placeholder", context))
+
+
+# ---------------------------------------------------------------------------
+# 1 — translator-derived edges reach the handler (RED before the wiring)
+# ---------------------------------------------------------------------------
+
+
+class TestTranslatorEdgesReachTheHandler:
+
+    @pytest.mark.parametrize("axis_key", list(_AXES))
+    def test_translator_edges_reach_the_handler(self, axis_key):
+        """Id-validated pairs are the graph actually submitted to the handler."""
+        context = _base_context()
+        with _translator_llm(_LLM_VALID), _handler_capturing(
+            axis_key, {"extensions": {"grounded": [[]]}}
+        ) as handler:
+            _invoke(axis_key, context)
+        submitted = _submitted_attacks(axis_key, handler)
+        assert _EXPECTED_PAIR in submitted, (
+            f"[{axis_key}] the handler was not handed the id-validated pair "
+            f"derived from the text — the Dung-family translator wiring "
+            "(#1698) is not in effect"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 2 — arbitrated empty: empty graph + discriminated cause (RED before)
+# ---------------------------------------------------------------------------
+
+
+class TestArbitratedEmptyYieldsCause:
+
+    @pytest.mark.parametrize("axis_key", list(_AXES))
+    def test_arbitrated_empty_yields_empty_graph_and_cause(self, axis_key):
+        """Translator ran, found nothing → [] submitted + cause written."""
+        context = _base_context()
+        with _translator_llm(_LLM_EMPTY), _handler_capturing(
+            axis_key, {"extensions": {"grounded": [[]]}}
+        ) as handler:
+            _invoke(axis_key, context)
+        submitted = _submitted_attacks(axis_key, handler)
+        cause_key = f"_structured_arg_cause:{axis_key}"
+        assert submitted == [], (
+            f"[{axis_key}] arbitrator found no genuine relations yet the "
+            f"submitted graph is not empty: {submitted!r}"
+        )
+        assert context.get(cause_key) == "no_genuine_relations", (
+            f"[{axis_key}] discriminated cause not written to context — "
+            "an empty graph without its cause is indistinguishable from a "
+            "silent producer (#1019)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 3 — anti-pendule: no synthetic source survives an arbitration (RED before)
+# ---------------------------------------------------------------------------
+
+
+class TestNoSyntheticSourceSurvivesArbitration:
+
+    @pytest.mark.parametrize("axis_key", list(_AXES))
+    def test_no_synthetic_source_survives_an_arbitration(self, axis_key):
+        """Fallacies in context + arbitrator says 'none' → no fallacy_* edge.
+
+        This forbids the false fix the issue names: minting fallacy nodes (or
+        keeping the synthetic producer as a fallback) would produce edges that
+        drop 100% at the handler guard — the exact inert-graph defect.
+        """
+        context = _base_context(
+            phase_hierarchical_fallacy_output={
+                "fallacies": [
+                    # arg_N ids as minted by shared_state._generate_id (#1629).
+                    {"type": "hasty", "target_argument": "arg_1"},
+                    {"type": "appeal", "target_argument": "arg_2"},
+                ]
+            },
+        )
+        with _translator_llm(_LLM_EMPTY), _handler_capturing(
+            axis_key, {"extensions": {"grounded": [[]]}}
+        ) as handler:
+            _invoke(axis_key, context)
+        submitted = _submitted_attacks(axis_key, handler)
+        synthetic = [
+            a
+            for a in submitted
+            if isinstance(a, (list, tuple)) and str(a[0]).startswith("fallacy_")
+        ]
+        assert not synthetic, (
+            f"[{axis_key}] synthetic fallacy_* sources reached the submitted "
+            f"graph alongside the translator's arbitration — mixing producers "
+            "forbids attributing an edge to its source (#1698 anti-pendule)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 4 — counter-controls, GREEN before AND after (forbid the false fix)
+# ---------------------------------------------------------------------------
+
+
+class TestCounterControls:
+
+    @pytest.mark.parametrize("axis_key", _PASSTHROUGH_AXES)
+    def test_caller_provided_attacks_pass_through(self, axis_key):
+        """Genuine caller input is never overridden by the translator.
+
+        Green before this PR (these three sites already read
+        ``context["attacks"]``) and must stay green after: the wiring only
+        fires when the context brings nothing genuine.
+        """
+        genuine = [[_ARGS[2], _ARGS[0]]]
+        context = _base_context(attacks=list(genuine))
+        # LLM would propose a DIFFERENT pair — the caller's must win anyway.
+        with _translator_llm(_LLM_VALID), _handler_capturing(
+            axis_key, {"extensions": {"grounded": [[]]}}
+        ) as handler:
+            _invoke(axis_key, context)
+        submitted = _submitted_attacks(axis_key, handler)
+        assert submitted == genuine, (
+            f"[{axis_key}] caller-provided genuine attacks were overridden: "
+            f"{submitted!r}"
+        )
+
+    def test_honest_absent_door_untouched(self):
+        """JVM down → degraded honest-absent dict on the Dung axis.
+
+        Green before and after: the honest-absent door is not modified by the
+        translator wiring (#1698 DoD).
+        """
+        context = _base_context()
+        with _translator_llm(_LLM_VALID):
+            with patch(
+                f"{LOGIC}.af_handler.AFHandler",
+                side_effect=RuntimeError("no JVM"),
+            ):
+                result = _invoke("dung_extensions", context)
+        assert result.get("degraded") is True
+        assert result.get("semantics") == "unavailable"
+        assert "honest-absent" in result.get("note", "")


### PR DESCRIPTION
# #1698 — Sixth id-validated translator `translate_to_dung_attacks` + genuine-first wiring on the 4 orphan axes

Closes #1698. R811 dispatch (msg-20260814T183056-3ij30h).

## What

- **`translate_to_dung_attacks`** (`structured_arg_translator.py`): the 6th id-validated translator. Binary `[source, target]` pairs, both ids validated against the inventory, canonical-text output → `BOTH_in` by construction, no fabricated node. New `_validate_dung_attacks` (binary, not `_validate_setaf_attacks` — a SetAF joint attack is a set, not decomposable into N binary attacks; unfolding would fabricate edges the model never proposed).
- **`_dung_attacks_genuine_first`** (`invoke_callables.py`): the family wiring helper, mirrored on the SetAF pattern. Caller > translator > synthetic:
  - caller-supplied `context["attacks"]` never overridden;
  - translator relations → submitted graph + `context["attacks"]` (shared by the 4 axes, same pairwise shape — same sharing contract as a caller-supplied list);
  - `no_genuine_relations` (arbitrated empty) → **empty graph**, no fallback (#1629 soustraction — the synthetic producer's `fallacy_*`/`CA:` sources are dropped 100% at the handler inventory guard, so it would substitute an inert echo for the arbitration's answer);
  - `translator_failed`/`translator_unconfigured` (no answer obtained) → synthetic producer stands (pre-#1698 behavior preserved).
  - Cause propagated per capability (`dung_extensions`, `social_argumentation`, `probabilistic_argumentation`, `epistemic_argumentation`).
- **Wired on the 4 orphan sites**: `_invoke_dung_extensions` (:7650), `_invoke_probabilistic` (:4367), `_invoke_social` (:4788), `_invoke_eaf` (:4864).
- **Measurement script** `scripts/measure_1698_dung_translator.py` + real-run artifact (gitignored, `evaluation/results/real_analysis/`).

## DoD verification

### 1. BOTH_in > 0 on 3 corpora — MEASURED, TRUE (4 independent runs)

Real production path per run: real `_invoke_fact_extraction` → real `_invoke_dung_extensions` (wiring runs the translator internally). Raw proposals captured before validation; BOTH_in ALSO recomputed independently from raw ids vs inventory. Final run (artifact `measure_1698_dung_translator_20260816T010841Z.json`, gitignored):

| corpus | window | draw1 | draw2 | cause |
| --- | --- | --- | --- | --- |
| corpus_A | offset 0 | both_in=3 | both_in=0 (arbitrated, `no_genuine_relations`) | evaluated / arbitrated |
| corpus_B | offset 30000 (prose, past TOC) | both_in=7 | both_in=6 | evaluated |
| corpus_C | offset 10400 (production window) | both_in=6 | both_in=2 | evaluated |

Across all 4 runs of the script, every corpus rendered BOTH_in > 0 in ≥1 draw (max per corpus: A=8, B=14, C=15). Arbitrated zeros (translator ran, found nothing) appear and are recorded with their cause — a legitimate result, not a failure.

### 2. ≥1 semantics excluding ≥1 argument — MEASURED, TRUE (final run)

Reading `all_extensions` per semantics (the site's `result["extensions"]` is the primary semantics' enriched payload — the first summarizer version iterated it and produced garbage keys; fixed):

- corpus_A draw1: 8 semantics (preferred, grounded, stable, complete, admissible, semi_stable, stage, ideal) each exclude 3 of 10 arguments.
- corpus_B draw2: the same 8 semantics each exclude 2 of 11.
- corpus_C draw2: grounded + ideal exclude 2 of 10 — a genuine semantic discrimination: preferred's credulous extensions collectively accept everything (union covers all), the skeptical grounded/ideal reject the attacked pair.

Two draws hit the 180s Tweety timeout (honest-absent, `_DUNG_TIMEOUT_S` #992 — 128/512-extension admissible enumerations) and are recorded degraded, not counted.

### Dissociative control — HONEST RESULT

corpus_B@offset 0 is a table of contents (fingerprint: 49 year-tokens, ~50 pseudo-sentences). Across the 4 runs the TOC window rendered raw ∈ {0, 1, 4} — the control does NOT cleanly dissociate. This is consistent with the known high-variance, rare-event nature of attack proposals (R807: any non-zero cell in an attack channel is a draw). Reported as measured; the prose-window non-zeros rest on 4-run replication, not on the control.

### 3. No fallback to `_generate_attacks_from_args` after an arbitration — TESTED (red-before-fix)

`test_arbitrated_empty_yields_empty_graph_and_cause` × 4 axes: arbitrator answers "none" → submitted graph `[]` + cause `no_genuine_relations` written. RED before (no cause key ever written; synthetic producer ran), GREEN after.

`test_no_synthetic_source_survives_an_arbitration` × 4 axes: fallacies in context + arbitration "none" → NO `fallacy_*` edge submitted. RED before (synthetic producer minted them), GREEN after.

### 4. Red-before-fix, assertion reached — EXECUTED + TRIAGE

Pre-fix tree via stash (same final test file): **12 red / 4 green**. All 12 reds are assertion-reached (verified in output: each fails on the test's own `assert`, not a mock/infra error):
- 4 × `test_translator_edges_reach_the_handler`: `assert [arg1_text, arg2_text] in []` — handler received the synthetic producer's (empty) graph.
- 4 × `test_arbitrated_empty_yields_empty_graph_and_cause`: `assert None == 'no_genuine_relations'` — no cause key.
- 4 × `test_no_synthetic_source_survives_an_arbitration`: `assert not [['fallacy_0_hasty', …]]` — synthetic edges minted.

Post-fix: **16/16 green**.

**Non-regression reds triaged** (tests I did not author):

Full sweep `tests/unit/argumentation_analysis/orchestration/` = **3009 passed / 4 failed**; plus 5 targeted files outside the dir = 149 passed / 13 failed. Every red triaged:

- 13 reds in `test_tweety_fallbacks.py` + `test_capability_duality_invariant.py`: **pre-existing on main** (verified by stash: identical 13 red on the clean tree — ranking/ADF fallback contracts + duality docs, unrelated to this diff).
- 2 reds in `test_camembert_invoke.py`: **pre-existing on main** (verified by stash — self-hosted detector endpoint tests, untouched by this diff).
- 1 red `test_fact_extraction_opposing_poles_1745` (requires_api): stochastic behavioral guard documented in #1745/R810 (gpt-5-mini mint-rate on synthetic prose); `_invoke_fact_extraction` untouched by this diff.
- 1 red caused by this change: `test_dung_aspic_wiring.py::test_generates_attacks_from_fallacies` — asserted the OLD contract (fallacies → `fallacy_*` edges always submitted), which #1698 replaces by design. Updated to exercise the preserved synthetic arm (translator raises → `translator_failed` → synthetic stands); 33/33 green on the file.

### 5. Counter-control green before AND after — EXECUTED

- `test_caller_provided_attacks_pass_through` × 3 axes (green before on the 3 sites that already read `context["attacks"]`; still green after — the wiring only fires when the context brings nothing).
- `test_honest_absent_door_untouched` (JVM down → degraded honest-absent dict on the Dung axis) — green before and after.

## Anti-pendules honored (dispatch)

- NO `fallacy_*` added to `arguments` (unattacked node wins everywhere = symmetrical false-green) — the anti-theater note is in `_validate_dung_attacks`' docstring.
- BOTH_in>0 not read as victory: the rejection criterion (DoD 2) is measured separately; absence of rejection on one corpus would be reported as a legitimate result.
- The translator is NOT a 3rd branch of `_generate_attacks_from_args` — separate helper, never mixed in one list (test 3 forbids the mix).
- State-writers gate `_STRUCTURED_ARG_INPUT_KEYS` NOT extended (would change evaluated/absent labels for 5 legacy axes — out of scope, cause stays at context level like the pre-#1698 setaf contract).

## Privacy

All artifacts under gitignored `evaluation/results/real_analysis/`. Opaque IDs only in this PR (corpus_A/B/C, arg indices). No prose excerpts.

## Files removed and why

None.
