### PR TITLE
fix(logic): formal axes no longer depend on call order for class loading (#1775)

### DIFF
--- a/argumentation_analysis/plugins/tweety_logic_plugin.py
+++ b/argumentation_analysis/plugins/tweety_logic_plugin.py
@@ -76,6 +76,27 @@ def _jvm_required(func):
     return wrapper
 
 
+def _ready_initializer():
+    """#1775: a bare ``TweetyInitializer()`` never loads the Tweety classes,
+    so the handler guards rejected a booted JVM and axis availability depended
+    on which tools happened to run first in the process. Warm the initializer
+    explicitly (idempotent after the first call, traced) before constructing
+    handlers."""
+    from argumentation_analysis.agents.core.logic.tweety_initializer import (
+        TweetyInitializer,
+    )
+
+    initializer = TweetyInitializer()  # type: ignore[no-untyped-call]
+    if not initializer.is_jvm_ready():
+        logger.info(
+            "#1775: Tweety classes not loaded on this path — warming the "
+            "initializer before handler construction so axis availability "
+            "does not depend on call order."
+        )
+        initializer.ensure_jvm_and_components_are_ready()
+    return initializer
+
+
 class TweetyLogicPlugin:
     """Semantic Kernel plugin exposing Tweety logic handlers to LLM agents.
 
@@ -102,9 +123,6 @@ class TweetyLogicPlugin:
     def analyze_dung_framework(self, input: str) -> str:
         params = _parse_json_or_default(input, {"arguments": [], "attacks": []})
         from argumentation_analysis.agents.core.logic.af_handler import AFHandler
-        from argumentation_analysis.agents.core.logic.tweety_initializer import (
-            TweetyInitializer,
-        )
 
         # CONV-B #1333 (po-2025): AFHandler requires an ``initializer_instance``
         # (af_handler.py:38) and exposes ``analyze_dung_framework`` -- NOT
@@ -112,7 +130,7 @@ class TweetyLogicPlugin:
         # (#1371): the previous call constructed the handler with no args
         # (TypeError) and invoked a nonexistent method (AttributeError), so the
         # FormalAgent's prescribed ETAPE 3 (Dung analysis) crashed at call time.
-        initializer = TweetyInitializer()  # type: ignore[no-untyped-call]
+        initializer = _ready_initializer()
         handler = AFHandler(initializer)
         args = params.get("arguments", [])
         attacks = params.get("attacks", [])
@@ -205,16 +223,13 @@ class TweetyLogicPlugin:
     def check_modal_satisfiability(self, input: str) -> str:
         params = _parse_json_or_default(input, {"formula": input})
         from argumentation_analysis.agents.core.logic.modal_handler import ModalHandler
-        from argumentation_analysis.agents.core.logic.tweety_initializer import (
-            TweetyInitializer,
-        )
 
         # CONV-B #1333 (po-2025): ``ModalHandler`` requires an
         # ``initializer_instance`` in its constructor and exposes
         # ``is_modal_kb_consistent`` (query-based consistency, #1205); the
         # previous call constructed the handler with no args (TypeError) and
         # invoked a nonexistent ``check_satisfiability`` (AttributeError).
-        initializer = TweetyInitializer()  # type: ignore[no-untyped-call]
+        initializer = _ready_initializer()
         handler = ModalHandler(initializer)
         formula = params.get("formula", input)
         is_consistent, message = handler.is_modal_kb_consistent(str(formula))
@@ -451,11 +466,8 @@ class TweetyLogicPlugin:
     def check_dl_consistency(self, input: str) -> str:
         params = _parse_json_or_default(input, {})
         from argumentation_analysis.agents.core.logic.dl_handler import DLHandler
-        from argumentation_analysis.agents.core.logic.tweety_initializer import (
-            TweetyInitializer,
-        )
 
-        initializer = TweetyInitializer()
+        initializer = _ready_initializer()
         handler = DLHandler(initializer)
         kb = handler.create_knowledge_base(
             tbox=params.get("tbox", []),
@@ -480,11 +492,8 @@ class TweetyLogicPlugin:
     def query_conditional_logic(self, input: str) -> str:
         params = _parse_json_or_default(input, {})
         from argumentation_analysis.agents.core.logic.cl_handler import CLHandler
-        from argumentation_analysis.agents.core.logic.tweety_initializer import (
-            TweetyInitializer,
-        )
 
-        initializer = TweetyInitializer()
+        initializer = _ready_initializer()
         handler = CLHandler(initializer)
         kb = handler.create_knowledge_base(
             conditionals=params.get("conditionals", []),
@@ -544,11 +553,8 @@ class TweetyLogicPlugin:
     def analyze_setaf(self, input: str) -> str:
         params = _parse_json_or_default(input, {"arguments": [], "set_attacks": []})
         from argumentation_analysis.agents.core.logic.setaf_handler import SetAFHandler
-        from argumentation_analysis.agents.core.logic.tweety_initializer import (
-            TweetyInitializer,
-        )
 
-        initializer = TweetyInitializer()
+        initializer = _ready_initializer()
         handler = SetAFHandler(initializer)
         result = handler.analyze_setaf(
             arguments=params.get("arguments", []),
@@ -569,11 +575,8 @@ class TweetyLogicPlugin:
         from argumentation_analysis.agents.core.logic.weighted_handler import (
             WeightedHandler,
         )
-        from argumentation_analysis.agents.core.logic.tweety_initializer import (
-            TweetyInitializer,
-        )
 
-        initializer = TweetyInitializer()
+        initializer = _ready_initializer()
         handler = WeightedHandler(initializer)
         result = handler.analyze_weighted_framework(
             arguments=params.get("arguments", []),
@@ -592,11 +595,8 @@ class TweetyLogicPlugin:
         from argumentation_analysis.agents.core.logic.social_handler import (
             SocialHandler,
         )
-        from argumentation_analysis.agents.core.logic.tweety_initializer import (
-            TweetyInitializer,
-        )
 
-        initializer = TweetyInitializer()
+        initializer = _ready_initializer()
         handler = SocialHandler(initializer)
         votes = params.get("votes", {})
         if votes:
@@ -618,11 +618,8 @@ class TweetyLogicPlugin:
     def analyze_epistemic_framework(self, input: str) -> str:
         params = _parse_json_or_default(input, {"arguments": [], "attacks": []})
         from argumentation_analysis.agents.core.logic.eaf_handler import EAFHandler
-        from argumentation_analysis.agents.core.logic.tweety_initializer import (
-            TweetyInitializer,
-        )
 
-        initializer = TweetyInitializer()
+        initializer = _ready_initializer()
         handler = EAFHandler(initializer)
         result = handler.analyze_epistemic_framework(
             arguments=params.get("arguments", []),
@@ -640,11 +637,8 @@ class TweetyLogicPlugin:
     def analyze_delp(self, input: str) -> str:
         params = _parse_json_or_default(input, {"program": input})
         from argumentation_analysis.agents.core.logic.delp_handler import DeLPHandler
-        from argumentation_analysis.agents.core.logic.tweety_initializer import (
-            TweetyInitializer,
-        )
 
-        initializer = TweetyInitializer()
+        initializer = _ready_initializer()
         handler = DeLPHandler(initializer)
         result = handler.analyze_delp(
             program_text=params.get("program", input),
@@ -661,11 +655,8 @@ class TweetyLogicPlugin:
     def check_qbf(self, input: str) -> str:
         params = _parse_json_or_default(input, {"formula": input, "quantifiers": []})
         from argumentation_analysis.agents.core.logic.qbf_handler import QBFHandler
-        from argumentation_analysis.agents.core.logic.tweety_initializer import (
-            TweetyInitializer,
-        )
 
-        initializer = TweetyInitializer()
+        initializer = _ready_initializer()
         handler = QBFHandler(initializer)
         result = handler.analyze_qbf(
             quantifiers=params.get("quantifiers", []),

--- a/tests/integration/argumentation_analysis/test_1775_axis_order_independence.py
+++ b/tests/integration/argumentation_analysis/test_1775_axis_order_independence.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+"""#1775 — l'ordre d'appel ne doit plus décider de la disponibilité d'un axe formel.
+
+``TweetyInitializer._classes_loaded`` est un attribut de CLASSE : il survit
+entre les tests d'un même processus et n'importe quel autre test peut l'avoir
+posé (construction d'un ``TweetyBridge``, runner PM, fixture JVM). Un test en
+isolation de processus est donc la seule preuve honnête que le PREMIER axe
+formel appelé sur un système démarré fonctionne — cf. l'avertissement du
+body de #1775 : « un test rouge en isolation processus, sinon il serait vert
+à tort ».
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+
+# Sous-processus : processus frais, JVM démarrée par l'entrée de production,
+# AUCUN TweetyBridge construit (c'est lui qui pose le drapeau en effet de bord),
+# puis appel direct du premier axe formel. La précondition « démarre froid »
+# est assertée à l'intérieur : si un jour un import réchauffe le drapeau, le
+# test échoue sur sa précondition au lieu de passer à tort (#1019).
+_FRESH_AXIS_SCRIPT = r"""
+import json
+
+import argumentation_analysis.core.dll_guard  # noqa: F401 — doit précéder jpype
+
+from argumentation_analysis.core.jvm_setup import initialize_jvm
+from argumentation_analysis.agents.core.logic.tweety_initializer import TweetyInitializer
+
+assert initialize_jvm(), "initialize_jvm() a echoue"
+assert not TweetyInitializer._classes_loaded, (
+    "precondition violee : le processus frais demarre chaud — le test ne "
+    "prouverait plus l'independance d'ordre"
+)
+
+from argumentation_analysis.plugins.tweety_logic_plugin import TweetyLogicPlugin
+
+result = TweetyLogicPlugin().analyze_dung_framework(
+    '{"arguments": ["a", "b"], "attacks": [["a", "b"]]}'
+)
+data = json.loads(result)
+assert isinstance(data, dict), f"reponse non-dict : {result[:200]}"
+assert "error" not in data, f"axe rend une erreur : {data}"
+extensions = data.get("extensions") or {}
+assert extensions, f"axe rend une charge d'extensions vide : {data}"
+print("AXIS_OK:", json.dumps(data)[:300])
+"""
+
+
+@pytest.mark.integration
+@pytest.mark.no_jvm_session
+def test_first_formal_axis_survives_cold_boot():
+    """#1775 DoD : processus frais, JVM démarrée, zéro TweetyBridge au
+    préalable — ``analyze_dung_framework`` doit réussir. Avant le fix, il
+    levait ``RuntimeError('AFHandler instantiated before JVM is ready.')``
+    alors que la JVM tournait depuis le bootstrap."""
+    env = os.environ.copy()
+    # Le sous-processus simule un processus de production, pas un contexte
+    # pytest (sinon ``ensure_jvm_and_components_are_ready`` exigerait une
+    # fixture pour démarrer la JVM).
+    env.pop("PYTEST_RUNNING", None)
+    proc = subprocess.run(
+        [sys.executable, "-c", _FRESH_AXIS_SCRIPT],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        cwd=PROJECT_ROOT,
+        env=env,
+        timeout=420,
+    )
+    print("--- STDOUT (fresh-axis subprocess) ---")
+    print(proc.stdout[-3000:])
+    print("--- STDERR (fresh-axis subprocess) ---")
+    print(proc.stderr[-3000:])
+    assert (
+        proc.returncode == 0
+    ), f"l'axe formel a echoue en processus frais (code {proc.returncode})"
+    assert "AXIS_OK" in proc.stdout


### PR DESCRIPTION
## Summary

Fixes #1775. A bare `TweetyInitializer()` never loads the Tweety Java classes, so 8 of 21 formal axes raised `"instantiated before JVM is ready"` on a fully booted system — availability depended on which tools the LLM happened to call first (any `TweetyBridge` construction warms the class flag as a side effect).

## DoD item 1 first — severity bounded (measured, posted on the issue)

The full conversational production setup (`initialize_jvm` + `setup_registry` + LLM service + 8 agents incl. FormalAgent with its 11 plugins) leaves the flag **cold** — first `analyze_dung_framework` call RAISED. **The defect fires everywhere**, not only in direct/API mode. The only existing warmups are off-path: `unified_pipeline.py` JPype warmup (workflow `spectacular` only, pipeline phases don't serve these axes) and the enhanced-PM runner's `ModalLogicAgent` construction.

## The fix

One `_ready_initializer()` helper (tweety_logic_plugin.py): constructs the initializer, and if `is_jvm_ready()` is False calls `ensure_jvm_and_components_are_ready()` — the same idempotent warmup the spectacular workflow already uses — **with a trace** (anti-pendule: no silent warming). Applied at **10 sites**: the 6 named in the issue (dung, modal, dl, setaf, weighted, epistemic — 115/217/458/551/576/625) plus 4 same-form sites the sweep found (social 599, delp 647, qbf 668, query_conditional_logic 487 — the latter two only passed in ai-01's measurement because they ran *after* the flag flip).

Anti-pendules respected:
- handler guards untouched; `is_jvm_ready()` semantics untouched; bootstrap untouched (setup timeline stays cold — no global warmup at import)
- genuine class-loading failure still raises loudly (RuntimeError with classpath, from `_import_java_classes`)
- no claim made about previously published formal results; no causal link asserted with #1772's zero-emission

## Test — red before fix, process isolation

`tests/integration/argumentation_analysis/test_1775_axis_order_independence.py`: `_classes_loaded` is a **class** flag surviving across tests in one process, so the only honest test spawns a fresh interpreter (pattern of `test_logic_demos.py`): JVM booted via the production entry, `PYTEST_RUNNING` stripped, **cold start asserted as precondition** (fails loudly instead of passing vacuously if an import ever warms the flag), then `analyze_dung_framework` must succeed.

- RED on unfixed main: `RuntimeError('AFHandler instantiated before JVM is ready.')` (21.7s)
- GREEN after fix (21.1s): `{"semantics": "preferred", "extensions": {"preferred": [["a"]]}}` — genuine computed extension
- After-fix timeline (same measurement script as the severity run): t0→t4 cold, axis call SUCCESS, flag warm only from that call

## Validation

- New test: red → green as above
- Non-regression: `pytest tests/unit/argumentation_analysis/plugins/` → **556 passed** (includes #1776 kernel-input convention + conv_b deciders)
- black + flake8 clean on both files
- Ephemeral measurement script deleted (not committed)

Closes #1775