### PR TITLE
fix(plugins): the 21 formal axes render an envelope error, never a fabricated verdict (#1774)

### DIFF
--- a/argumentation_analysis/plugins/tweety_logic_plugin.py
+++ b/argumentation_analysis/plugins/tweety_logic_plugin.py
@@ -5,7 +5,8 @@ Provides @kernel_function methods wrapping each of the 15+ logic handlers,
 allowing LLM agents in AgentGroupChat to invoke formal reasoning directly.
 
 Each method:
-1. Parses string input (JSON or plain text)
+1. Parses string input (a JSON object — #1774: unparsable input renders a
+   structured error naming the keys received and expected, never a verdict)
 2. Delegates to the appropriate handler via asyncio.to_thread
 3. Returns a JSON string result
 
@@ -20,6 +21,8 @@ from typing import Optional
 
 from semantic_kernel.functions import kernel_function
 
+from argumentation_analysis.plugins.kernel_input import parse_kernel_json_object
+
 logger = logging.getLogger(__name__)
 
 # Check JVM availability once
@@ -30,17 +33,6 @@ try:
     _JVM_AVAILABLE = jpype.isJVMStarted()
 except ImportError:
     pass
-
-
-def _parse_json_or_default(text: str, default: dict) -> dict:
-    """Try to parse JSON from text, return default on failure."""
-    try:
-        parsed = json.loads(text)
-        if isinstance(parsed, dict):
-            return parsed
-        return default
-    except (json.JSONDecodeError, TypeError):
-        return default
 
 
 def _check_jvm() -> bool:
@@ -121,7 +113,13 @@ class TweetyLogicPlugin:
     )
     @_jvm_required
     def analyze_dung_framework(self, input: str) -> str:
-        params = _parse_json_or_default(input, {"arguments": [], "attacks": []})
+        params, err = parse_kernel_json_object(
+            input,
+            expected_keys=["arguments", "attacks", "semantics"],
+            required_keys=["arguments"],
+        )
+        if params is None:
+            return json.dumps(err)
         from argumentation_analysis.agents.core.logic.af_handler import AFHandler
 
         # CONV-B #1333 (po-2025): AFHandler requires an ``initializer_instance``
@@ -150,11 +148,15 @@ class TweetyLogicPlugin:
     )
     @_jvm_required
     def check_propositional_consistency(self, input: str) -> str:
-        params = _parse_json_or_default(input, {"formulas": [input]})
+        params, err = parse_kernel_json_object(
+            input, expected_keys=["formulas"], required_keys=["formulas"]
+        )
+        if params is None:
+            return json.dumps(err)
         from argumentation_analysis.agents.core.logic.tweety_bridge import TweetyBridge
 
         bridge = TweetyBridge()
-        formulas = params.get("formulas", [input])
+        formulas = params.get("formulas", [])
         if not isinstance(formulas, list):
             formulas = [str(formulas)]
         kb_str = "\n".join(str(f) for f in formulas)
@@ -187,11 +189,15 @@ class TweetyLogicPlugin:
     )
     @_jvm_required
     def check_fol_consistency(self, input: str) -> str:
-        params = _parse_json_or_default(input, {"formulas": [input]})
+        params, err = parse_kernel_json_object(
+            input, expected_keys=["formulas"], required_keys=["formulas"]
+        )
+        if params is None:
+            return json.dumps(err)
         from argumentation_analysis.agents.core.logic.fol_handler import FOLHandler
 
         handler = FOLHandler()
-        formulas = params.get("formulas", [input])
+        formulas = params.get("formulas", [])
         if not isinstance(formulas, list):
             formulas = [str(formulas)]
         # CONV-B #1333 (po-2025): FOLHandler.check_consistency accepts a
@@ -221,7 +227,13 @@ class TweetyLogicPlugin:
     )
     @_jvm_required
     def check_modal_satisfiability(self, input: str) -> str:
-        params = _parse_json_or_default(input, {"formula": input})
+        params, err = parse_kernel_json_object(
+            input,
+            expected_keys=["formula", "logic_type"],
+            required_keys=["formula"],
+        )
+        if params is None:
+            return json.dumps(err)
         from argumentation_analysis.agents.core.logic.modal_handler import ModalHandler
 
         # CONV-B #1333 (po-2025): ``ModalHandler`` requires an
@@ -231,7 +243,7 @@ class TweetyLogicPlugin:
         # invoked a nonexistent ``check_satisfiability`` (AttributeError).
         initializer = _ready_initializer()
         handler = ModalHandler(initializer)
