### PR TITLE
fix(plugins): functools.wraps on _jvm_required — 20 published schemas become invocable (#1768)

### DIFF
--- a/argumentation_analysis/plugins/tweety_logic_plugin.py
+++ b/argumentation_analysis/plugins/tweety_logic_plugin.py
@@ -13,6 +13,7 @@ Gracefully handles JVM unavailability (returns error message instead of crashing
 """
 
 import asyncio
+import functools
 import json
 import logging
 from typing import Optional
@@ -61,6 +62,7 @@ def _check_jvm() -> bool:
 def _jvm_required(func):
     """Decorator that checks JVM availability before calling handler."""
 
+    @functools.wraps(func)
     def wrapper(self, *args, **kwargs):
         if not _check_jvm():
             return json.dumps(
@@ -71,8 +73,6 @@ def _jvm_required(func):
             )
         return func(self, *args, **kwargs)
 
-    wrapper.__name__ = func.__name__
-    wrapper.__doc__ = func.__doc__
     return wrapper
 
 

--- a/tests/unit/argumentation_analysis/plugins/test_conv_b_kernel_deciders.py
+++ b/tests/unit/argumentation_analysis/plugins/test_conv_b_kernel_deciders.py
@@ -31,7 +31,7 @@ agent's invocation/scheduling rather than to a dead cable.
 """
 
 import json
-from typing import Any, Dict
+from typing import Any, Dict, List, Tuple
 
 import pytest
 
@@ -162,3 +162,75 @@ class TestConvBKernelDeciders:
         ), "Dung decider unreachable (JVM short-circuit)"
         # The repaired contract returns {semantics, extensions, statistics}.
         assert "extensions" in result, f"Dung decider produced no extensions: {result}"
+
+
+class TestJvmRequiredSchemaIntegrity:
+    """#1768 — ``functools.wraps`` on ``@_jvm_required``: published schemas.
+
+    #1732 (PR #1767) measured that the 20 ``@_jvm_required`` kernel_functions
+    advertised an in-invocable schema: SK introspects
+    ``wrapper(self, *args, **kwargs)`` and publishes ``[args, kwargs] (required)``
+    instead of the real ``input: str``. The manual ``__name__``/``__doc__`` copies
+    made the plugin look intact in every inventory — that is precisely how the
+    defect survived review — so the controls below assert on the INTROSPECTED
+    PUBLISHED SIGNATURE, never on ``__name__``.
+
+    Red-before-fix by degenerate substitution: remove ``functools.wraps`` from
+    ``_jvm_required`` and these tests fail (the 20 decorated functions re-publish
+    args/kwargs; ``solve_sat``, the only undecorated one, stays intact as the
+    natural control group).
+
+    JVM-free by construction: only SK metadata is introspected, no handler runs.
+    """
+
+    @pytest.fixture(scope="class")
+    def kernel_plugin(self) -> "Any":
+        from semantic_kernel.functions import KernelPlugin
+
+        return KernelPlugin.from_object(
+            plugin_name="tweety_logic", plugin_instance=TweetyLogicPlugin()
+        )
+
+    @staticmethod
+    def _published_params(kernel_plugin: "Any") -> "Dict[str, List[Tuple[str, bool]]]":
+        return {
+            name: [(p.name, p.is_required) for p in fn.parameters]
+            for name, fn in kernel_plugin.functions.items()
+        }
+
+    def test_no_kernel_function_publishes_args_kwargs(
+        self, kernel_plugin: "Any"
+    ) -> None:
+        schemas = self._published_params(kernel_plugin)
+        trapped = {
+            name: params
+            for name, params in schemas.items()
+            if any(p[0] in ("args", "kwargs") for p in params)
+        }
+        assert not trapped, (
+            f"{len(trapped)} kernel_function(s) publish the *args/**kwargs "
+            f"wrapper signature instead of their real one (#1768 regression — "
+            f"functools.wraps missing or bypassed on _jvm_required): "
+            f"{sorted(trapped)}"
+        )
+
+    def test_every_kernel_function_publishes_input(self, kernel_plugin: "Any") -> None:
+        schemas = self._published_params(kernel_plugin)
+        bad = {n: p for n, p in schemas.items() if p != [("input", True)]}
+        assert not bad, (
+            "every kernel_function must publish its real required `input` "
+            f"parameter (expected [('input', True)]), got deviations: {bad}"
+        )
+
+    def test_solve_sat_control_signature_intact(self, kernel_plugin: "Any") -> None:
+        """``solve_sat`` is the only function WITHOUT ``@_jvm_required`` — the
+        témoin from #1732. It was intact before the fix and must remain so."""
+        schemas = self._published_params(kernel_plugin)
+        assert schemas.get("solve_sat") == [("input", True)]
+
+    def test_decorated_wrapper_exposes_wrapped(self) -> None:
+        """``functools.wraps`` sets ``__wrapped__`` so introspection (SK,
+        inspect.signature) reaches the real function through the wrapper."""
+        assert hasattr(
+            TweetyLogicPlugin.analyze_aspic, "__wrapped__"
+        ), "_jvm_required wrapper must expose __wrapped__ (functools.wraps)"


### PR DESCRIPTION
Fixes #1768. Dispatched R816 (msg-glgwvq); lane started autonomously in the same round — the RED proof (20/1 at metadata level) was established before the dispatch arrived.

## The fix (subtraction, not counterweight)

`_jvm_required` (`argumentation_analysis/plugins/tweety_logic_plugin.py`) copied `__name__`/`__doc__` by hand, without `functools.wraps` nor `__wrapped__`. The copies made the wrapper look intact in every inventory — that is precisely how the defect survived review. The fix removes the manual copies and puts `@functools.wraps(func)`: the wrapper stops masking the function.

No hand-rewritten schema, no added type annotations on the wrapper — a rewritten schema would go stale at the next handler.

## DoD

### 1. `functools.wraps` on `_jvm_required` — done
`__wrapped__` is available for introspection (asserted by the canary).

### 2. Canary, red-before-fix by degenerate substitution — done
`tests/unit/argumentation_analysis/plugins/test_conv_b_kernel_deciders.py::TestJvmRequiredSchemaIntegrity` (JVM-free by construction — only SK metadata is introspected):

- `test_no_kernel_function_publishes_args_kwargs` — sweeps every kernel_function; no published schema may carry `args`/`kwargs`
- `test_every_kernel_function_publishes_input` — every schema must be exactly `[("input", True)]`
- `test_solve_sat_control_signature_intact` — the témoin from #1732
- `test_decorated_wrapper_exposes_wrapped` — `__wrapped__` present

All assertions are on the **introspected published signature** (`KernelPlugin.from_object` → `fn.parameters`), never on `__name__` — it is `__name__` that masked the defect.

**Red proof**: with `@functools.wraps` temporarily removed (degenerate substitution), the class runs `3 failed, 1 passed` — the only pass being `solve_sat`, which never had the decorator. With the fix: `4 passed`. Full file (4 JVM deciders + 4 canaries): `8 passed`.

### 3. 20 / 1 → 0 / 21 by the same probe — done

```
BROKEN schema (*args/**kwargs leaked): 0
INTACT signatures: 21 — all [('input', True)]:
  analyze_aba, analyze_adf, analyze_aspic, analyze_bipolar_framework,
  analyze_delp, analyze_dung_framework, analyze_epistemic_framework,
  analyze_probabilistic, analyze_setaf, analyze_social_framework,
  analyze_weighted_framework, check_dl_consistency, check_fol_consistency,
  check_modal_satisfiability, check_propositional_consistency, check_qbf,
  execute_dialogue, query_conditional_logic, rank_arguments, revise_beliefs,
  solve_sat
```

### 4. `solve_sat` intact — done
Undecorated, unchanged, `[('input', True)]` before and after (explicit test).

### 5. Reachability re-measured on corpus_A, 3 states — the result did NOT move

Instrument of #1732 (2 taps: advertisement via `AsyncCompletions.create`, invocation via `Kernel.invoke_function_call`), corpus_A, budget 1800 s, **n=1**, ran to completion in 267 s, **on po-2023 with the JVM up** (`jvm_setup.initialize_jvm` → "JVM démarrée avec succès", JDK 17). A call, had one been emitted, would have executed for real.

| function | state | advertised | PM advertised | emitted | invoked | executed |
|---|---|---|---|---|---|---|
| `analyze_setaf` | **1 — advertised-mais-0-hit** | 90/109 req | 87/88 | 0 | 0 | 0 |
| `analyze_weighted_framework` | **1 — advertised-mais-0-hit** | 90/109 req | 87/88 | 0 | 0 | 0 |
| `analyze_bipolar_framework` | **1 — advertised-mais-0-hit** | 90/109 req | 87/88 | 0 | 0 | 0 |
| `analyze_aspic` | **1 — advertised-mais-0-hit** | 90/109 req | 87/88 | 0 | 0 | 0 |

**All 4 remain in state 1.** Invocability is repaired (0/21) — the marshalling can now succeed — but the PM emitted none of them in this run: the constraint has moved one layer up, **from marshalling to emission**. Distinction per the dispatch: nothing became "invocable-but-erroring" here — on this machine, with the JVM up, a hypothetical call would have been a real formal computation; there simply was no call.

Caveats, honestly: n=1 on both sides (baseline #1732: 97/126 req, 94/95 PM, 0/0/0 — same shape); variance dominates at n=1, and #1732 showed the PM *can* emit toward trapped functions (`analyze_aba`: 55 attempts) — so 0-emitted is a property of this run, not proof of structural never-emit. What IS structural: the 55-attempt class of failure (schema-shaped TypeError) is now impossible, canary-guarded.

Consequence for #1644 step D: the nudge lane is now **unblocked** — steering the PM toward these tools can no longer die in the marshalling.

## Gates

- mypy `--strict` on both files: 42 errors before / 42 after (baseline unchanged, 0 new; pre-existing errors untouched)
- black: clean
- tests: file `8 passed`; canary red/green proven above

## Files changed

| File | Change |
|---|---|
| `argumentation_analysis/plugins/tweety_logic_plugin.py` | `functools` import + `@functools.wraps(func)` replacing 2 manual copy lines |
| `tests/unit/argumentation_analysis/plugins/test_conv_b_kernel_deciders.py` | +`TestJvmRequiredSchemaIntegrity` (4 tests) |

No deletions — Cleanup Gate N/A. Artifacts (JSON measurement) under gitignored `evaluation/results/1768_reachability/`.

— Claude Code @ myia-po-2023:2025-Epita-Intelligence-Symbolique
