### PR TITLE
feat(core): computed reading-head selection yields prose, never a fixed offset (#1737 step 2)

### DIFF
--- a/argumentation_analysis/core/reading_window.py
+++ b/argumentation_analysis/core/reading_window.py
@@ -1,0 +1,127 @@
+"""Selection of the reading window head (#1737 step 2).
+
+The 12+ reading-window sites slice the source text at a fixed offset 0
+(``text[:2000..4000]``). On compilation corpora the head is a table of
+contents, so the whole analysis chain reads metadata (measured in #1734,
+pinned by the #1737 head-nature instrument: corpus_B head is metadata at
+every window from 1500 to 4000). This module computes WHERE to read
+instead — from the text itself, never a hard-coded offset (a constant
+recalibrated on today's input is the exact defect being repaired).
+
+Design constraint (coordinator R817): the selector must rest on properties
+INDEPENDENT from the head-nature classifier, otherwise the acceptance test
+"classifier says prose at the selected head" cannot fail. The classifier
+verdicts from year-token density, list-marker lines, 5-gram repetition,
+average sentence length, alpha ratio and sentence density — none of which
+measure sub-clause punctuation. Prose carries subordinate clauses; TOC
+entries are noun phrases. Measured on the known points (per kchar):
+TOC head 1.33 vs every prose point 9.33-17.33 — a 7x gap on an observable
+the classifier never reads. The two functions provably disagree on crafted
+inputs (see tests): comma-less prose is blessed by the classifier and
+refused here; a comma-dense date list is refused by the classifier and
+accepted here.
+
+Mechanism: scan the text in fixed stride segments; a segment passes when
+its ``,;:`` density reaches the threshold; the selected offset is the
+start of the first run of consecutive passing segments long enough to fill
+the requested window. A boundary segment (half TOC, half prose) fails on
+diluted density, so the run starts at the prose boundary. Deterministic,
+pure, no LLM, no I/O — same input, same selection.
+"""
+
+import re
+from dataclasses import dataclass
+from typing import List
+
+_STRIDE = 500
+_PUNCT_RE = re.compile(r"[,;:]")
+# Per-kchar sub-clause punctuation threshold, calibrated in the gap between
+# the known TOC head (1.33/kchar) and the weakest known prose point
+# (9.33/kchar); the acceptance artifact re-checks both calibration points.
+_PUNCT_PER_KCHAR_THRESHOLD = 4.0
+
+STATUS_SELECTED = "selected"
+STATUS_NO_PUNCTUATED_SPAN = "no_punctuated_span_found"
+STATUS_EMPTY_INPUT = "empty_input"
+STATUS_SHORT_INPUT = "short_input"
+
+
+@dataclass(frozen=True)
+class WindowSelection:
+    """Result of the head selection.
+
+    ``offset`` is where the caller should read from; ``status`` is the
+    tri-state verdict (#1737: never a silent window). ``STATUS_SELECTED``
+    means a punctuation-structured span fills the window from ``offset``;
+    the other statuses keep ``offset=0`` so a consumer that ignores the
+    status preserves its old behaviour instead of crashing.
+    """
+
+    offset: int
+    window: int
+    status: str
+
+
+def _segment_passes(segment: str) -> bool:
+    if not segment.strip():
+        return False
+    kchars = max(len(segment), 1) / 1000
+    return len(_PUNCT_RE.findall(segment)) / kchars >= _PUNCT_PER_KCHAR_THRESHOLD
+
+
+def _first_passing_run_start(passes: List[bool], needed: int) -> int:
+    run = 0
+    for i, ok in enumerate(passes):
+        run = run + 1 if ok else 0
+        if run >= needed:
+            return (i - needed + 1) * _STRIDE
+    return -1
+
+
+def select_reading_head(
+    text: str, window: int, stride: int = _STRIDE
+) -> WindowSelection:
+    """Compute where to start reading ``text`` for a ``window``-char span.
+
+    Returns the start of the first stride-aligned run of
+    punctuation-structured segments long enough to cover ``window``. When
+    the head itself qualifies (ordinary prose corpora) the selection is
+    offset 0 and nothing moves — that is the non-regression property: a
+    corpus that already reads prose keeps reading the same span.
+    """
+    if window <= 0:
+        raise ValueError(f"window must be positive, got {window}")
+    if stride <= 0:
+        raise ValueError(f"stride must be positive, got {stride}")
+    if not text or not text.strip():
+        return WindowSelection(0, window, STATUS_EMPTY_INPUT)
+
+    segments = [text[i : i + stride] for i in range(0, len(text), stride)]
+    if len(text) < window:
+        # Too short to fill any window: judge the head segments anyway so a
+        # short punctuated text still reports selected, otherwise say so.
+        if (
+            _first_passing_run_start(
+                [_segment_passes(s) for s in segments], len(segments)
+            )
+            == 0
+        ):
+            return WindowSelection(0, window, STATUS_SELECTED)
+        return WindowSelection(0, window, STATUS_SHORT_INPUT)
+
+    needed = max(1, -(-window // stride))
+    passes = [_segment_passes(s) for s in segments]
+    offset = _first_passing_run_start(passes, needed)
+    if offset < 0:
+        return WindowSelection(0, window, STATUS_NO_PUNCTUATED_SPAN)
+    # The boundary segment can pass on diluted density while still carrying
+    # a ragged tail of the skipped head (one partial line). Line-structured
+    # documents (TOC entries, prose paragraphs) put a newline at that
+    # boundary: advance past it so the window starts clean. Only when
+    # something was skipped: an offset-0 selection reproduces today's
+    # window exactly (non-regression on already-prose corpora).
+    if offset > 0:
+        nl = text.find("\n", offset)
+        if 0 <= nl < offset + stride:
+            offset = nl + 1
+    return WindowSelection(offset, window, STATUS_SELECTED)

--- a/scripts/measure_1737_head_selection.py
+++ b/scripts/measure_1737_head_selection.py
@@ -1,0 +1,172 @@
+"""#1737 step 2 — acceptance run for the computed reading-head selection.
+
+The coordinator's acceptance contract (R817): the selector is judged by the
+#1770 head-nature instrument, whose features it does NOT use (independence
+proven in tests/unit/argumentation_analysis/core/test_reading_window.py —
+the two functions disagree on crafted inputs in both directions, so this
+acceptance CAN fail).
+
+Checks, per corpus and per production window (1500/2000/3000/4000):
+- corpus_B (head = TOC, defect carrier): verdict at the SELECTED head must
+  be ``prose``.
+- corpus_A / corpus_C (heads already prose): selection must be offset 0 —
+  a corpus that already reads prose keeps reading the same span — and the
+  verdict stays ``prose``.
+- The instrument's two calibration points still pass (B@0 = metadata,
+  C@10400 = prose) — threshold drift would show there first.
+- probe2: the whole run is executed twice and must hash identically.
+
+Privacy HARD: in-memory dataset, opaque corpus IDs, numeric features and
+offsets only; artifact under gitignored evaluation/results/real_analysis/.
+
+Usage:
+    conda run -n projet-is-roo-new --no-capture-output python scripts/measure_1737_head_selection.py [--probe2]
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+sys.path.insert(0, str(Path(__file__).parent))
+os.chdir(Path(__file__).parent.parent)
+
+_env_path = Path(__file__).parent.parent / ".env"
+if _env_path.exists():
+    with open(_env_path, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line and not line.startswith("#") and "=" in line:
+                key, _, val = line.partition("=")
+                os.environ.setdefault(key.strip(), val.strip())
+
+from measure_1737_head_nature import (  # noqa: E402
+    CORPUS_SRC_IDX,
+    classify_head,
+    head_features,
+    load_corpus_text,
+)
+from argumentation_analysis.core.reading_window import select_reading_head  # noqa: E402
+
+# The four distinct windows the anchored reading sites actually use.
+WINDOWS = [1500, 2000, 3000, 4000]
+RESULTS_DIR = Path("argumentation_analysis/evaluation/results/real_analysis")
+
+
+def run_once() -> dict:
+    texts = {label: load_corpus_text(label) for label in CORPUS_SRC_IDX}
+    report = {"calibration": [], "selections": []}
+
+    for label, offset, expected in (("B", 0, "metadata"), ("C", 10400, "prose")):
+        head = texts[label][offset : offset + 3000]
+        got = classify_head(head_features(head))
+        report["calibration"].append(
+            {
+                "corpus": f"corpus_{label}",
+                "at": offset,
+                "verdict": got,
+                "expected": expected,
+                "ok": got == expected,
+            }
+        )
+
+    for label, text in texts.items():
+        head0_verdict = classify_head(head_features(text[:3000]))
+        for window in WINDOWS:
+            sel = select_reading_head(text, window)
+            window_text = text[sel.offset : sel.offset + window]
+            feats = head_features(window_text)
+            verdict = classify_head(feats)
+            report["selections"].append(
+                {
+                    "corpus": f"corpus_{label}",
+                    "window": window,
+                    "selected_offset": sel.offset,
+                    "status": sel.status,
+                    "verdict_at_selection": verdict,
+                    "head0_verdict_w3000": head0_verdict,
+                    # acceptance verdicts only need the features, kept for audit
+                    "avg_sentence_len": feats["avg_sentence_len"],
+                    "alpha_ratio": feats["alpha_ratio"],
+                    "sentences_per_kchar": feats["sentences_per_kchar"],
+                    "year_tokens_per_kchar": feats["year_tokens_per_kchar"],
+                    "list_marker_lines_pct": feats["list_marker_lines_pct"],
+                    "top5gram_repetition_pct": feats["top5gram_repetition_pct"],
+                }
+            )
+    return report
+
+
+def check_acceptance(report: dict) -> bool:
+    ok = all(c["ok"] for c in report["calibration"])
+    for row in report["selections"]:
+        if row["corpus"] == "corpus_B":
+            ok = ok and row["verdict_at_selection"] == "prose"
+        else:
+            ok = ok and row["selected_offset"] == 0
+            ok = ok and row["verdict_at_selection"] == "prose"
+    return ok
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--probe2", action="store_true")
+    a = ap.parse_args()
+
+    report = run_once()
+    run_hash = hashlib.sha256(
+        json.dumps(report, sort_keys=True, ensure_ascii=False).encode("utf-8")
+    ).hexdigest()[:16]
+
+    if a.probe2:
+        report2 = run_once()
+        hash2 = hashlib.sha256(
+            json.dumps(report2, sort_keys=True, ensure_ascii=False).encode("utf-8")
+        ).hexdigest()[:16]
+        print(f"probe1 hash: {run_hash}")
+        print(f"probe2 hash: {hash2}")
+        if run_hash != hash2:
+            print("NON-DETERMINISM DETECTED — do not compare anything (R814)")
+            sys.exit(1)
+
+    accepted = check_acceptance(report)
+    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    artifact = RESULTS_DIR / f"measure_1737_head_selection_{ts}.json"
+    with open(artifact, "w", encoding="utf-8") as f:
+        json.dump(
+            {
+                "generated": ts,
+                "rows_sha256_16": run_hash,
+                "probe2": bool(a.probe2),
+                "accepted": accepted,
+                **report,
+            },
+            f,
+            indent=2,
+            ensure_ascii=False,
+        )
+
+    print(f"\n=== #1737 step-2 acceptance (hash {run_hash}) ===")
+    for c in report["calibration"]:
+        print(
+            f"calibration {c['corpus']}@{c['at']}: {c['verdict']} "
+            f"(expected {c['expected']}) ok={c['ok']}"
+        )
+    for row in report["selections"]:
+        print(
+            f"{row['corpus']} w={row['window']}: offset={row['selected_offset']:>6} "
+            f"status={row['status']:<28} verdict={row['verdict_at_selection']}"
+        )
+    print(f"ACCEPTED: {accepted}")
+    print(f"artifact: {artifact}")
+    if not accepted:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/argumentation_analysis/core/test_reading_window.py
+++ b/tests/unit/argumentation_analysis/core/test_reading_window.py
@@ -1,0 +1,158 @@
+# -*- coding: utf-8 -*-
+"""#1737 step 2 — unit tests for the reading-head selector.
+
+The load-bearing tests are the two independence proofs: the selector and
+the head-nature classifier must be ABLE to disagree in both directions,
+otherwise the acceptance test "classifier says prose at the selected head"
+cannot fail and proves nothing (coordinator R817 trap).
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[4] / "scripts"))
+
+from measure_1737_head_nature import classify_head, head_features  # noqa: E402
+
+from argumentation_analysis.core.reading_window import (  # noqa: E402
+    STATUS_EMPTY_INPUT,
+    STATUS_NO_PUNCTUATED_SPAN,
+    STATUS_SELECTED,
+    STATUS_SHORT_INPUT,
+    select_reading_head,
+)
+
+
+def _prose_like(n_chars: int, commas: bool = True) -> str:
+    """Synthetic prose: long VARIED sentences (rotation keeps 5-gram
+    repetition below the classifier's boilerplate threshold), alphabetic,
+    one paragraph line."""
+    sentences = [
+        "Le raisonnement déployé ici soutient une thèse précise, "
+        "appuyée sur des prémisses explicites, que l'auditoire peut examiner",
+        "Cette argumentation progressait par étapes successives, "
+        "chacune annoncée comme décisive, et pourtant toujours révisable",
+        "L'orateur concédait volontiers l'apparence d'une objection, "
+        "avant d'en retourner la force contre celui qui l'avait formulée",
+        "Une pareille construction suppose un auditoire patient, "
+        "disposé à suivre l'enchaînement des preuves jusqu'à sa conclusion",
+        "Le propos ne cherchait pas la conciliation, mais l'épreuve, "
+        "et cette préférence se lisait dans chaque transition du discours",
+        "Face à cette accumulation d'arguments circonstanciels, "
+        "la conclusion paraissait inévitable, bien qu'elle ne fût jamais dite",
+    ]
+    if not commas:
+        sentences = [s.replace(",", "") for s in sentences]
+    out = []
+    total = 0
+    i = 0
+    while total < n_chars:
+        out.append(sentences[i % len(sentences)] + ". ")
+        total += len(sentences[i % len(sentences)]) + 2
+        i += 1
+    return "".join(out)
+
+
+def _toc_like(n_chars: int, punctuated: bool = False) -> str:
+    """Synthetic TOC: short title lines, one per line."""
+    entries = [
+        "Discours de Marseille 14 juillet 1990",
+        "Discours de Lyon 8 juin 1991",
+        "Allocution de Paris 12 mai 1992",
+        "Déclaration de Lille 3 mars 1993",
+    ]
+    sep = ", page " if punctuated else " page "
+    out = []
+    total = 0
+    i = 0
+    while total < n_chars:
+        line = entries[i % len(entries)] + sep + str(10 + i) + "\n"
+        out.append(line)
+        total += len(line)
+        i += 1
+    return "".join(out)
+
+
+class TestIndependenceFromClassifier:
+    """The selector does NOT embed the classifier (R817 trap, defused)."""
+
+    def test_classifier_blesses_what_selector_refuses(self):
+        """Comma-less clean prose: classifier says prose, selector finds no
+        punctuated span. A circular selector (reusing classifier features)
+        would have selected offset 0 here — this test cannot pass for it."""
+        text = _prose_like(6000, commas=False)
+        assert classify_head(head_features(text[:3000])) == "prose"
+        sel = select_reading_head(text, 3000)
+        assert sel.status == STATUS_NO_PUNCTUATED_SPAN
+
+    def test_selector_accepts_what_classifier_condemns(self):
+        """Comma-dense year list: selector selects, classifier says
+        metadata (year density). The two verdicts cross here."""
+        text = _toc_like(6000, punctuated=True)
+        sel = select_reading_head(text, 3000)
+        assert sel.status == STATUS_SELECTED
+        assert classify_head(head_features(text[sel.offset : sel.offset + 3000])) in (
+            "metadata",
+            "mixed",
+        )
+
+
+class TestSelection:
+    def test_prose_head_selected_at_zero(self):
+        # Ordinary prose head: nothing moves (non-regression property).
+        sel = select_reading_head(_prose_like(8000), 3000)
+        assert sel.offset == 0
+        assert sel.status == STATUS_SELECTED
+
+    def test_offset_zero_never_snapped(self):
+        # A newline inside the first stride must NOT move an offset-0
+        # selection (multi-paragraph prose corpus head): reproducing
+        # today's window exactly is the non-regression contract.
+        paras = _prose_like(400) + "\n" + _prose_like(6000)
+        sel = select_reading_head(paras, 3000)
+        assert sel.offset == 0
+        assert sel.status == STATUS_SELECTED
+
+    def test_skips_toc_to_find_prose(self):
+        toc = _toc_like(30000)
+        prose = _prose_like(8000)
+        text = toc + prose
+        sel = select_reading_head(text, 3000)
+        assert sel.status == STATUS_SELECTED
+        assert sel.offset >= 30000 - 500  # at most one stride before prose
+        window = text[sel.offset : sel.offset + 3000]
+        # The selected window contains no TOC entry — a boundary mix would.
+        assert "juillet" not in window
+
+    def test_all_metadata_reports_loudly(self):
+        # Fail loud, never a silent window: a TOC-only text is reported.
+        sel = select_reading_head(_toc_like(50000), 3000)
+        assert sel.status == STATUS_NO_PUNCTUATED_SPAN
+        assert sel.offset == 0
+
+    def test_empty_input(self):
+        sel = select_reading_head("", 3000)
+        assert sel.status == STATUS_EMPTY_INPUT
+        assert sel.offset == 0
+
+    def test_short_input(self):
+        sel = select_reading_head("Court texte sans structure.", 3000)
+        assert sel.status == STATUS_SHORT_INPUT
+        assert sel.offset == 0
+
+    def test_short_punctuated_input_selects(self):
+        text = _prose_like(2000)
+        sel = select_reading_head(text, 3000)
+        assert sel.status == STATUS_SELECTED
+
+    def test_invalid_window_raises(self):
+        with pytest.raises(ValueError):
+            select_reading_head("texte", 0)
+
+    def test_determinism(self):
+        text = _toc_like(20000) + _prose_like(8000)
+        a = select_reading_head(text, 4000)
+        b = select_reading_head(text, 4000)
+        assert a == b


### PR DESCRIPTION
## Summary

Step 2 of #1737 (dispatch R817): the 12+ reading-window sites slice the source at offset 0; on corpus_B the head is a TOC (instrument #1770). This PR computes WHERE to read, from the text itself — never a hard-coded offset.

## The coordinator's trap, defused

**If the selector uses the same features as the classifier, the acceptance test cannot fail.** The selector is built on sub-clause punctuation density (`,;:`) — an observable the classifier never reads (it verdicts from year density, list markers, 5-gram repetition, sentence length, alpha ratio, sentence density). Measured gap on the known points: TOC head **1.33/kchar** vs every prose point **9.33–17.33** (7×). Independence is **proven, not claimed** — two unit tests show the functions disagree on crafted inputs in both directions:
- comma-less clean prose → classifier says `prose`, selector refuses (a circular selector would have selected offset 0)
- comma-dense year list → selector selects, classifier says `metadata`

## Mechanism

Scan stride segments (500 chars); a segment passes when its `,;:` density ≥ 4.0/kchar (calibrated in the measured gap); select the start of the first run of consecutive passing segments long enough to fill the requested window. Boundary handling: a ragged TOC tail surviving in the boundary segment is skipped past the next newline (only when something was skipped — an offset-0 selection reproduces today's window exactly). Tri-state loud status (`selected` / `no_punctuated_span_found` / `empty_input` / `short_input`) — never a silent window.

## Acceptance (real corpora, script `scripts/measure_1737_head_selection.py`, probe2 hash-identical `7ff4113b4a5b6ccd`)

| corpus | w=1500 | w=2000 | w=3000 | w=4000 |
|---|---|---|---|---|
| corpus_A | offset **0**, prose | 0, prose | 0, prose | 0, prose |
| corpus_B | offset **15001**, **prose** | 15001, prose | 15001, prose | 15001, prose |
| corpus_C | offset **0**, prose | 0, prose | 0, prose | 0, prose |

- **DoD 1** (selection computed, prose on corpus_B): ✅ offset 15001 computed from the text — there is punctuated line-structured text from ~15000, earlier than the 30000 known-good point of R807, and the independent classifier judges `prose` at all four windows.
- **DoD 2** (non-regression A/C): ✅ offset 0 everywhere — a corpus that already reads prose keeps reading the same span (unit-tested: an early newline never snaps an offset-0 selection).
- **DoD 3** (calibration): ✅ B@0 = metadata, C@10400 = prose — both still pass.
- **DoD 4** (probe2): ✅ identical hashes.
- No window was widened (anti-pendule); no offset constant anywhere in the selector.

## Files

- `argumentation_analysis/core/reading_window.py` — selector (pure, deterministic, no LLM/IO)
- `tests/unit/argumentation_analysis/core/test_reading_window.py` — 11 tests incl. the two independence proofs
- `scripts/measure_1737_head_selection.py` — acceptance run, judges via the #1770 instrument (single classifier source), artifact under gitignored `evaluation/results/real_analysis/`

## Validation

- mypy strict: clean · black: applied · flake8: clean
- Unit tests: 11/11
- Step 3 (wiring the selector into the reading sites, surfacing status to consumers) is out of scope here.

Closes nothing yet (#1737 stays open for steps 3+). Refs #1737, #1734, #1770.