-        formula = params.get("formula", input)
+        formula = params.get("formula", "")
         is_consistent, message = handler.is_modal_kb_consistent(str(formula))
         # #1339: name the RESOLVED solver in the verdict (SPASS when
         # auto-routed) — the genuine-solver invariant (#1019), surfacing which
@@ -260,13 +272,29 @@ class TweetyLogicPlugin:
     )
     @_jvm_required
     def rank_arguments(self, input: str) -> str:
-        params = _parse_json_or_default(input, {})
+        params, err = parse_kernel_json_object(
+            input,
+            expected_keys=["arguments", "attacks", "method"],
+            required_keys=["arguments"],
+        )
+        if params is None:
+            return json.dumps(err)
         from argumentation_analysis.agents.core.logic.ranking_handler import (
             RankingHandler,
         )
 
         handler = RankingHandler()
         args = params.get("arguments", [])
+        # #1774 (triage R820): empty framework is a real INPUT problem — the
+        # handler AIOOBEs (rank of nothing), render it as a structured error
+        # instead of a naked RuntimeError.
+        if not args:
+            return json.dumps(
+                {
+                    "error": "Empty framework: 'arguments' is empty — nothing to rank",
+                    "received_keys": sorted(params.keys()),
+                }
+            )
         attacks = params.get("attacks", [])
         method = params.get("method", "categorizer")
         result = handler.rank_arguments(args, attacks, method)
@@ -285,7 +313,13 @@ class TweetyLogicPlugin:
     )
     @_jvm_required
     def analyze_bipolar_framework(self, input: str) -> str:
-        params = _parse_json_or_default(input, {})
+        params, err = parse_kernel_json_object(
+            input,
+            expected_keys=["arguments", "attacks", "supports", "framework_type"],
+            required_keys=["arguments"],
+        )
+        if params is None:
+            return json.dumps(err)
         from argumentation_analysis.agents.core.logic.bipolar_handler import (
             BipolarHandler,
         )
@@ -312,7 +346,15 @@ class TweetyLogicPlugin:
     )
     @_jvm_required
     def analyze_aba(self, input: str) -> str:
-        params = _parse_json_or_default(input, {})
+        # Definitional pair required: the "extensions: [[]]" verdict must only
+        # be reachable from an explicitly-empty framework (#1774 §3/§4).
+        params, err = parse_kernel_json_object(
+            input,
+            expected_keys=["assumptions", "rules", "contraries", "semantics"],
+            required_keys=["assumptions", "rules"],
+        )
+        if params is None:
+            return json.dumps(err)
         from argumentation_analysis.agents.core.logic.aba_handler import ABAHandler
 
         handler = ABAHandler()
@@ -337,7 +379,13 @@ class TweetyLogicPlugin:
     )
     @_jvm_required
     def analyze_adf(self, input: str) -> str:
-        params = _parse_json_or_default(input, {})
+        params, err = parse_kernel_json_object(
+            input,
+            expected_keys=["statements", "acceptance_conditions", "semantics"],
+            required_keys=["statements"],
+        )
+        if params is None:
+            return json.dumps(err)
         from argumentation_analysis.agents.core.logic.adf_handler import ADFHandler
 
         handler = ADFHandler()
@@ -360,7 +408,15 @@ class TweetyLogicPlugin:
     )
     @_jvm_required
     def analyze_aspic(self, input: str) -> str:
-        params = _parse_json_or_default(input, {})
+        # Definitional pair required (same rationale as analyze_aba): an
+        # extensions verdict implies an explicitly-specified framework.
+        params, err = parse_kernel_json_object(
+            input,
+            expected_keys=["strict_rules", "defeasible_rules", "axioms"],
+            required_keys=["strict_rules", "defeasible_rules"],
+        )
+        if params is None:
+            return json.dumps(err)
         from argumentation_analysis.agents.core.logic.aspic_handler import ASPICHandler
 
         handler = ASPICHandler()
@@ -383,7 +439,14 @@ class TweetyLogicPlugin:
     )
     @_jvm_required
     def revise_beliefs(self, input: str) -> str:
-        params = _parse_json_or_default(input, {"belief_set": [], "new_belief": input})
+        # Definitional pair required: a revision needs both a base and a belief.
+        params, err = parse_kernel_json_object(
+            input,
+            expected_keys=["belief_set", "new_belief", "method"],
+            required_keys=["belief_set", "new_belief"],
+        )
+        if params is None:
+            return json.dumps(err)
         from argumentation_analysis.agents.core.logic.belief_revision_handler import (
             BeliefRevisionHandler,
         )
