### PR TITLE
fix(orchestration): stakes_extraction joins CAPABILITY_STATE_WRITERS, 8 #506 dualities documented (#1781)

### DIFF
--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -10060,7 +10060,9 @@ async def _invoke_stakes_extractor(
     """Extract stakes, stakeholders, register, and arena (Track TT #723).
 
     Reads arguments from state, calls the StakesExtractor specialist,
-    writes results to state.stakes_and_stakeholders.
+    persists via ``_write_stakes_to_state`` (registered under
+    ``CAPABILITY_STATE_WRITERS['stakes_extraction']`` — the inline call keeps
+    direct, non-executor callers persisting as before).
     """
     state = context.get("_state_object")
     if state is None:
@@ -10129,8 +10131,14 @@ async def _invoke_stakes_extractor(
         deanonymized=bool(getattr(state, "deanonymized", True)),
     )
 
-    # Write to state
-    state.stakes_and_stakeholders = result
+    # Persist via the shared writer so the capability is primary under the
+    # duality invariant (the executor re-calls it post-phase; idempotent,
+    # same four values — see the writer's double-write note).
+    from argumentation_analysis.orchestration.state_writers import (
+        _write_stakes_to_state,
+    )
+
+    _write_stakes_to_state(result, state, context)
 
     n_stakes = len(result.get("stakes", []))
     n_stakeholders = len(result.get("stakeholders", []))

--- a/argumentation_analysis/orchestration/state_writers.py
+++ b/argumentation_analysis/orchestration/state_writers.py
@@ -284,6 +284,7 @@ __all__ = [
     "_write_narrative_synthesis_to_state",
     "_write_external_fol_solver_to_state",
     "_write_external_modal_solver_to_state",
+    "_write_stakes_to_state",
     "CAPABILITY_STATE_WRITERS",
 ]
 
@@ -1534,7 +1535,8 @@ def _write_setaf_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
         # ``target`` keys; drop malformed entries rather than crash the
         # writer boundary.
         sanitised = [
-            dict(a) for a in set_attacks
+            dict(a)
+            for a in set_attacks
             if isinstance(a, dict)
             and isinstance(a.get("attackers"), list)
             and isinstance(a.get("target"), str)
@@ -2107,6 +2109,47 @@ def _write_external_modal_solver_to_state(
             state.modal_analysis_results["external_degraded"] = degraded
 
 
+def _write_stakes_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
+    """Write the Track TT #723 stakes & stakeholders extraction to state.
+
+    ``_invoke_stakes_extractor`` landed with its state write inline — the
+    only primary pipeline capability absent from ``CAPABILITY_STATE_WRITERS``,
+    so the workflow executor did not recognise it as primary
+    (``test_capability_duality_invariant`` red since #723; the integration
+    suite is not in CI, so nothing flagged it). Extracted per the D1b
+    precedent (#1167 ``_write_deep_synthesis_to_state``): the writer rebuilds
+    ``state.stakes_and_stakeholders`` from the invoke output, which carries
+    the four schema keys defined at ``shared_state`` init. An error output
+    (direct call without shared state) leaves the honest empty default —
+    never fabricate stakes (#1019).
+
+    Double-write note: the invoke calls this writer inline so its direct
+    callers (``conversational_orchestrator`` post-processing) persist the
+    result without going through the executor; the executor then calls it
+    again via this registration after the phase completes. The second write
+    is an idempotent overwrite of the same four values — no guard added, the
+    same-value disjointness argument as ``_write_deep_synthesis_to_state``.
+    """
+    if not output or not isinstance(output, dict) or "error" in output:
+        return
+    stakes = output.get("stakes", [])
+    stakeholders = output.get("stakeholders", [])
+    if isinstance(state, dict):
+        state["stakes_and_stakeholders"] = {
+            "stakes": stakes,
+            "stakeholders": stakeholders,
+            "rhetorical_register": output.get("rhetorical_register", ""),
+            "discursive_arena": output.get("discursive_arena", ""),
+        }
+    elif hasattr(state, "stakes_and_stakeholders"):
+        state.stakes_and_stakeholders = {
+            "stakes": stakes,
+            "stakeholders": stakeholders,
+            "rhetorical_register": output.get("rhetorical_register", ""),
+            "discursive_arena": output.get("discursive_arena", ""),
+        }
+
+
 CAPABILITY_STATE_WRITERS: Dict[str, Any] = {
     "argument_quality": _write_quality_to_state,
     "counter_argument_generation": _write_counter_argument_to_state,
@@ -2150,6 +2193,7 @@ CAPABILITY_STATE_WRITERS: Dict[str, Any] = {
     "act1_framing": _write_act1_framing_to_state,
     "act3_conclusion": _write_act3_conclusion_to_state,
     "nl_extraction": _write_text_to_kb_to_state,
+    "stakes_extraction": _write_stakes_to_state,
     "kb_to_tweety": _write_kb_to_tweety_to_state,
     "formal_result_interpretation": _write_tweety_interpretation_to_state,
     "external_fol_solving": _write_external_fol_solver_to_state,

--- a/tests/integration/test_capability_duality_invariant.py
+++ b/tests/integration/test_capability_duality_invariant.py
@@ -40,6 +40,21 @@ ACCEPTED_DUALITIES: dict[str, str] = {
     "belief_revision": "BeliefRevisionPlugin; _invoke_belief_revision same backend",
     "neural_fallacy_detection": "FrenchFallacyPlugin wraps detection; _invoke_camembert_fallacy callable",
     "formal_synthesis": "NarrativeSynthesisPlugin; _invoke_formal_synthesis aggregates formal results",
+    # #506 plugin↔service twins — each _invoke_* instantiates its twin plugin
+    # directly, so the two paths share the backend by construction (verified:
+    # _invoke_text_to_kb builds TextToKBPlugin(), _invoke_kb_to_tweety builds
+    # KBToTweetyPlugin(), _invoke_tweety_interpretation builds
+    # TweetyResultInterpretationPlugin). Undocumented since those services
+    # were registered — the integration suite is not in CI, so nothing
+    # flagged them.
+    "nl_extraction": "text_to_kb_service _invoke_text_to_kb instantiates TextToKBPlugin (#474)",
+    "argument_extraction": "text_to_kb_service _invoke_text_to_kb instantiates TextToKBPlugin (#474)",
+    "kb_construction": "text_to_kb_service _invoke_text_to_kb instantiates TextToKBPlugin (#474)",
+    "kb_to_tweety": "kb_to_tweety_service _invoke_kb_to_tweety instantiates KBToTweetyPlugin (#475)",
+    "formula_translation": "kb_to_tweety_service _invoke_kb_to_tweety instantiates KBToTweetyPlugin (#475)",
+    "tweety_validation": "kb_to_tweety_service _invoke_kb_to_tweety instantiates KBToTweetyPlugin (#475)",
+    "formal_result_interpretation": "tweety_interpretation_service _invoke_tweety_interpretation instantiates TweetyResultInterpretationPlugin (#476)",
+    "dung_interpretation": "tweety_interpretation_service _invoke_tweety_interpretation instantiates TweetyResultInterpretationPlugin (#476)",
 }
 
 

--- a/tests/unit/argumentation_analysis/orchestration/test_state_writers_stakes_extraction.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_state_writers_stakes_extraction.py
@@ -1,0 +1,112 @@
+"""stakes_extraction joins CAPABILITY_STATE_WRITERS — duality invariant repair.
+
+``_invoke_stakes_extractor`` (Track TT #723) landed with its state write
+inline, so ``stakes_extraction`` was the only primary pipeline capability
+absent from ``CAPABILITY_STATE_WRITERS`` and the workflow executor did not
+recognise it as primary — ``test_capability_duality_invariant`` has been red
+on main since #723 (the integration suite is not in CI, so nothing flagged
+it). These tests pin the extracted-writer contract:
+
+- the writer is registered under ``stakes_extraction``;
+- it populates ``state.stakes_and_stakeholders`` from the invoke output;
+- an error output leaves the honest empty default (never fabricate, #1019);
+- a direct (non-executor) invoke call still persists — the conversational
+  orchestrator's post-processing path relies on it.
+"""
+
+import asyncio
+from unittest.mock import patch
+
+from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+from argumentation_analysis.orchestration.state_writers import (
+    CAPABILITY_STATE_WRITERS,
+    _write_stakes_to_state,
+)
+
+_EMPTY_DEFAULT = {
+    "stakes": [],
+    "stakeholders": [],
+    "rhetorical_register": "",
+    "discursive_arena": "",
+}
+
+
+class TestWriteStakesToState:
+    def test_registered_under_stakes_extraction(self):
+        assert (
+            CAPABILITY_STATE_WRITERS.get("stakes_extraction") is _write_stakes_to_state
+        )
+
+    def test_populates_state_from_output(self):
+        state = UnifiedAnalysisState("speech")
+        output = {
+            "stakes": [{"stake_type": "economic", "description": "tax base"}],
+            "stakeholders": [{"name": "government", "stance": "for"}],
+            "rhetorical_register": "mobilization",
+            "discursive_arena": "parliament",
+            "summary": "extracted",
+        }
+        _write_stakes_to_state(output, state, {})
+        assert state.stakes_and_stakeholders["stakes"] == output["stakes"]
+        assert state.stakes_and_stakeholders["stakeholders"] == output["stakeholders"]
+        assert state.stakes_and_stakeholders["rhetorical_register"] == "mobilization"
+        assert state.stakes_and_stakeholders["discursive_arena"] == "parliament"
+
+    def test_error_output_leaves_honest_default(self):
+        state = UnifiedAnalysisState("speech")
+        _write_stakes_to_state({"error": "No shared state"}, state, {})
+        assert state.stakes_and_stakeholders == _EMPTY_DEFAULT
+
+    def test_empty_output_leaves_honest_default(self):
+        state = UnifiedAnalysisState("speech")
+        _write_stakes_to_state(None, state, {})
+        _write_stakes_to_state({}, state, {})
+        assert state.stakes_and_stakeholders == _EMPTY_DEFAULT
+
+
+class TestDirectInvokeStillPersists:
+    """The conversational orchestrator calls the invoke directly (no
+    executor), so the invoke's inline writer call must persist — strengthened
+    from B02's ``hasattr`` (which passed even with no write at all, the attr
+    is initialised in ``UnifiedAnalysisState.__init__``)."""
+
+    def test_direct_call_populates_state(self):
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _invoke_stakes_extractor,
+        )
+
+        state = UnifiedAnalysisState("speech")
+        state.identified_arguments = {"a1": "We must reform the tax system."}
+
+        class _StubExtractor:
+            async def extract(self, **kwargs):
+                return {
+                    "stakes": [{"stake_type": "economic", "description": "d"}],
+                    "stakeholders": [{"name": "gov", "stance": "for"}],
+                    "rhetorical_register": "legitimation",
+                    "discursive_arena": "assembly",
+                }
+
+        with (
+            patch(
+                "argumentation_analysis.orchestration.invoke_callables"
+                "._get_openai_client",
+                return_value=(None, ""),
+            ),
+            patch(
+                "argumentation_analysis.agents.core.political.stakes_extractor"
+                ".StakesExtractor",
+                return_value=_StubExtractor(),
+            ),
+        ):
+            result = asyncio.get_event_loop().run_until_complete(
+                _invoke_stakes_extractor(
+                    "", {"_state_object": state, "source_metadata": {}}
+                )
+            )
+
+        assert "error" not in result
+        assert state.stakes_and_stakeholders["stakes"] == [
+            {"stake_type": "economic", "description": "d"}
+        ]
+        assert state.stakes_and_stakeholders["rhetorical_register"] == "legitimation"


### PR DESCRIPTION
## #1781 — le garde duality, silencieusement rouge depuis #723, redevient 4/4 vert

Signalé au coord en R822 (« `test_capability_duality_invariant` échoue 2/4 sur base propre `be719a69` ») ; investigué ce tour en autonome (algo worker-round : test rouge sur main = urgence sans dispatch). **Issue #1781 ouverte avec le diagnostic complet.**

### Contrôle rouge (base propre `be719a69`, mesuré ce tour)

```
2 failed, 2 passed — tests/integration/test_capability_duality_invariant.py
```

Invisible en CI : le workflow ne tourne que `tests/unit/ tests/scripts/`.

### Défaut 1 — `stakes_extraction` sans writer enregistré

- `_invoke_stakes_extractor` (Track TT #723) écrivait `state.stakes_and_stakeholders` **en ligne** (invoke_callables.py:10133) — la seule capacité primaire absente de `CAPABILITY_STATE_WRITERS` (41 entrées).
- `git log -S "stakes" -- state_writers.py` : le writer n'a **jamais** existé → rouge depuis l'ajout de la phase L5b #723.
- **Fix = extraction** (précédent D1b #1167 `deep_synthesis`, sortie droppée sans writer) : `_write_stakes_to_state(output, state, ctx)` reconstruit le struct 4 clés depuis l'output ; erreur → défaut vide honnête (#1019).
- **Piège traité** : le chemin conversationnel appelle l'invoke **directement** (conversational_orchestrator.py:1583) et dépendait de l'écriture inline. L'invoke appelle donc le writer inline (appelants directs persistent à l'identique) ; l'exécuteur le rappelle après la phase — réécriture idempotent des mêmes 4 valeurs, documentée dans la note double-write du writer (même argument de disjointness que `_write_deep_synthesis_to_state`).

### Défaut 2 — 8 dualités #506 non documentées

Les 3 paires plugin↔service de #506 (`text_to_kb`, `kb_to_tweety`, `tweety_interpretation`) étaient enregistrées côte à côte dans `registry_setup.py` sans entrée `ACCEPTED_DUALITIES`. **Vérifié avant de documenter** : chaque `_invoke_*` instancie littéralement son plugin jumeau (`_invoke_text_to_kb` construit `TextToKBPlugin()`, etc.) — même backend par construction. Les 8 entrées citent la paire et la vérification. La NOTE du fichier de test prévoyait exactement ce cas ; personne n'avait fait le suivi.

### Tests

- Nouveau `test_state_writers_stakes_extraction.py` : enregistrement, peuplement depuis l'output, défaut vide honnête sur erreur, **persistance de l'appel direct** (renforcé vs B02 `test_stakes_written_to_state` dont le `hasattr` passait même sans aucune écriture — l'attribut est initialisé dans `__init__`).
- Duality : 2 failed/2 passed → **4/4 vert** ; B02 suite verte ; sweep régression orchestration + sanitize + restitution + deep_synthesis (consommateurs aval de `stakes_and_stakeholders`) en cours de validation (résultat dans le commentaire de suivi si divergence).
- mypy : `state_writers.py` et `invoke_callables.py` **0 erreur** ; black propre (4 fichiers).

Closes #1781. Refs #723, #1167, #506, #1019.
