### PR TITLE
fix(logic): the formal channel can no longer render a verdict without computing (#1773)

### DIFF
--- a/argumentation_analysis/agents/core/logic/first_order_logic_agent_adapter.py
+++ b/argumentation_analysis/agents/core/logic/first_order_logic_agent_adapter.py
@@ -70,17 +70,23 @@ class FOLLogicAgent:
             self._sk_agent = None
 
         # Initialiser TweetyBridge (réel ou dégradé)
-        self._tweety_bridge = None
+        self._tweety_bridge: Optional[Any] = None
         self._init_tweety_bridge()
 
     def _init_tweety_bridge(self):
         """Initialise TweetyBridge (réel si possible, sinon mode dégradé)."""
         try:
-            # Essayer d'importer et initialiser le vrai TweetyBridge
-            from ....bridges.tweety_bridge import TweetyBridge
+            # CONV-B #1333 / #1773: l'ancien import pointait vers
+            # ``argumentation_analysis.bridges.tweety_bridge`` (module
+            # inexistant) — ImportError permanent, donc mode dégradé à
+            # TOUTES les exécutions, sans que la JVM soit jamais consultée.
+            # Le vrai module vit dans agents/core/logic/.
+            from argumentation_analysis.agents.core.logic.tweety_bridge import (
+                TweetyBridge,
+            )
 
             self._tweety_bridge = TweetyBridge()
-            if not self._tweety_bridge.is_jvm_ready():
+            if not self._tweety_bridge.initializer.is_jvm_ready():
                 self.logger.warning("JVM TweetyBridge non prête, mode dégradé activé")
                 self._tweety_bridge = None
         except Exception as e:

--- a/argumentation_analysis/agents/core/logic/query_executor.py
+++ b/argumentation_analysis/agents/core/logic/query_executor.py
@@ -53,7 +53,10 @@ class QueryExecutor:
         )
 
         # Vérifier si la JVM est prête
-        if not self._tweety_bridge.is_jvm_ready():
+        # CONV-B #1333 / #1773: ``is_jvm_ready()`` vit sur TweetyInitializer,
+        # pas sur TweetyBridge — l'ancienne forme levait AttributeError sur
+        # TOUTE exécution de execute_query.
+        if not self._tweety_bridge.initializer.is_jvm_ready():
             error_msg = "JVM non prête ou composants Tweety non chargés"
             self._logger.error(error_msg)
             return None, f"FUNC_ERROR: {error_msg}"
@@ -114,15 +117,13 @@ class QueryExecutor:
         """
         try:
             # Valider la requête
-            (
-                is_valid,
-                validation_msg,
-            ) = self._tweety_bridge.pl_handler.validate_pl_formula(query)
+            # #1773 constat 3 (frère): ``validate_pl_formula`` vit sur
+            # TweetyBridge (retour booléen simple) — PLHandler ne l'expose
+            # pas. L'ancien appel dépaquetait ce bool comme un tuple.
+            is_valid = self._tweety_bridge.validate_pl_formula(query)
             if not is_valid:
-                self._logger.error(
-                    f"Requête propositionnelle invalide: {validation_msg}"
-                )
-                return None, f"FUNC_ERROR: Requête invalide: {validation_msg}"
+                self._logger.error(f"Requête propositionnelle invalide: {query}")
+                return None, f"FUNC_ERROR: Requête invalide: {query}"
 
             # Exécuter la requête
             result = self._tweety_bridge.pl_handler.pl_query(belief_set.content, query)

--- a/argumentation_analysis/agents/core/logic/tweety_bridge.py
+++ b/argumentation_analysis/agents/core/logic/tweety_bridge.py
@@ -475,9 +475,13 @@ class TweetyBridge:
     def validate_pl_formula(self, formula: str) -> bool:
         """Valide la syntaxe d'une formule de logique propositionnelle en tentant de la parser."""
         try:
-            # La validation se fait en tentant un parsing. Si ça ne lève pas d'erreur, c'est valide.
-            self.pl_handler.parse_pl_formula(formula)
-            return True
+            # #1773 constat 3 : ``parse_pl_formula`` signale l'échec de deux
+            # façons — ``raise ValueError`` (parse Java levé) et ``return None``
+            # (rejet sanitizer / entrée non exploitable). Ne tester que
+            # l'exception transformait tout ``None`` en verdict ``True`` :
+            # le validateur était toujours-vrai sur la moitié des chemins.
+            parsed = self.pl_handler.parse_pl_formula(formula)
+            return parsed is not None
         except ValueError:
             return False
 

--- a/argumentation_analysis/plugins/kb_to_tweety_plugin.py
+++ b/argumentation_analysis/plugins/kb_to_tweety_plugin.py
@@ -15,6 +15,8 @@ from typing import Dict, List, Optional, Tuple
 from pydantic import BaseModel, Field
 from semantic_kernel.functions import kernel_function
 
+from argumentation_analysis.plugins.kernel_input import parse_kernel_json_object
+
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -128,16 +130,28 @@ def _build_modal_formula(belief_text: str) -> str:
 def _jvm_available() -> bool:
     try:
         from argumentation_analysis.agents.core.logic.tweety_bridge import TweetyBridge
-        return TweetyBridge.get_instance().is_jvm_ready()
-    except Exception:
+    except ImportError:
+        return False
+    # CONV-B #1333 / #1773: ``is_jvm_ready()`` lives on TweetyInitializer
+    # (``bridge.initializer``), NOT on TweetyBridge. The previous bare
+    # ``except Exception`` swallowed the AttributeError, so this probe ALWAYS
+    # returned False and the branches below fabricated ``True`` verdicts
+    # ("skipped validation"). Only genuine unavailability (module absent,
+    # JVM init failed) may return False — a broken probe must raise.
+    try:
+        return TweetyBridge.get_instance().initializer.is_jvm_ready()
+    except RuntimeError:
         return False
 
 
 def _validate_pl(formula: str) -> Tuple[bool, str]:
     if not _jvm_available():