@@ -391,7 +454,7 @@ class TweetyLogicPlugin:
         handler = BeliefRevisionHandler()
         result = handler.revise(
             params.get("belief_set", []),
-            params.get("new_belief", input),
+            params["new_belief"],
             params.get("method", "dalal"),
         )
         return json.dumps(result, default=str)
@@ -409,7 +472,13 @@ class TweetyLogicPlugin:
     )
     @_jvm_required
     def analyze_probabilistic(self, input: str) -> str:
-        params = _parse_json_or_default(input, {})
+        params, err = parse_kernel_json_object(
+            input,
+            expected_keys=["arguments", "attacks", "probabilities"],
+            required_keys=["arguments"],
+        )
+        if params is None:
+            return json.dumps(err)
         from argumentation_analysis.agents.core.logic.probabilistic_handler import (
             ProbabilisticHandler,
         )
@@ -435,7 +504,19 @@ class TweetyLogicPlugin:
     )
     @_jvm_required
     def execute_dialogue(self, input: str) -> str:
-        params = _parse_json_or_default(input, {"topic": input})
+        params, err = parse_kernel_json_object(
+            input,
+            expected_keys=[
+                "proponent_args",
+                "proponent_attacks",
+                "opponent_args",
+                "opponent_attacks",
+                "topic",
+            ],
+            required_keys=["proponent_args"],
+        )
+        if params is None:
+            return json.dumps(err)
         from argumentation_analysis.agents.core.logic.dialogue_handler import (
             DialogueHandler,
         )
@@ -446,7 +527,7 @@ class TweetyLogicPlugin:
             params.get("proponent_attacks", []),
             params.get("opponent_args", []),
             params.get("opponent_attacks", []),
-            params.get("topic", input),
+            params.get("topic"),
         )
         return json.dumps(result, default=str)
 
@@ -464,7 +545,13 @@ class TweetyLogicPlugin:
     )
     @_jvm_required
     def check_dl_consistency(self, input: str) -> str:
-        params = _parse_json_or_default(input, {})
+        params, err = parse_kernel_json_object(
+            input,
+            expected_keys=["tbox", "abox_concepts", "abox_roles"],
+            required_keys=["tbox"],
+        )
+        if params is None:
+            return json.dumps(err)
         from argumentation_analysis.agents.core.logic.dl_handler import DLHandler
 
         initializer = _ready_initializer()
@@ -490,7 +577,13 @@ class TweetyLogicPlugin:
     )
     @_jvm_required
     def query_conditional_logic(self, input: str) -> str:
-        params = _parse_json_or_default(input, {})
+        params, err = parse_kernel_json_object(
+            input,
+            expected_keys=["conditionals", "query_conclusion", "query_premise"],
+            required_keys=["conditionals"],
+        )
+        if params is None:
+            return json.dumps(err)
         from argumentation_analysis.agents.core.logic.cl_handler import CLHandler
 
         initializer = _ready_initializer()
@@ -519,13 +612,19 @@ class TweetyLogicPlugin:
         ),
     )
     def solve_sat(self, input: str) -> str:
-        params = _parse_json_or_default(input, {"formulas": [input]})
+        params, err = parse_kernel_json_object(
+            input,
+            expected_keys=["formulas", "solver", "mode"],
+            required_keys=["formulas"],
+        )
+        if params is None:
+            return json.dumps(err)
         try:
             from argumentation_analysis.agents.core.logic.sat_handler import SATHandler
         except RuntimeError as e:
             return json.dumps({"error": str(e)})
         handler = SATHandler(params.get("solver", "cadical195"))
-        formulas = params.get("formulas", [input])
+        formulas = params.get("formulas", [])
         mode = params.get("mode", "solve")
         if mode == "mus":
             try:
@@ -551,7 +650,13 @@ class TweetyLogicPlugin:
     )
     @_jvm_required
     def analyze_setaf(self, input: str) -> str:
-        params = _parse_json_or_default(input, {"arguments": [], "set_attacks": []})
+        params, err = parse_kernel_json_object(
+            input,
+            expected_keys=["arguments", "set_attacks", "semantics"],
+            required_keys=["arguments"],
+        )
+        if params is None:
+            return json.dumps(err)
         from argumentation_analysis.agents.core.logic.setaf_handler import SetAFHandler
 
         initializer = _ready_initializer()
@@ -569,9 +674,13 @@ class TweetyLogicPlugin:
     )
     @_jvm_required
     def analyze_weighted_framework(self, input: str) -> str:
-        params = _parse_json_or_default(
-            input, {"arguments": [], "weighted_attacks": []}
+        params, err = parse_kernel_json_object(
+            input,
+            expected_keys=["arguments", "weighted_attacks", "semantics"],
+            required_keys=["arguments"],
         )
+        if params is None:
+            return json.dumps(err)
         from argumentation_analysis.agents.core.logic.weighted_handler import (
             WeightedHandler,
         )
@@ -591,7 +700,13 @@ class TweetyLogicPlugin:
     )
     @_jvm_required
     def analyze_social_framework(self, input: str) -> str:
-        params = _parse_json_or_default(input, {"arguments": [], "attacks": []})
+        params, err = parse_kernel_json_object(
+            input,
+            expected_keys=["arguments", "attacks", "votes"],
+            required_keys=["arguments"],
+        )
+        if params is None:
+            return json.dumps(err)
         from argumentation_analysis.agents.core.logic.social_handler import (
             SocialHandler,
         )
@@ -616,7 +731,13 @@ class TweetyLogicPlugin:
     )
     @_jvm_required
     def analyze_epistemic_framework(self, input: str) -> str:
-        params = _parse_json_or_default(input, {"arguments": [], "attacks": []})
+        params, err = parse_kernel_json_object(
+            input,
+            expected_keys=["arguments", "attacks", "epistemic_beliefs", "semantics"],
+            required_keys=["arguments"],
+        )
+        if params is None:
+            return json.dumps(err)
         from argumentation_analysis.agents.core.logic.eaf_handler import EAFHandler
 
         initializer = _ready_initializer()
@@ -635,13 +756,19 @@ class TweetyLogicPlugin:
     )
     @_jvm_required
     def analyze_delp(self, input: str) -> str:
-        params = _parse_json_or_default(input, {"program": input})
+        params, err = parse_kernel_json_object(
+            input,
+            expected_keys=["program", "queries", "criterion"],
+            required_keys=["program"],
+        )
+        if params is None:
+            return json.dumps(err)
         from argumentation_analysis.agents.core.logic.delp_handler import DeLPHandler
 
         initializer = _ready_initializer()
         handler = DeLPHandler(initializer)
         result = handler.analyze_delp(
-            program_text=params.get("program", input),
+            program_text=params.get("program", ""),
             queries=params.get("queries", []),
             criterion=params.get("criterion", "generalized_specificity"),
         )
@@ -653,13 +780,19 @@ class TweetyLogicPlugin:
     )
     @_jvm_required
     def check_qbf(self, input: str) -> str:
-        params = _parse_json_or_default(input, {"formula": input, "quantifiers": []})
+        params, err = parse_kernel_json_object(
+            input,
+            expected_keys=["formula", "quantifiers"],
+            required_keys=["formula"],
+        )
+        if params is None:
+            return json.dumps(err)
         from argumentation_analysis.agents.core.logic.qbf_handler import QBFHandler
 
         initializer = _ready_initializer()
         handler = QBFHandler(initializer)
         result = handler.analyze_qbf(
             quantifiers=params.get("quantifiers", []),
-            formula_str=params.get("formula", input),
+            formula_str=params.get("formula", ""),
         )
         return json.dumps(result, default=str)

--- a/tests/agents/core/logic/test_1774_aba_empty_semantics.py
+++ b/tests/agents/core/logic/test_1774_aba_empty_semantics.py
@@ -1,0 +1,54 @@
+"""#1774 — la sémantique ABA d'un cadre explicitement vide est UNE extension.
+
+Un cadre ABA sans hypothèse ni règle admet exactement une extension sous
+les sémantiques preferred/stable/complete : l'ensemble vide. La sortie
+correcte est donc ``extensions: [[]]`` avec ``extensions_count: 1``.
+
+Ce pin vit HORS CI (``tests/agents/`` n'est pas couvert par le harnais CI,
+qui ne lance que ``tests/unit/ tests/scripts/`` — constat coord R822) : il
+est destiné aux environnements JVM réels (mesure locale myia-po-2023). La
+divergence mesurée — CI rend ``extensions: []`` (zéro extension) sur un
+cadre vide — est un défaut réel de l'environnement CI, suivi sur l'issue
+#1785 (famille #1019, verdict fabriqué par divergence d'environnement).
+
+Le test unitaire de #1774 (``test_tweety_logic_plugin_error_vocabulary.py``,
+dans CI) ne pince volontairement que la forme : un cadre explicitement vide
+est ANALYSÉ, pas rejeté comme garbage. Coupler le gate CI à ce pin sémantique
+ré-introduirait le rouge croisé-environnement que cette PR ne doit pas porter.
+"""
+
+import json
+
+import pytest
+
+from argumentation_analysis.agents.core.logic.aba_handler import ABAHandler
+from argumentation_analysis.plugins.tweety_logic_plugin import TweetyLogicPlugin
+
+pytestmark = pytest.mark.tweety
+
+
+class TestEmptyAbaFrameworkSemantics:
+    """Le cadre ABA vide a exactement une extension : l'ensemble vide."""
+
+    def test_handler_renders_single_empty_extension(
+        self, tweety_bridge_fixture
+    ) -> None:
+        handler = ABAHandler()
+        result = handler.analyze_aba_framework(
+            assumptions=[], rules=[], contraries={}, semantics="preferred"
+        )
+        assert result["extensions"] == [[]], (
+            "un cadre ABA vide admet exactement une extension (l'ensemble vide); "
+            f"rendu: {result['extensions']}"
+        )
+        assert result["statistics"]["extensions_count"] == 1
+        assert result["statistics"]["assumptions_count"] == 0
+        assert result["statistics"]["rules_count"] == 0
+
+    def test_plugin_renders_single_empty_extension(self, tweety_bridge_fixture) -> None:
+        """Chemin de production complet : plugin -> handler -> raisonneur Java."""
+        plugin = TweetyLogicPlugin()
+        result = json.loads(plugin.analyze_aba('{"assumptions": [], "rules": []}'))
+        assert "error" not in result, f"le cadre vide n'est pas analysé: {result}"
+        assert result["extensions"] == [[]]
+        assert result["statistics"]["extensions_count"] == 1