-        return True, "JVM unavailable — skipped validation"
+        # #1773 constat 2: pas de validation => pas de verdict. Rendre True
+        # ici fabriquait un is_valid:true sans aucun calcul.
+        return False, "JVM unavailable — validation not performed"
     try:
         from argumentation_analysis.agents.core.logic.tweety_bridge import TweetyBridge
+
         bridge = TweetyBridge.get_instance()
         valid = bridge.validate_pl_formula(formula)
         return valid, "Valid" if valid else "Invalid PL syntax"
@@ -147,9 +161,10 @@ def _validate_pl(formula: str) -> Tuple[bool, str]:
 
 def _validate_fol(formula: str, belief_set: str = "") -> Tuple[bool, str]:
     if not _jvm_available():
-        return True, "JVM unavailable — skipped validation"
+        return False, "JVM unavailable — validation not performed"
     try:
         from argumentation_analysis.agents.core.logic.tweety_bridge import TweetyBridge
+
         bridge = TweetyBridge.get_instance()
         is_valid, msg = bridge.check_consistency(
             belief_set or formula, logic_type="fol"
@@ -161,9 +176,10 @@ def _validate_fol(formula: str, belief_set: str = "") -> Tuple[bool, str]:
 
 def _validate_modal(formula: str, belief_set: str = "") -> Tuple[bool, str]:
     if not _jvm_available():
-        return True, "JVM unavailable — skipped validation"
+        return False, "JVM unavailable — validation not performed"
     try:
         from argumentation_analysis.agents.core.logic.tweety_bridge import TweetyBridge
+
         bridge = TweetyBridge.get_instance()
         is_valid, msg = bridge.check_consistency(
             belief_set or formula, logic_type="modal_k"
@@ -229,7 +245,10 @@ async def _translate_with_retry(
 
         logger.debug(
             "Attempt %d/%d failed for '%s': %s",
-            attempt, max_retries, belief_text[:50], msg,
+            attempt,
+            max_retries,
+            belief_text[:50],
+            msg,
         )
 
     # All retries exhausted — return last attempt
@@ -271,10 +290,13 @@ class KBToTweetyPlugin:
     )
     async def translate_to_tweety(self, input: str) -> str:
         """Translate a KB entry to Tweety formula with retry."""
-        try:
-            params = json.loads(input) if isinstance(input, str) else input
-        except (json.JSONDecodeError, TypeError):
-            return json.dumps({"error": "Invalid JSON input"})
+        params, err = parse_kernel_json_object(
+            input,
+            expected_keys=["text", "logic_type", "signature"],
+            required_keys=["text"],
+        )
+        if params is None:
+            return json.dumps(err)
 
         text = params.get("text", "")
         logic_type = params.get("logic_type", "pl").lower()
@@ -298,10 +320,13 @@ class KBToTweetyPlugin:
     )
     async def translate_batch_to_tweety(self, input: str) -> str:
         """Translate a batch of KB entries to Tweety formulas."""
-        try:
-            params = json.loads(input) if isinstance(input, str) else input
-        except (json.JSONDecodeError, TypeError):
-            return json.dumps({"error": "Invalid JSON input"})
+        params, err = parse_kernel_json_object(
+            input,
+            expected_keys=["beliefs", "logic_type", "signature"],
+            required_keys=["beliefs"],
+        )
+        if params is None:
+            return json.dumps(err)
 
         beliefs = params.get("beliefs", [])
         logic_type = params.get("logic_type", "pl").lower()
@@ -311,6 +336,7 @@ class KBToTweetyPlugin:
             return json.dumps({"error": "No beliefs provided", "translations": []})
 
         import asyncio
+
         tasks = [
             _translate_with_retry(b, logic_type, max_retries=3, signature=signature)
             for b in beliefs
@@ -325,12 +351,14 @@ class KBToTweetyPlugin:
                 translations.append(r.model_dump())
 
         valid_count = sum(1 for t in translations if t.get("is_valid"))
-        return json.dumps({
-            "translations": translations,
-            "total": len(translations),
-            "valid": valid_count,
-            "pass_rate": valid_count / len(translations) if translations else 0.0,
-        })
+        return json.dumps(
+            {
+                "translations": translations,
+                "total": len(translations),
+                "valid": valid_count,
+                "pass_rate": valid_count / len(translations) if translations else 0.0,
+            }
+        )
 
     @kernel_function(
         name="translate_dung",
@@ -342,10 +370,11 @@ class KBToTweetyPlugin:
     )
     async def translate_dung(self, input: str) -> str:
         """Build a Dung AF from KB arguments and attacks."""
-        try:
-            params = json.loads(input) if isinstance(input, str) else input
-        except (json.JSONDecodeError, TypeError):
-            return json.dumps({"error": "Invalid JSON input"})
+        params, err = parse_kernel_json_object(
+            input, expected_keys=["arguments", "attacks"]
+        )
+        if params is None:
+            return json.dumps(err)
 
         arguments = params.get("arguments", [])
         attacks = params.get("attacks", [])
@@ -353,9 +382,12 @@ class KBToTweetyPlugin:
         # Validate attacks reference existing arguments
         arg_set = set(arguments)
         valid_attacks = [
-            a for a in attacks
-            if isinstance(a, (list, tuple)) and len(a) >= 2
-            and a[0] in arg_set and a[1] in arg_set
+            a
+            for a in attacks
+            if isinstance(a, (list, tuple))
+            and len(a) >= 2
+            and a[0] in arg_set
+            and a[1] in arg_set
         ]
 
         result = DungTranslationResult(
@@ -377,10 +409,16 @@ class KBToTweetyPlugin:
     )
     async def translate_aspic(self, input: str) -> str:
         """Build an ASPIC+ argumentation system from KB."""
-        try:
-            params = json.loads(input) if isinstance(input, str) else input
-        except (json.JSONDecodeError, TypeError):
-            return json.dumps({"error": "Invalid JSON input"})
+        params, err = parse_kernel_json_object(
+            input,
+            expected_keys=[
+                "strict_rules",
+                "defeasible_rules",
+                "ordinary_premises",
+            ],
+        )
+        if params is None:
+            return json.dumps(err)
 
         strict_rules = params.get("strict_rules", [])
         defeasible_rules = params.get("defeasible_rules", [])
@@ -408,10 +446,11 @@ class KBToTweetyPlugin:
         if state is None:
             return json.dumps({"error": "No state provided"})
 
-        try:
-            params = json.loads(input) if isinstance(input, str) else input
-        except (json.JSONDecodeError, TypeError):
-            return json.dumps({"error": "Invalid JSON input"})
+        params, err = parse_kernel_json_object(
+            input, expected_keys=["formulas"], required_keys=["formulas"]
+        )
+        if params is None:
+            return json.dumps(err)
 
         formulas = params.get("formulas", [])
         belief_ids = []
@@ -420,11 +459,17 @@ class KBToTweetyPlugin:
         if callable(add_bs):
             for f in formulas:
                 formula = f.get("formula", "") if isinstance(f, dict) else str(f)
-                logic_type = f.get("logic_type", "propositional") if isinstance(f, dict) else "propositional"
+                logic_type = (
+                    f.get("logic_type", "propositional")
+                    if isinstance(f, dict)
+                    else "propositional"
+                )
                 if formula:
                     belief_ids.append(add_bs(logic_type, formula))
 
-        return json.dumps({
-            "formulas_written": len(belief_ids),
-            "belief_ids": belief_ids,
-        })
+        return json.dumps(
+            {
+                "formulas_written": len(belief_ids),
+                "belief_ids": belief_ids,
+            }
+        )

--- a/argumentation_analysis/plugins/kernel_input.py
+++ b/argumentation_analysis/plugins/kernel_input.py
@@ -1,0 +1,42 @@
+"""Shared JSON-object input parsing for ``@kernel_function`` entry points.
+
+#1773 constat 4 (amendement R819): this is a REUSABLE convention — TweetyLogicPlugin's
+21 functions (#1774) must adopt the same error shape, not a local variant. Rules:
+
+- anything that is not a JSON object renders a structured error, never raises;
+- a missing required key names the keys received AND the keys expected, so a
+  caller that sent the wrong shape can converge by retry.
+"""
+
+import json
+from typing import Any, Dict, Optional, Sequence, Tuple
+
+
+def parse_kernel_json_object(
+    raw: Any,
+    expected_keys: Sequence[str],
+    required_keys: Sequence[str] = (),
+) -> Tuple[Optional[Dict[str, Any]], Optional[Dict[str, Any]]]:
+    """Parse a ``@kernel_function`` JSON input into an object.
+
+    Returns ``(params, None)`` when ``raw`` is a usable JSON object, otherwise
+    ``(None, error_dict)`` where ``error_dict`` is ready to ``json.dumps``.
+    """
+    if isinstance(raw, str):
+        try:
+            raw = json.loads(raw)
+        except json.JSONDecodeError:
+            return None, {"error": "Invalid JSON input"}
+    if not isinstance(raw, dict):
+        return None, {
+            "error": "Invalid input: expected a JSON object",
+            "received_type": type(raw).__name__,
+        }
+    missing = [key for key in required_keys if key not in raw]
+    if missing:
+        return None, {
+            "error": "Missing required key(s): " + ", ".join(missing),
+            "received_keys": sorted(raw.keys()),
+            "expected_keys": list(expected_keys),
+        }
+    return raw, None

--- a/tests/agents/core/logic/test_1773_verdict_reading.py
+++ b/tests/agents/core/logic/test_1773_verdict_reading.py
@@ -1,0 +1,151 @@
+"""#1773 constat 3 — le validateur PL doit lire la valeur de retour.
+
+``PLHandler.parse_pl_formula`` signale l'échec de deux façons : ``raise
+ValueError`` (parse Java levé) et ``return None`` (rejet sanitizer / entrée
+non exploitable). ``TweetyBridge.validate_pl_formula`` ne testait que
+l'exception — tout ``None`` devenait un verdict ``True`` : le validateur
+était toujours-vrai sur la moitié des chemins d'échec.
+
+Le contrôle visé par le dispatch : ``validate_pl_formula('))garbage((')``
+doit rendre ``False``. Rouge sur main d'aujourd'hui.
+
+Inclut les deux frères découverts au sweep constat 1 :
+- ``query_executor`` sondait ``bridge.is_jvm_ready()`` (inexistant) et
+  dépaquetait un bool comme tuple (validateur fantôme sur le handler) ;
+- ``first_order_logic_agent_adapter`` importait ``bridges.tweety_bridge``
+  (module inexistant) → ImportError permanent → mode dégradé à toutes les
+  exécutions, sans que la JVM soit jamais consultée.
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from argumentation_analysis.agents.core.logic.tweety_bridge import TweetyBridge
+from argumentation_analysis.agents.core.logic.query_executor import QueryExecutor
+from argumentation_analysis.agents.core.logic.belief_set import PropositionalBeliefSet
+from argumentation_analysis.agents.core.logic.first_order_logic_agent_adapter import (
+    FOLLogicAgent as FOLLogicAgentAdapter,
+)
+
+
+class TestValidatePlFormulaReadsReturnValue:
+    """Le verdict doit refléter le retour du handler, pas seulement l'absence d'exception."""
+
+    def setup_method(self):
+        self._patchers = [
+            patch(
+                "argumentation_analysis.agents.core.logic.tweety_bridge.TweetyInitializer"
+            ),
+            patch(
+                "argumentation_analysis.agents.core.logic.tweety_bridge."
+                "PropositionalLogicHandler"
+            ),
+        ]
+        self.mock_initializer_class = self._patchers[0].start()
+        self.mock_pl_handler_class = self._patchers[1].start()
+        self.mock_initializer_class.return_value.is_jvm_ready.return_value = True
+        self.mock_pl_handler = self.mock_pl_handler_class.return_value
+        TweetyBridge._instance = None
+        self.bridge = TweetyBridge.get_instance()
+
+    def teardown_method(self):
+        for p in self._patchers:
+            p.stop()
+        TweetyBridge._instance = None
+
+    def test_none_return_is_not_valid(self):
+        """Chemin None (rejet sanitizer) => verdict négatif. Rouge sur main."""
+        self.mock_pl_handler.parse_pl_formula.return_value = None
+        assert self.bridge.validate_pl_formula("))garbage((") is False
+
+    def test_parsed_return_is_valid(self):
+        self.mock_pl_handler.parse_pl_formula.return_value = MagicMock()
+        assert self.bridge.validate_pl_formula("a => b") is True
+
+    def test_value_error_is_not_valid(self):
+        self.mock_pl_handler.parse_pl_formula.side_effect = ValueError("syntax")
+        assert self.bridge.validate_pl_formula("a ==> b") is False
+
+
+# ---------------------------------------------------------------------------
+# Contrôle réel (JVM up) — le test que le dispatch veut voir échouer sur main
+# ---------------------------------------------------------------------------
+
+
+class TestValidatePlFormulaRealJvm:
+    pytestmark = pytest.mark.tweety
+
+    def test_garbage_formula_is_invalid(self, tweety_bridge_fixture):
+        """'))garbage((' passe par le rejet sanitizer (return None) : doit etre False."""
+        bridge = TweetyBridge.get_instance()
+        assert bridge.validate_pl_formula("))garbage((") is False
+
+    def test_wellformed_formula_is_valid(self, tweety_bridge_fixture):
+        bridge = TweetyBridge.get_instance()
+        assert bridge.validate_pl_formula("a => b") is True
+
+
+# ---------------------------------------------------------------------------
+# Frère 1 — query_executor : sonde fantôme + validateur fantôme
+# ---------------------------------------------------------------------------
+
+
+class TestQueryExecutorRealContract:
+    def _executor_with_mock_bridge(self):
+        executor = QueryExecutor.__new__(QueryExecutor)
+        executor._logger = MagicMock()
+        executor._tweety_bridge = MagicMock()
+        executor._tweety_bridge.initializer.is_jvm_ready.return_value = True
+        return executor
+
+    def test_jvm_probe_goes_through_initializer(self):
+        """La sonde doit consulter initializer.is_jvm_ready (pas bridge.is_jvm_ready)."""
+        executor = self._executor_with_mock_bridge()
+        executor._tweety_bridge.initializer.is_jvm_ready.return_value = False
+        result, message = executor.execute_query(PropositionalBeliefSet("a => b"), "a")
+        executor._tweety_bridge.initializer.is_jvm_ready.assert_called_once()
+        assert result is None
+        assert "FUNC_ERROR" in message
+
+    def test_pl_validation_uses_bridge_validator_bool(self):
+        """Le validateur vit sur le bridge (bool) — pas de tuple a dépaqueter."""
+        executor = self._executor_with_mock_bridge()
+        executor._tweety_bridge.validate_pl_formula.return_value = False
+        result, message = executor.execute_query(PropositionalBeliefSet("a => b"), "a")
+        executor._tweety_bridge.validate_pl_formula.assert_called_once_with("a")
+        assert result is None
+        assert "Requête invalide" in message
+
+
+# ---------------------------------------------------------------------------
+# Frère 2 — adaptateur FOL : l'ImportError permanent fabriquait le mode dégradé
+# ---------------------------------------------------------------------------
+
+
+class TestFolAdapterBridgeInit:
+    def test_bridge_survives_when_module_path_is_real(self):
+        """Avec le vrai module patché et une JVM prete, le bridge doit etre pose.
+
+        Sur main, l'import pointait vers ``bridges.tweety_bridge`` (module
+        inexistant) : ImportError capture => _tweety_bridge reste None a
+        TOUTES les exécutions, même JVM prete.
+        """
+        with patch(
+            "argumentation_analysis.agents.core.logic.tweety_bridge.TweetyBridge"
+        ) as mock_bridge_class:
+            mock_bridge_class.return_value.initializer.is_jvm_ready.return_value = True
+            adapter = FOLLogicAgentAdapter(agent_name="test_adapter")
+            assert adapter._tweety_bridge is mock_bridge_class.return_value, (
+                "le bridge n'a pas été posé alors que la JVM est prête "
+                "(import fantôme ou sonde fantôme)"
+            )
+
+    def test_degraded_still_honest_when_jvm_not_ready(self):
+        with patch(
+            "argumentation_analysis.agents.core.logic.tweety_bridge.TweetyBridge"
+        ) as mock_bridge_class:
+            mock_bridge_class.return_value.initializer.is_jvm_ready.return_value = False
+            adapter = FOLLogicAgentAdapter(agent_name="test_adapter")
+            assert adapter._tweety_bridge is None

--- a/tests/agents/core/logic/test_query_executor.py
+++ b/tests/agents/core/logic/test_query_executor.py
@@ -69,7 +69,8 @@ class TestQueryExecutor:
 
                 # Configurer les mocks
                 self.mock_tweety_bridge = self.query_executor._tweety_bridge
-                self.mock_tweety_bridge.is_jvm_ready.return_value = True
+                # #1773: la sonde JVM vit sur bridge.initializer (#1333)
+                self.mock_tweety_bridge.initializer.is_jvm_ready.return_value = True
 
                 # On mock les handlers directement sur l'instance du bridge
                 self.mock_tweety_bridge.pl_handler = MagicMock()
@@ -89,12 +90,12 @@ class TestQueryExecutor:
     @pytest.mark.asyncio
     async def test_execute_query_jvm_not_ready(self):
         """Test de l'exécution d'une requête lorsque la JVM n'est pas prête."""
-        self.mock_tweety_bridge.is_jvm_ready.return_value = False
+        self.mock_tweety_bridge.initializer.is_jvm_ready.return_value = False
 
         belief_set = PropositionalBeliefSet("a => b")
         result, message = self.query_executor.execute_query(belief_set, "a")
 
-        self.mock_tweety_bridge.is_jvm_ready.assert_called_once()
+        self.mock_tweety_bridge.initializer.is_jvm_ready.assert_called_once()
 
         assert result is None
         assert "FUNC_ERROR" in message
@@ -102,18 +103,14 @@ class TestQueryExecutor:
     @pytest.mark.asyncio
     async def test_execute_query_propositional_accepted(self):
         """Test de l'exécution d'une requête propositionnelle acceptée."""
-        self.mock_tweety_bridge.pl_handler.validate_pl_formula.return_value = (
-            True,
-            "OK",
-        )
+        # #1773: le validateur vit sur TweetyBridge (retour booléen simple)
+        self.mock_tweety_bridge.validate_pl_formula.return_value = True
         self.mock_tweety_bridge.pl_handler.pl_query.return_value = True
 
         belief_set = PropositionalBeliefSet("a => b")
         result, message = self.query_executor.execute_query(belief_set, "a")
 
-        self.mock_tweety_bridge.pl_handler.validate_pl_formula.assert_called_once_with(
-            "a"
-        )
+        self.mock_tweety_bridge.validate_pl_formula.assert_called_once_with("a")
         self.mock_tweety_bridge.pl_handler.pl_query.assert_called_once_with(
             belief_set.content, "a"
         )
@@ -124,18 +121,13 @@ class TestQueryExecutor:
     @pytest.mark.asyncio
     async def test_execute_query_propositional_rejected(self):
         """Test de l'exécution d'une requête propositionnelle rejetée."""
-        self.mock_tweety_bridge.pl_handler.validate_pl_formula.return_value = (
-            True,
-            "OK",
-        )
+        self.mock_tweety_bridge.validate_pl_formula.return_value = True
         self.mock_tweety_bridge.pl_handler.pl_query.return_value = False
 
         belief_set = PropositionalBeliefSet("a => b")
         result, message = self.query_executor.execute_query(belief_set, "a")
 
-        self.mock_tweety_bridge.pl_handler.validate_pl_formula.assert_called_once_with(
-            "a"
-        )
+        self.mock_tweety_bridge.validate_pl_formula.assert_called_once_with("a")
         self.mock_tweety_bridge.pl_handler.pl_query.assert_called_once_with(
             belief_set.content, "a"
         )
@@ -146,10 +138,7 @@ class TestQueryExecutor:
     @pytest.mark.asyncio
     async def test_execute_query_propositional_error(self):
         """Test de l'exécution d'une requête propositionnelle avec erreur."""
-        self.mock_tweety_bridge.pl_handler.validate_pl_formula.return_value = (
-            True,
-            "OK",
-        )
+        self.mock_tweety_bridge.validate_pl_formula.return_value = True
         self.mock_tweety_bridge.pl_handler.pl_query.return_value = (
             "FUNC_ERROR: Erreur de syntaxe"
         )
@@ -157,9 +146,7 @@ class TestQueryExecutor:
         belief_set = PropositionalBeliefSet("a => b")
         result, message = self.query_executor.execute_query(belief_set, "a")
 
-        self.mock_tweety_bridge.pl_handler.validate_pl_formula.assert_called_once_with(
-            "a"
-        )
+        self.mock_tweety_bridge.validate_pl_formula.assert_called_once_with("a")
         self.mock_tweety_bridge.pl_handler.pl_query.assert_called_once_with(
             belief_set.content, "a"
         )
@@ -223,17 +210,17 @@ class TestQueryExecutor:
     @pytest.mark.asyncio
     async def test_execute_queries(self):
         """Test de l'exécution de plusieurs requêtes."""
-        self.mock_tweety_bridge.pl_handler.validate_pl_formula.side_effect = [
-            (True, "OK"),
-            (True, "OK"),
-            (False, "Syntax Error in c"),  # Simule un échec de validation
+        self.mock_tweety_bridge.validate_pl_formula.side_effect = [
+            True,
+            True,
+            False,  # Simule un échec de validation
         ]
         self.mock_tweety_bridge.pl_handler.pl_query.side_effect = [True, False]
 
         belief_set = PropositionalBeliefSet("a => b")
         results = self.query_executor.execute_queries(belief_set, ["a", "b", "c"])
 
-        assert self.mock_tweety_bridge.pl_handler.validate_pl_formula.call_count == 3
+        assert self.mock_tweety_bridge.validate_pl_formula.call_count == 3
         assert self.mock_tweety_bridge.pl_handler.pl_query.call_count == 2
 
         assert len(results) == 3
@@ -251,4 +238,4 @@ class TestQueryExecutor:
         query3, result3, message3 = results[2]
         assert query3 == "c"
         assert result3 is None
-        assert message3 == "FUNC_ERROR: Requête invalide: Syntax Error in c"
+        assert message3 == "FUNC_ERROR: Requête invalide: c"

--- a/tests/unit/argumentation_analysis/plugins/test_1773_kernel_input_convention.py
+++ b/tests/unit/argumentation_analysis/plugins/test_1773_kernel_input_convention.py
@@ -1,0 +1,192 @@
+"""#1773 — le canal formel ne peut pas rendre un verdict sans calcul.
+
+Constats 1, 2 et 4 du dispatch (msg-20260816T095211-52twvk, amendé R819) :
+les tests ci-dessous portent sur le VERDICT rendu, jamais sur le nom d'une
+fonction. Ils sont rouges sur main d'aujourd'hui :
+
+- constat 1 : la sonde JVM du plugin avalait l'AttributeError d'une sonde
+  cassée (``bridge.is_jvm_ready``) via un ``except Exception`` nu —
+  une sonde cassée doit lever, pas rendre « indisponible » ;
+- constat 2 : la branche « pas de JVM » rendait ``True`` (« skipped
+  validation ») — un verdict positif sans aucun calcul ;
+- constat 4 : toute entrée non-objet-JSON levait AttributeError (liste,
+  int) ou rendait une erreur mensongère sans nommer les clés (clé absente).
+"""
+
+import asyncio
+import json
+
+import pytest
+
+import argumentation_analysis.plugins.kb_to_tweety_plugin as kb_plugin
+from argumentation_analysis.plugins.kb_to_tweety_plugin import KBToTweetyPlugin
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+def _parsed(result: str):
+    assert isinstance(result, str), "kernel_function must return a JSON string"
+    return json.loads(result)
+
+
+# ---------------------------------------------------------------------------
+# Constat 1 — la sonde JVM : un probe cassé lève, seul l'indisponible rend False
+# ---------------------------------------------------------------------------
+
+
+class TestJvmProbeBrokenVsUnavailable:
+    def test_broken_probe_raises(self, monkeypatch):
+        """Une sonde cassée (AttributeError) doit PROPAGER, pas rendre False."""
+        from argumentation_analysis.agents.core.logic import tweety_bridge as tb_mod
+
+        class _BrokenBridge:
+            @property
+            def initializer(self):
+                raise AttributeError("is_jvm_ready' has no attribute")
+
+        monkeypatch.setattr(
+            tb_mod.TweetyBridge,
+            "get_instance",
+            classmethod(lambda cls: _BrokenBridge()),
+        )
+        with pytest.raises(AttributeError):
+            kb_plugin._jvm_available()
+
+    def test_genuine_unavailability_returns_false(self, monkeypatch):
+        from argumentation_analysis.agents.core.logic import tweety_bridge as tb_mod
+
+        class _UninitializedBridge:
+            @property
+            def initializer(self):
+                raise RuntimeError("JVM not started")
+
+        monkeypatch.setattr(
+            tb_mod.TweetyBridge,
+            "get_instance",
+            classmethod(lambda cls: _UninitializedBridge()),
+        )
+        assert kb_plugin._jvm_available() is False
+
+    def test_ready_bridge_returns_true(self, monkeypatch):
+        from argumentation_analysis.agents.core.logic import tweety_bridge as tb_mod
+
+        class _ReadyInitializer:
+            @staticmethod
+            def is_jvm_ready():
+                return True
+
+        class _ReadyBridge:
+            initializer = _ReadyInitializer()
+
+        monkeypatch.setattr(
+            tb_mod.TweetyBridge, "get_instance", classmethod(lambda cls: _ReadyBridge())
+        )
+        assert kb_plugin._jvm_available() is True
+
+
+# ---------------------------------------------------------------------------
+# Constat 2 — pas de JVM => pas de verdict positif
+# ---------------------------------------------------------------------------
+
+
+class TestNoJvmNoPositiveVerdict:
+    @pytest.mark.parametrize(
+        "validator",
+        [
+            kb_plugin._validate_pl,
+            lambda f: kb_plugin._validate_fol(f),
+            lambda f: kb_plugin._validate_modal(f),
+        ],
+        ids=["pl", "fol", "modal"],
+    )
+    def test_unavailable_jvm_renders_invalid(self, validator, monkeypatch):
+        monkeypatch.setattr(kb_plugin, "_jvm_available", lambda: False)
+        valid, msg = validator("p => q")
+        assert valid is False, (
+            "sans JVM le validateur doit rendre un verdict NEGATIF, "
+            f"pas un verdict fabrique: ({valid}, {msg})"
+        )
+        assert "not performed" in msg
+
+    def test_unavailable_jvm_renders_invalid_retry_loop(self, monkeypatch):
+        """Le verdict remonte jusqu'a la reponse du plugin : is_valid False."""
+        monkeypatch.setattr(kb_plugin, "_jvm_available", lambda: False)
+        result = _parsed(
+            _run(
+                KBToTweetyPlugin().translate_to_tweety(
+                    json.dumps({"text": "the butler did it", "logic_type": "pl"})
+                )
+            )
+        )
+        assert (
+            result.get("is_valid") is False
+        ), f"le canal formel a rendu un verdict positif sans JVM: {result}"
+
+
+# ---------------------------------------------------------------------------
+# Constat 4 — surface d'entree : erreur structuree qui nomme les cles
+# (tests du helper lui-meme : tests/unit/argumentation_analysis/plugins/
+#  test_kernel_input.py — fichier separe pour ne pas casser la collection
+#  du present fichier lors du controle rouge sur main)
+# ---------------------------------------------------------------------------
+
+
+class TestEntryPointsStructuredErrors:
+    """Les 5 @kernel_function : jamais d'exception, toujours une erreur nommee."""
+
+    def test_translate_to_tweety_array_input(self):
+        result = _parsed(_run(KBToTweetyPlugin().translate_to_tweety("[1, 2, 3]")))
+        assert "error" in result
+        assert result.get("received_type") == "list"
+
+    def test_translate_to_tweety_int_input(self):
+        result = _parsed(_run(KBToTweetyPlugin().translate_to_tweety(42)))
+        assert "error" in result
+        assert result.get("received_type") == "int"
+
+    def test_translate_to_tweety_missing_text_names_keys(self):
+        result = _parsed(
+            _run(KBToTweetyPlugin().translate_to_tweety('{"logic_type": "pl"}'))
+        )
+        assert "error" in result
+        assert "text" in result["error"]
+        assert result.get("received_keys") == ["logic_type"]
+        assert "text" in result.get("expected_keys", [])
+
+    def test_translate_batch_missing_beliefs_names_keys(self):
+        result = _parsed(
+            _run(KBToTweetyPlugin().translate_batch_to_tweety('{"logic_type": "pl"}'))
+        )
+        assert "error" in result
+        assert "beliefs" in result["error"]
+        assert result.get("received_keys") == ["logic_type"]
+
+    def test_translate_dung_array_input(self):
+        result = _parsed(_run(KBToTweetyPlugin().translate_dung('["a", "b"]')))
+        assert "error" in result
+        assert result.get("received_type") == "list"
+
+    def test_translate_aspic_bad_json(self):
+        result = _parsed(_run(KBToTweetyPlugin().translate_aspic("{{{")))
+        assert "error" in result
+
+    def test_write_tweety_to_state_missing_formulas(self):
+        state = None
+        result = KBToTweetyPlugin().write_tweety_to_state('{"other": 1}', state=state)
+        # state None est traite avant le parsing : erreur dediee, pas d'exception
+        assert "error" in json.loads(result)
+
+    def test_write_tweety_to_state_names_keys(self):
+        class _State:
+            def add_belief_set(self, logic_type, formula):
+                return "bs1"
+
+        result = KBToTweetyPlugin().write_tweety_to_state(
+            '{"other": 1}', state=_State()
+        )
+        parsed = json.loads(result)
+        assert "error" in parsed
+        assert "formulas" in parsed["error"]
+        assert parsed.get("received_keys") == ["other"]

--- a/tests/unit/argumentation_analysis/plugins/test_kernel_input.py
+++ b/tests/unit/argumentation_analysis/plugins/test_kernel_input.py
@@ -1,0 +1,56 @@
+"""Tests du helper ``parse_kernel_json_object`` (#1773 constat 4, amendement R819).
+
+Le helper EST la convention réutilisable : TweetyLogicPlugin (#1774) doit
+adopter la même forme d'erreur, pas une variante locale. Ces tests fixent
+le contrat :
+- non-objet JSON => erreur structurée avec le type reçu, jamais d'exception ;
+- clé requise absente => l'erreur nomme les clés reçues ET attendues.
+"""
+
+from argumentation_analysis.plugins.kernel_input import parse_kernel_json_object
+
+
+class TestParseKernelJsonObject:
+    def test_invalid_json_string(self):
+        params, err = parse_kernel_json_object("not json", ["text"])
+        assert params is None
+        assert err == {"error": "Invalid JSON input"}
+
+    def test_json_array_is_not_an_object(self):
+        params, err = parse_kernel_json_object("[1, 2]", ["text"])
+        assert params is None
+        assert err["error"] == "Invalid input: expected a JSON object"
+        assert err["received_type"] == "list"
+
+    def test_non_string_non_object(self):
+        params, err = parse_kernel_json_object(123, ["text"])
+        assert params is None
+        assert err["received_type"] == "int"
+
+    def test_json_string_scalar_is_not_an_object(self):
+        params, err = parse_kernel_json_object('"a string"', ["text"])
+        assert params is None
+        assert err["received_type"] == "str"
+
+    def test_missing_required_key_names_both_sides(self):
+        params, err = parse_kernel_json_object(
+            {"logic_type": "pl"},
+            expected_keys=["text", "logic_type"],
+            required_keys=["text"],
+        )
+        assert params is None
+        assert "text" in err["error"]
+        assert err["received_keys"] == ["logic_type"]
+        assert "text" in err["expected_keys"]
+
+    def test_valid_object_passes_through(self):
+        params, err = parse_kernel_json_object(
+            '{"text": "a"}', expected_keys=["text"], required_keys=["text"]
+        )
+        assert err is None
+        assert params == {"text": "a"}
+
+    def test_optional_missing_key_is_fine(self):
+        params, err = parse_kernel_json_object("{}", expected_keys=["text"])
+        assert err is None
+        assert params == {}


### PR DESCRIPTION
## Résumé

Le canal formel (KBToTweetyPlugin + TweetyBridge) ne peut plus rendre un verdict sans calcul. Quatre constats du dispatch (msg-20260816T095211-52twvk, amendé R819), chacun avec son test rouge-avant-vert. **Contrôle rouge prouvé sur main `8cf1d9ed` : 17 tests failed / 7 passed au worktree ; 40 passed / 0 failed après** (JVM-free, `--disable-jvm-session`). Toutes les formules de test sont synthétiques.

## Constat 1 — la sonde JVM cassée avalée par `except Exception` nu

`kb_to_tweety_plugin._jvm_available()` appelait `bridge.is_jvm_ready()` (méthode inexistante — elle vit sur `bridge.initializer`, fix #1333) et le `except Exception` nu avalait l'AttributeError : la sonde rendait *False constant*, même pont prêt. Désormais : `ImportError` → False (module absent), `RuntimeError` → False (JVM non démarrée), **AttributeError → propage** (une sonde cassée doit être visible, pas silencieuse).

### Liste des frères (sweep `\.is_jvm_ready\(\)` complet, sans troncature)

Corrigés dans cette PR :
| Site | Défaut | Fix |
|---|---|---|
| `query_executor.py:59` | `bridge.is_jvm_ready()` inexistant → AttributeError sur **toute** exécution de `execute_query` (consommé par `services/web_api/services/logic_service.py:28`) | `bridge.initializer.is_jvm_ready()` |
| `query_executor.py:123` | Validateur fantôme `pl_handler.validate_pl_formula` (n'existe que dans les mocks) dépaqueté en tuple — un bool dépaqueté en `(is_valid, msg)` | `bridge.validate_pl_formula(query)` (retour bool, sans dépaquetage) |
| `first_order_logic_agent_adapter.py:80-89` | Import du module **inexistant** `argumentation_analysis.bridges.tweety_bridge` → ImportError permanent → mode dégradé à toutes les exécutions, la JVM n'était jamais consultée | Import du vrai module `agents.core.logic.tweety_bridge` + `initializer.is_jvm_ready()` |

Conformes dès le sweep (aucun fix nécessaire) : les 20+ `*_handler.py` sondent tous `initializer_instance.is_jvm_ready()` (forme correcte), `watson_logic_assistant.py:106` (staticmethod), `tweety_bridge.py` interne (property), `propositional_logic_agent.py:319` (déjà via initializer). Zéro site `.is_jvm_ready()` direct sur un pont ne subsiste, zéro import `bridges.tweety_bridge` ne subsiste.

## Constat 2 — la branche « pas de JVM » rendait un verdict positif

Les trois validateurs (`_validate_pl`, `_validate_fol`, `_validate_modal`) rendaient `True, "JVM unavailable — skipped validation"` sans aucun calcul. Désormais `False, "JVM unavailable — validation not performed"`. **Soustraction pure, aucun nouveau drapeau** (`degraded` non introduit : pas de consommateur).

## Constat 3 — `validate_pl_formula` jetait la valeur de retour

`PLHandler.parse_pl_formula` signale l'échec de deux façons : `raise ValueError` (parse Java levé) **et** `return None` (rejet sanitizer : formule vide, non-str, tokens invalides). `TweetyBridge.validate_pl_formula` ne testait que l'exception → tout `None` devenait `True` : validateur toujours-vrai sur la moitié des chemins d'échec. Fix : `parsed = ...parse_pl_formula(formula); return parsed is not None`.

**Contrôle du dispatch : `validate_pl_formula('))garbage((')` rendait `True` sur main** (chemin rejet sanitizer → `return None` → jeté) ; rend `False` ici — test rouge sur main, vert sur la branche, y compris le test JVM-réel (`tweety_bridge_fixture`).

### Onde mesurée — les 6 sites de production encaissent `False` (mesuré AVANT le merge, comme demandé)

| Site | Comportement avec `False` (avant : toujours `True`) |
|---|---|
| `propositional_logic_agent.py:740` (`_invoke_pl_syntax_check`) | `if not is_valid` → retour gracieux FUNC_ERROR — avant : toute formule passait le check syntaxique |
| `propositional_logic_agent.py:829` (`validate_formula`) | `is_valid` propagé dans le résultat JSON — verdict honnête au lieu de toujours-vrai |
| `kb_to_tweety_plugin.py:155` | boucle retry → `is_valid: false` après épuisement — avant : `is_valid: true` sans validation |
| `logic_agent_plugin.py:79` (`check_pl_consistency`) | pass-through JSON — verdict honnête |
| `logic_agent_plugin.py:357` (`validate_formula`) | idem |
| `nl_to_logic.py:604` | `False` → `"Invalid propositional formula syntax"` → retry/fallback — avant : prose acceptée comme formule |
| `query_executor.py:123` (corrigé ici) | `None, "FUNC_ERROR: Requête invalide"` — avant : AttributeError (validateur fantôme) |

Aucun site ne crashe sur `False` : tous ont un chemin de dégradation conçu. L'onde est un durcissement, pas une rupture. Tests des 6 consommateurs : **100 passed** (`test_logic_agent_plugin`, `test_nl_to_logic`, `test_propositional_logic_agent_authentic`, `test_fol_logic_agent`, `test_first_order_logic_agent_authentic`, `test_modal_logic_agent`).

## Constat 4 — parse défensif réutilisable (amendement R819)

Nouveau helper `argumentation_analysis/plugins/kernel_input.py` : `parse_kernel_json_object(raw, expected_keys, required_keys)`. Contrat :
- tout ce qui n'est pas un objet JSON rend une **erreur structurée**, jamais une exception (`received_type` nomme le type reçu) ;
- une clé requise absente rend une erreur qui **nomme les clés reçues ET attendues** (`received_keys` / `expected_keys`) — un appelant qui s'est trompé de forme peut converger par retry.

Câblé sur les 5 `@kernel_function` de `KBToTweetyPlugin`. **Forme citable pour le dispatch #1774** : c'est la convention que les 21 fonctions de `TweetyLogicPlugin` doivent adopter — importer le helper, pas réécrire une variante locale. Tests du contrat dans `test_kernel_input.py` (7 tests).

## Anti-pendules respectés

- `except ValueError` de `validate_pl_formula` **non élargi** à `Exception` (le défaut était la valeur de retour jetée, pas l'exception trop étroite) ;
- pas de bascule `is_valid: false` global par prudence — le verdict rendu est celui du calcul, site par site ;
- pas de try/except Exception global sur les corps — les 3 frères corrigés l'avaient **déjà** ; leur défaut était un câble mort (import inexistant, méthode fantôme), trié avant tout enveloppement ;
- aucune conclusion sur le choix du PM d'émettre vers ce canal (les 7 tentatives R817 = n=1).

## Tests

- `tests/unit/argumentation_analysis/plugins/test_1773_kernel_input_convention.py` — constats 1, 2, 4 (13 tests)
- `tests/agents/core/logic/test_1773_verdict_reading.py` — constat 3 + les 2 frères (10 tests, dont 2 JVM-réel `pytest.mark.tweety`)
- `tests/unit/argumentation_analysis/plugins/test_kernel_input.py` — contrat du helper (7 tests)
- `tests/agents/core/logic/test_query_executor.py` — réaligné sur le contrat réel (la version main codait le contrat fantôme tuple/`pl_handler`)
- Rouge sur main `8cf1d9ed` (worktree, fichiers de tests copiés tels quels) : **17 failed / 7 passed** ; triage : les tests constat-4 array/int échouent par raise (le défaut EST le crash), les tests constats 1/2/3 par assertion (verdict fabrique)
- mypy `--strict` sur les 5 fichiers : **0 nouvelle erreur** (5 erreurs de baseline éliminées au passage) ; black OK

## Suppressions

Aucune (Cleanup Gate N/A).

Closes #1773