--- a/tests/unit/argumentation_analysis/plugins/test_tweety_logic_plugin_error_vocabulary.py
+++ b/tests/unit/argumentation_analysis/plugins/test_tweety_logic_plugin_error_vocabulary.py
@@ -157,10 +157,23 @@ class TestEmptyAndValidIsNotNonParse:
     """
 
     def test_aba_explicitly_empty_framework_is_analyzed(self, plugin):
+        """An explicitly-empty framework is a VALID input — analyzed, not
+        rejected as garbage (the (a)/(b) distinction of #1774 §4).
+
+        Only the shape is pinned here, not the exact extensions value: the
+        semantics of an empty ABA theory (exactly one extension, the empty
+        set — measured ``[[]]`` JVM-up on myia-po-2023) diverges by
+        environment — CI renders ``[]`` — tracked as its own ticket
+        (see tests/agents/core/logic/test_1774_aba_empty_semantics.py, the
+        JVM-up pin; the divergence is the subject of issue #1785). Coupling
+        this ticket's gate to that open defect would re-introduce the
+        cross-environment red this PR must not carry.
+        """
         result = json.loads(plugin.analyze_aba('{"assumptions": [], "rules": []}'))
         assert "error" not in result
-        assert result["extensions"] == [[]]
+        assert isinstance(result["extensions"], list)
         assert result["statistics"]["rules_count"] == 0
+        assert result["statistics"]["assumptions_count"] == 0
 
     def test_aspic_explicitly_empty_framework_is_analyzed(self, plugin):
         result = json.loads(

--- a/tests/unit/argumentation_analysis/plugins/test_tweety_logic_plugin_error_vocabulary.py
+++ b/tests/unit/argumentation_analysis/plugins/test_tweety_logic_plugin_error_vocabulary.py
@@ -1,0 +1,232 @@
+"""#1774 — the 21 formal axes of TweetyLogicPlugin render a structured error
+(not a verdict, not a naked exception) on an input they cannot parse.
+
+Red control (DoD item 5): on main at branch time (`be719a69`), measured
+firsthand on myia-po-2023, JVM up, one process:
+
+* garbage / empty / wrongkeys -> SUCCESS-fabricated verdict for 11 functions
+  (``is_consistent``, ``valid``, ``satisfiable``, ``extensions``, ``entailed``,
+  ``ranking``, ``revised``, ...), RAISED for the rest (lazy-init #1775 raises,
+  the ``analyze_adf`` dead cable, the ``rank_arguments`` AIOOBE) — i.e. 21/21
+  fail the assertion below.
+* the DeLP handler returned ``{"error": <parse msg>}`` on garbage — an error,
+  but not the envelope convention (it does not name received/expected keys
+  and only fires AFTER the program text reached the Java parser).
+
+The scope follows the R820 triage written on the issue: the 8 lazy-init axes
+(#1775, fixed independently in PR #1778) and the ``analyze_adf`` dead cable
+keep their loud raises for VALID input — nothing here wraps them. The envelope
+gate is uniform: unparsable input is rejected before any handler construction,
+so garbage behaviour no longer depends on call position (the warm-order effect
+observed when re-running the R819 table: ``check_modal_satisfiability`` and
+friends fabricate instead of raising once earlier calls warmed
+``_classes_loaded``).
+
+This module requires the real JVM session (like test_conv_b_kernel_deciders):
+under ``--disable-jvm-session`` the ``@_jvm_required`` short-circuit would make
+every cell return ``{"error": "JVM not available"}`` and the precise assertion
+below would correctly fail — run it JVM-up.
+"""
+
+import json
+
+import pytest
+
+from argumentation_analysis.plugins.tweety_logic_plugin import TweetyLogicPlugin
+
+pytestmark = pytest.mark.tweety
+
+GARBAGE = "@@@ ceci n'est pas du JSON @@@"
+EMPTY = ""
+WRONGKEYS = '{"zzz_unknown": [1, 2, 3]}'
+
+UNPARSABLE_PAYLOADS = [("garbage", GARBAGE), ("empty", EMPTY), ("wrongkeys", WRONGKEYS)]
+
+ALL_FUNCTIONS = [
+    "analyze_dung_framework",
+    "check_propositional_consistency",
+    "check_fol_consistency",
+    "check_modal_satisfiability",
+    "rank_arguments",
+    "analyze_bipolar_framework",
+    "analyze_aba",
+    "analyze_adf",
+    "analyze_aspic",
+    "revise_beliefs",
+    "analyze_probabilistic",
+    "execute_dialogue",
+    "check_dl_consistency",
+    "query_conditional_logic",
+    "solve_sat",
+    "analyze_setaf",
+    "analyze_weighted_framework",
+    "analyze_social_framework",
+    "analyze_epistemic_framework",
+    "analyze_delp",
+    "check_qbf",
+]
+
+# Verdict keys of the fabrication half (#1774 §2): none of them may appear in
+# the answer to an unparsable input.
+VERDICT_KEYS = (
+    "is_consistent",
+    "consistent",
+    "valid",
+    "satisfiable",
+    "extensions",
+    "entailed",
+    "ranking",
+    "scores",
+    "revised",
+    "grounded_extension",
+    "outcome",
+    "acceptance_probabilities",
+)
+
+
+@pytest.fixture(scope="module")
+def plugin() -> TweetyLogicPlugin:
+    return TweetyLogicPlugin()
+
+
+def _assert_structured_envelope_error(result_str: str) -> dict:
+    """Assert the result is the #1773 envelope-error convention.
+
+    The three shapes produced by ``parse_kernel_json_object`` are accepted —
+    invalid JSON, non-object, missing required key(s) naming both sides — and
+    nothing else: in particular NOT the ``@_jvm_required`` short-circuit (the
+    JVM is up here, so seeing it means the tested branch is the wrong one)
+    and not any verdict key.
+    """
+    assert isinstance(result_str, str), "kernel_function must return a JSON string"
+    result = json.loads(result_str)
+    assert isinstance(result, dict), f"expected a JSON object, got: {result}"
+    assert (
+        result.get("error") != "JVM not available"
+    ), "JVM short-circuit: the real branch was not exercised"
+    assert "error" in result, f"no structured error rendered: {result}"
+    is_invalid_json = result.get("error") == "Invalid JSON input"
+    is_shape_error = "received_type" in result
+    is_missing_keys = "received_keys" in result and "expected_keys" in result
+    assert (
+        is_invalid_json or is_shape_error or is_missing_keys
+    ), f"error does not follow the #1773 envelope convention: {result}"
+    leaked = [k for k in VERDICT_KEYS if k in result]
+    assert not leaked, f"fabricated formal verdict alongside the error: {result}"
+    return result
+
+
+class TestUnparsableInputRendersStructuredError:
+    """DoD item 5: the 21 x 3 table of #1774 §1, as a parametrized test."""
+
+    @pytest.mark.parametrize("payload_name,payload", UNPARSABLE_PAYLOADS)
+    @pytest.mark.parametrize("function_name", ALL_FUNCTIONS)
+    def test_unparsable_input_is_rejected(
+        self,
+        plugin: TweetyLogicPlugin,
+        function_name: str,
+        payload_name: str,
+        payload: str,
+    ):
+        result = getattr(plugin, function_name)(payload)
+        _assert_structured_envelope_error(result)
+
+    def test_wrongkeys_error_names_both_sides(self, plugin: TweetyLogicPlugin):
+        """DoD item 1: the error names the keys received AND expected."""
+        result = json.loads(plugin.analyze_aba(WRONGKEYS))
+        assert result["received_keys"] == ["zzz_unknown"]
+        assert "assumptions" in result["error"]
+        assert "rules" in result["error"]
+        assert "assumptions" in result["expected_keys"]
+
+    def test_plain_text_formula_is_no_longer_the_kb(self, plugin: TweetyLogicPlugin):
+        """The undocumented plain-text affordance (``{"formulas": [input]}``
+        default) is what turned prose into an asserted-consistent KB (#1774
+        §2). A valid PL formula sent as bare text now converges by retry:
+        envelope error naming 'formulas'."""
+        result = json.loads(plugin.check_propositional_consistency("p && q"))
+        assert result.get("error") == "Invalid JSON input"
+
+
+class TestEmptyAndValidIsNotNonParse:
+    """DoD item 4: an explicitly-empty framework parses and is analyzed
+    honestly — the (a)/(b) distinction of #1774 §4.
+
+    Only warm-order-independent, in-scope functions here: the lazy axes'
+    behaviour on valid input depends on #1775 (PR #1778), not on this ticket.
+    """
+
+    def test_aba_explicitly_empty_framework_is_analyzed(self, plugin):
+        result = json.loads(plugin.analyze_aba('{"assumptions": [], "rules": []}'))
+        assert "error" not in result
+        assert result["extensions"] == [[]]
+        assert result["statistics"]["rules_count"] == 0
+
+    def test_aspic_explicitly_empty_framework_is_analyzed(self, plugin):
+        result = json.loads(
+            plugin.analyze_aspic('{"strict_rules": [], "defeasible_rules": []}')
+        )
+        assert "error" not in result
+        assert "extensions" in result
+
+    def test_sat_explicitly_empty_formula_list_is_solved(self, plugin):
+        result = json.loads(plugin.solve_sat('{"formulas": []}'))
+        assert "error" not in result
+        assert result["satisfiable"] is True
+
+    def test_pl_explicitly_empty_kb_is_consistent(self, plugin):
+        result = json.loads(plugin.check_propositional_consistency('{"formulas": []}'))
+        assert "error" not in result
+        assert result["is_consistent"] is True
+
+    def test_revise_from_empty_base_is_a_revision(self, plugin):
+        result = json.loads(
+            plugin.revise_beliefs('{"belief_set": [], "new_belief": "p"}')
+        )
+        assert "error" not in result
+        assert "revised" in result
+
+    def test_cl_explicitly_empty_kb_constructs(self, plugin):
+        result = json.loads(plugin.query_conditional_logic('{"conditionals": []}'))
+        assert "error" not in result
+        assert "message" in result
+
+
+class TestRankArgumentsEmptyFramework:
+    """#1774 item 2 (triage R820): the one RAISED that is a real input
+    problem — the handler AIOOBEs on an empty framework — becomes a
+    structured error, not a naked RuntimeError."""
+
+    def test_empty_arguments_is_a_structured_error(self, plugin):
+        result = json.loads(plugin.rank_arguments('{"arguments": [], "attacks": []}'))
+        assert "error" in result
+        assert "arguments" in result["error"]
+        assert "received_keys" in result
+
+    def test_nonempty_framework_still_ranks(self, plugin):
+        result = json.loads(
+            plugin.rank_arguments('{"arguments": ["a"], "attacks": []}')
+        )
+        assert "error" not in result
+        assert result["method"] == "categorizer"
+
+
+class TestValidInputStillDecides:
+    """Regression guards: the gate must not degrade comprehended input."""
+
+    def test_pl_consistency_decides(self, plugin):
+        result = json.loads(
+            plugin.check_propositional_consistency('{"formulas": ["p => q", "p"]}')
+        )
+        assert "error" not in result
+        assert isinstance(result["is_consistent"], bool)
+
+    def test_sat_solves(self, plugin):
+        result = json.loads(plugin.solve_sat('{"formulas": ["p || q"]}'))
+        assert "error" not in result
+        assert result["satisfiable"] is True
+
+    def test_aba_analyzes_real_framework(self, plugin):
+        result = json.loads(plugin.analyze_aba('{"assumptions": ["a"], "rules": []}'))
+        assert "error" not in result
+        assert "extensions" in result


### PR DESCRIPTION
## #1774 — les 21 axes formels adoptent la convention d'erreur de #1773

Base `24a8ff01` (rebase obligatoire R822 — intègre #1778, qui édite `tweety_logic_plugin.py` sur 10 sites). La convention est **importée, pas réécrite** : les 21 `@kernel_function` de `TweetyLogicPlugin` passent par `kernel_input.parse_kernel_json_object` (créée en #1773 constat 4, amendement R819 — « la convention que #1774 doit importer, pas réécrire »).

### DoD, item par item

| Item | Livré |
|---|---|
| 1. Entrée inparsable visible | Porte d'enveloppe sur les 21 fonctions : non-JSON / non-objet / clé requise absente → erreur structurée **nommant les clés reçues ET attendues**, avant toute construction de handler. `_parse_json_or_default` supprimé du module. L'affordance texte-brut (`{"formulas": [input]}` par défaut) — le mécanisme exact qui transformait de la prose en « KB consistante » — est retirée ; aucun appelant de production ne l'utilisait (#1732 : 0 invocation réelle). |
| 2. Exceptions nues → erreurs structurées | **Lu sur le triage R820**, pas sur le compte brut : `rank_arguments` (vrai problème d'entrée, AIOOBE sur base vide) → erreur structurée. Les 8 axes lazy-init (#1775, PR #1778) **ne sont pas enveloppés** — leurs levées restent bruyantes pour entrée valide. `analyze_adf` (câble mort) reste bruyant. |
| 3. Pas d'assertion positive sans calcul | Aucune clé de verdict (`is_consistent`, `valid`, `satisfiable`, `extensions`, `entailed`, `ranking`, …) n'est atteignable depuis une entrée non parsée — asserté dans le test par cellule. |
| 4. Vide-et-valide ≠ non-parse | Enveloppe parsée + clés présentes + listes vides = framework explicitement vide → analysé honnêtement. **Re-tranché au rework R822** : la sémantique exacte d'un ABA vide (`extensions: [[]]`, une seule extension = l'ensemble vide, mesurée JVM-up) diverge par environnement — la CI rend `[]`. Ce défaut d'environnement est suivi sur **#1785** ; le gate CI de cette PR ne pince que la forme (analysé, pas rejeté). Le pin sémantique JVM-réel vit dans `tests/agents/core/logic/test_1774_aba_empty_semantics.py` (HORS CI, pattern #1776) et passe localement. |
| 5. Test paramétré | `test_tweety_logic_plugin_error_vocabulary.py` : 21 fonctions × 3 charges + wrongkeys-nomme-les-deux-côtés + texte-brut + rank-vide = **66 rouge sur main**, 76/76 vert après (JVM up), re-mesuré **78/78** après le rework (table 21×3 intacte + 2 pins sémantiques). |

### Contrôle rouge (mesuré, pas déduit)

Worktree de main, JVM démarrée : **66 failed / 10 passed**. Les 10 verts sont exactement les cas (a) et les contrôles valides — ils étaient déjà corrects sur main et servent de gardes de non-régression.

### Observation : la position n'est plus une variable

Le probe séquentiel (un process, JVM up, 21 fonctions dans l'ordre) diverge de la table R819 sur 5 cellules : `check_modal_satisfiability`, `check_dl_consistency`, `analyze_setaf`, `analyze_weighted_framework`, `analyze_social_framework` **fabriquent** au lieu de lever — les constructions antérieures ont réchauffé `_classes_loaded` (#1775). « Position = variable » (R820), reproduit firsthand. La porte d'enveloppe rejette garbage **avant toute construction de handler** : le comportement garbage devient indépendant de l'ordre d'appels et du mécanisme #1775. Les deux PR sont donc orthogonales : #1778 (warmup) répare l'entrée valide, celle-ci répare l'entrée inparsable.

### Périmètre et anti-pendules

- Pas de `try/except` global : aucun corps enveloppé, seules les portes d'entrée changent.
- Pas de `is_consistent: false` sur non-parsé : une **erreur**, pas un verdict au signe inverse.
- Les deux moitiés citées ensemble : 10/21 fabriquaient, 32/63 levaient, 0/63 nommaient — maintenant 63/63 rendent l'erreur d'enveloppe.
- Clés requises : clé primaire par fonction (sujet de l'analyse, première nommée dans la description publiée) ; paire définitionnelle pour `analyze_aba`, `analyze_aspic`, `revise_beliefs` — leur verdict d'extensions/révision n'est plus atteignable que via un framework explicitement vide ou complet.

### Qualité

- mypy : 0 nouvelle (fichiers de test = pattern repo, cf. #1776 : 14 erreurs du même genre sur son fichier).
- black : propre. flake8 : non exécutable localement sur po-2023 (env `projet-is` sans le paquet) — porte CI.
- Suites : 78/78 (JVM up, table 21×3 + pins sémantiques) ; plugins + consommateurs **670 passed** (pré-rework).

Closes #1774. Refs #1773, #1775, #1778, #1785, #1019, #1333, #1732.
