### PR TITLE
feat(orchestration): #1737 etapes 3+4 — 23 sites de lecture cables a la fenetre calculee, re-mesure avant/apres

### DIFF
--- a/argumentation_analysis/adapters/french_fallacy_adapter.py
+++ b/argumentation_analysis/adapters/french_fallacy_adapter.py
@@ -28,6 +28,7 @@ from typing import Any, Dict, List, Optional
 from argumentation_analysis.core.interfaces.fallacy_detector import (
     AbstractFallacyDetector,
 )
+from argumentation_analysis.core.reading_window import selected_text
 
 logger = logging.getLogger(__name__)
 
@@ -1267,7 +1268,8 @@ class LLMFallacyDetector:
             import json as _json
 
             user_prompt = (
-                f"Analyse ce texte pour detecter les sophismes:\n\n{text[:3000]}"
+                "Analyse ce texte pour detecter les sophismes:\n\n"
+                + selected_text(text, 3000, "french_fallacy_llm")
             )
 
             response = await client.chat.completions.create(

--- a/argumentation_analysis/agents/core/political/stakes_extractor.py
+++ b/argumentation_analysis/agents/core/political/stakes_extractor.py
@@ -14,6 +14,8 @@ import json
 import logging
 from typing import Any, Awaitable, Callable, Dict, List, Optional
 
+from argumentation_analysis.core.reading_window import selected_text
+
 logger = logging.getLogger("StakesExtractor")
 
 
@@ -29,6 +31,7 @@ async def _default_chat_completion(client: Any, **kwargs: Any) -> Any:
     """
     return await client.chat.completions.create(**kwargs)
 
+
 EXTRACTION_PROMPT = (
     "You are a political-rhetorical analyst. Analyse the following discourse excerpt "
     "and extract FOUR elements in strict JSON format.\n\n"
@@ -39,7 +42,7 @@ EXTRACTION_PROMPT = (
     '   - "evidence_indices": list of integers referencing argument positions '
     "(0-based) that support this stake identification\n\n"
     '2. "stakeholders": List of objects, each with:\n'
-    "   - \"name\": {name_instruction}\n"
+    '   - "name": {name_instruction}\n'
     '   - "role": who they are in this discourse (speaker, opponent, audience, '
     "authority, institution, group)\n"
     '   - "stance": one of for, against, ambivalent, uncommitted\n'
@@ -113,7 +116,7 @@ class StakesExtractor:
             "\n".join(args_lines) if args_lines else "(no arguments extracted)"
         )
 
-        excerpt = (raw_text or "")[:3000]
+        excerpt = selected_text(raw_text or "", 3000, "stakes_extractor")
 
         # Epic #1258 / Track 1 #1259 — when the working state is deanonymized,
         # instruct the LLM to emit REAL stakeholder names (from source metadata);

--- a/argumentation_analysis/core/reading_window.py
+++ b/argumentation_analysis/core/reading_window.py
@@ -125,3 +125,46 @@ def select_reading_head(
         if 0 <= nl < offset + stride:
             offset = nl + 1
     return WindowSelection(offset, window, STATUS_SELECTED)
+
+
+def selected_text(text: str, window: int, site: str, state: object = None) -> str:
+    """#1737 step 3 wiring point: the slice a reading site feeds onward.
+
+    Computes the selection (pure, deterministic), records it on the shared
+    state when one is reachable, and returns the window slice. Sites with
+    access to the shared state pass it (``context['_state_object']`` in the
+    invoke layer, ``self.state`` in managers) so the status reaches the
+    report; stateless components call without it and still get the computed
+    slice. A state object that cannot record is a wiring bug, not a
+    condition to shrug off: it fails loud (#1019) rather than silently
+    dropping the status.
+    """
+    selection = select_reading_head(text, window)
+    if state is not None:
+        recorder = getattr(state, "record_reading_window", None)
+        if recorder is None:
+            raise TypeError(
+                f"reading site '{site}': state {type(state).__name__} has no "
+                "record_reading_window — pass the shared state or None, not "
+                "an unrelated object"
+            )
+        recorder(site, selection)
+    return text[selection.offset : selection.offset + window]
+
+
+def reading_state_from_context(context: object) -> object:
+    """Resolve the shared state from a workflow context dict (#1737 step 3).
+
+    The workflow executor writes the shared state as ``_state_object``
+    (preferred) or ``unified_state``. Returns None when no
+    ``UnifiedAnalysisState`` is reachable — stateless callers then skip the
+    recording instead of guessing at an unrelated object.
+    """
+    state = None
+    if isinstance(context, dict):
+        state = context.get("_state_object") or context.get("unified_state")
+    if state is None:
+        return None
+    from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+
+    return state if isinstance(state, UnifiedAnalysisState) else None

--- a/argumentation_analysis/core/shared_state.py
+++ b/argumentation_analysis/core/shared_state.py
@@ -145,9 +145,26 @@ class RhetoricalAnalysisState:
         self.errors: List[Dict[str, Any]] = []
         self.final_conclusion = None
         self._next_agent_designated = None
+        # #1737: dernière sélection de fenêtre de lecture par site —
+        # {site: {"status": ..., "offset": ..., "window": ...}}. Écrit par
+        # reading_window.selected_text, lu par le rapport (build_narrative).
+        self.reading_window_status: Dict[str, Dict[str, Any]] = {}
         state_logger.debug(
             f"Nouvelle instance RhetoricalAnalysisState créée (id: {id(self)}) avec texte (longueur: {len(initial_text)})."
         )
+
+    def record_reading_window(self, site: str, selection: Any) -> None:
+        """#1737 — enregistre la sélection de fenêtre d'un site de lecture.
+
+        Le statut tri-état (selected / no_punctuated_span_found / empty_input
+        / short_input) doit rester visible jusqu'au rapport : un statut que
+        personne ne relit est la forme #1019.
+        """
+        self.reading_window_status[site] = {
+            "status": getattr(selection, "status", str(selection)),
+            "offset": getattr(selection, "offset", 0),
+            "window": getattr(selection, "window", 0),
+        }
 
     def _generate_id(self, prefix: str, current_dict_or_list: Any) -> str:
         """Génère un ID simple basé sur la taille actuelle."""

--- a/argumentation_analysis/evaluation/judge.py
+++ b/argumentation_analysis/evaluation/judge.py
@@ -9,6 +9,8 @@ import logging
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
+from argumentation_analysis.core.reading_window import selected_text
+
 logger = logging.getLogger("evaluation.judge")
 
 JUDGE_SYSTEM_PROMPT = """You are an expert evaluator of argumentation analysis quality.
@@ -96,7 +98,7 @@ class LLMJudge:
             results_str = results_str[:12000] + "\n... [summarized]"
 
         user_msg = JUDGE_USER_TEMPLATE.format(
-            input_text=input_text[:2000],
+            input_text=selected_text(input_text, 2000, "judge"),
             workflow_name=workflow_name,
             analysis_results=results_str,
         )

--- a/argumentation_analysis/orchestration/collaborative_debate.py
+++ b/argumentation_analysis/orchestration/collaborative_debate.py
@@ -21,6 +21,11 @@ import os
 import time
 from typing import Any, Dict, List, Optional
 
+from argumentation_analysis.core.reading_window import (
+    reading_state_from_context,
+    selected_text,
+)
+
 logger = logging.getLogger("CollaborativeDebate")
 
 
@@ -145,7 +150,16 @@ async def _invoke_collaborative_analysis(
         for i, s in enumerate(sentences[:6]):
             arg_lines.append(f"S{i + 1}. {s}")
 
-    argument_text = "\n".join(arg_lines) if arg_lines else input_text[:1500]
+    argument_text = (
+        "\n".join(arg_lines)
+        if arg_lines
+        else selected_text(
+            input_text,
+            1500,
+            "collaborative_debate",
+            state=reading_state_from_context(context),
+        )
+    )
 
     # Quality context if available
     quality_summary = ""

--- a/argumentation_analysis/orchestration/conversational_orchestrator.py
+++ b/argumentation_analysis/orchestration/conversational_orchestrator.py
@@ -30,6 +30,7 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 import semantic_kernel as sk
 from semantic_kernel.agents import ChatCompletionAgent
 
+from argumentation_analysis.core.reading_window import selected_text
 from argumentation_analysis.orchestration.invoke_callables import (
     LLMBudgetExceeded,
     _bump_sk_budget,
@@ -95,7 +96,7 @@ def _detect_language(text: str) -> str:
     Distinguishes DE, FR, EN based on common function words and articles.
     Returns ISO 639-1 code: 'de', 'fr', 'en', or 'unknown'.
     """
-    sample = text[:3000].lower()
+    sample = selected_text(text, 3000, "detect_language").lower()
     scores: Dict[str, int] = {"de": 0, "fr": 0, "en": 0}
 
     de_markers = [

--- a/argumentation_analysis/orchestration/hierarchical/strategic/manager.py
+++ b/argumentation_analysis/orchestration/hierarchical/strategic/manager.py
@@ -20,6 +20,7 @@ import uuid
 from argumentation_analysis.orchestration.hierarchical.strategic.state import (
     StrategicState,
 )
+from argumentation_analysis.core.reading_window import selected_text
 from argumentation_analysis.paths import DATA_DIR, RESULTS_DIR
 from argumentation_analysis.core.communication import (
     MessageMiddleware,
@@ -347,7 +348,9 @@ class StrategicManager:
             self.logger.info("No raw_text available for LLM objectives, using fallback")
             return self._fallback_objectives()
 
-        text_preview = text[:2000]
+        text_preview = selected_text(
+            text, 2000, "strategic_objectives", state=self._unified_state
+        )
 
         # Epic #1258 / Track 1 #1259 — the opaque-ID discipline (lines below) is
         # dropped when the working state is deanonymized, so strategic objectives

--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -17,6 +17,11 @@ import time
 from contextlib import contextmanager
 from typing import Dict, Any, Awaitable, Callable, Iterator, Optional, List, Tuple
 
+from argumentation_analysis.core.reading_window import (
+    reading_state_from_context,
+    selected_text,
+)
+
 logger = logging.getLogger("UnifiedPipeline")
 
 # #1019: Preflight solver availability check (module-level, runs once)
@@ -1259,7 +1264,14 @@ async def _invoke_counter_argument(
                     targets.append(f"[quality={score:.1f}/10] {text}")
 
             if not targets:
-                targets = [input_text[:500]]
+                targets = [
+                    selected_text(
+                        input_text,
+                        500,
+                        "counter_argument",
+                        state=reading_state_from_context(context),
+                    )
+                ]
 
             llm_counters = await _generate_counters_for_targets(
                 client, model_id, targets
@@ -1608,7 +1620,14 @@ async def _invoke_debate_analysis(
                     )
 
             debate_material = (
-                "\n\n".join(debate_parts) if debate_parts else input_text[:1500]
+                "\n\n".join(debate_parts)
+                if debate_parts
+                else selected_text(
+                    input_text,
+                    1500,
+                    "debate_analysis",
+                    state=reading_state_from_context(context),
+                )
             )
 
             det_params = _get_determinism_params()
@@ -2076,7 +2095,14 @@ async def _invoke_governance(
                     context_parts.append("Formal inconsistency detected in PL/FOL")
 
             deliberation_input = (
-                "\n\n".join(context_parts) if context_parts else input_text[:2000]
+                "\n\n".join(context_parts)
+                if context_parts
+                else selected_text(
+                    input_text,
+                    2000,
+                    "governance",
+                    state=reading_state_from_context(context),
+                )
             )
 
             det_params = _get_determinism_params()
@@ -6087,7 +6113,15 @@ async def _invoke_fact_extraction(
                     model=model_id,
                     messages=[
                         {"role": "system", "content": system_content},
-                        {"role": "user", "content": input_text[:3000]},
+                        {
+                            "role": "user",
+                            "content": selected_text(
+                                input_text,
+                                3000,
+                                "fact_extraction",
+                                state=reading_state_from_context(context),
+                            ),
+                        },
                     ],
                     **llm_kwargs,
                 )
@@ -6332,6 +6366,14 @@ async def _invoke_propositional_logic(
                 client, model_id = _get_openai_client()
                 if client is not None and input_text and len(input_text) > 100:
 
+                    # #1737: the phase's reading window — one selection, two
+                    # feeds (pass 1 inventory + whole-text pass below).
+                    pl_reading = selected_text(
+                        input_text,
+                        4000,
+                        "propositional_logic",
+                        state=reading_state_from_context(context),
+                    )
                     # ── Pass 1: Atom inventory from full source text ──
                     pass1_prompt = (
                         "You are an expert in propositional logic. Your task is to identify "
@@ -6339,7 +6381,7 @@ async def _invoke_propositional_logic(
                         "Output a JSON object with a single key 'propositions' mapping to a "
                         "list of strings. Each string is an atomic proposition name in "
                         "lowercase snake_case (e.g. 'is_mortal', 'foreign_threat').\n\n"
-                        f"Text:\n{input_text[:4000]}"
+                        f"Text:\n{pl_reading}"
                     )
                     det_params = _get_determinism_params()
                     pass1_resp = await _guarded_chat_completion(
@@ -6384,7 +6426,7 @@ async def _invoke_propositional_logic(
 
                         async def _pl_batch_coro(_batch: list[str]) -> list[str]:
                             if len(_batch) == 1:
-                                _texts_block = f"Text:\n{_batch[0][:2000]}"
+                                _texts_block = f"Text:\n{selected_text(_batch[0], 2000, 'propositional_batch_atoms')}"
                             else:
                                 _parts = [
                                     f"Text {_i+1}:\n{_a[:1500]}"
@@ -6454,7 +6496,7 @@ async def _invoke_propositional_logic(
                                 "- Use ONLY the propositions from the list below.\n"
                                 "- Operators: ! (not), && (and), || (or), => (implies), <=> (iff)\n"
                                 "- Output JSON with key 'formulas' (list of strings).\n\n"
-                                f"Text:\n{input_text[:4000]}\n\n"
+                                f"Text:\n{pl_reading}\n\n"
                                 f"Allowed propositions:\n{_json.dumps({'propositions': shared_atoms}, indent=2)}"
                             )
                             wt_resp = await _guarded_chat_completion(
@@ -6679,6 +6721,10 @@ async def _invoke_fol_reasoning(
     those validated formulas. Otherwise falls back to template generation.
     (#208-H: wire NL-to-logic as pre-processing)
     """
+    # #1737: keep the untouched document for reading-window selection — the
+    # directive prepend below would otherwise have the selector judge the
+    # directives (punctuated prose) and read them instead of the corpus.
+    _doc_text_fol = input_text
     # RA-4 #1049 item 3: inject strategic directives for LLM-guided FOL translation
     _strat_text_fol, _strat_ids_fol = _get_strategic_directives(context)
     if _strat_text_fol:
@@ -6762,6 +6808,14 @@ async def _invoke_fol_reasoning(
                 client, model_id = _get_openai_client()
                 if client is not None and input_text and len(input_text) > 100:
 
+                    # #1737: reading window on the ORIGINAL document (not the
+                    # directive-prepended input_text).
+                    fol_reading = selected_text(
+                        _doc_text_fol,
+                        4000,
+                        "fol_reasoning",
+                        state=reading_state_from_context(context),
+                    )
                     # ── Pass 1: Shared FOL signature from full text ──
                     pass1_prompt = (
                         "You are a formal logic expert. Analyze the text and extract a "
@@ -6778,7 +6832,7 @@ async def _invoke_fol_reasoning(
                         "- Predicates: CamelCase, list arg sorts\n"
                         "- Constants: lowercase\n"
                         '- If unsure about sort, use "Thing"\n\n'
-                        f"Text:\n{input_text[:4000]}"
+                        f"Text:\n{fol_reading}"
                     )
                     det_params = _get_determinism_params()
                     pass1_resp = await _guarded_chat_completion(
@@ -6830,7 +6884,7 @@ async def _invoke_fol_reasoning(
 
                             async def _fol_batch_coro(_batch: list[str]) -> list[str]:
                                 if len(_batch) == 1:
-                                    _texts_block = f"Text:\n{_batch[0][:2000]}"
+                                    _texts_block = f"Text:\n{selected_text(_batch[0], 2000, 'fol_batch_signature')}"
                                 else:
                                     _parts = [
                                         f"Text {_i+1}:\n{_a[:1500]}"

--- a/argumentation_analysis/orchestration/structured_arg_translator.py
+++ b/argumentation_analysis/orchestration/structured_arg_translator.py
@@ -44,6 +44,8 @@ import logging
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Tuple
 
+from argumentation_analysis.core.reading_window import selected_text
+
 logger = logging.getLogger("UnifiedPipeline")
 
 
@@ -306,7 +308,8 @@ async def _llm_extract_relations(
         "Respond with ONLY a JSON object of this shape:\n" + shape
     )
     user_content = (
-        f"Source text (excerpt):\n{input_text[:3000]}\n\n"
+        f"Source text (excerpt):\n"
+        f"{selected_text(input_text, 3000, 'structured_arg_relations')}\n\n"
         f"Arguments (id → text):\n[{inventory_json}]\n\n"
         f"Return the {relation_kind} JSON."
     )

--- a/argumentation_analysis/plugins/coordinated_logic_plugin.py
+++ b/argumentation_analysis/plugins/coordinated_logic_plugin.py
@@ -17,6 +17,8 @@ from typing import List
 
 from semantic_kernel.functions import kernel_function
 
+from argumentation_analysis.core.reading_window import selected_text
+
 logger = logging.getLogger(__name__)
 
 
@@ -26,9 +28,21 @@ logger = logging.getLogger(__name__)
 # modal-free source returns an honest-empty inventory WITHOUT an LLM call
 # (anti-theater #1019: no fabricated modal atoms on non-modal text).
 MODAL_CUES: List[str] = [
-    "doit", "faut", "peut", "necessairement", "nécessairement",
-    "possible", "obligatoire", "interdit", "permis", "exige",
-    "exigeons", "devons", "pourront", " pourraient", "devraient",
+    "doit",
+    "faut",
+    "peut",
+    "necessairement",
+    "nécessairement",
+    "possible",
+    "obligatoire",
+    "interdit",
+    "permis",
+    "exige",
+    "exigeons",
+    "devons",
+    "pourront",
+    " pourraient",
+    "devraient",
 ]
 
 
@@ -102,7 +116,9 @@ class CoordinatedLogicPlugin:
     )
     async def extract_shared_pl_atoms(self, full_text: str) -> str:
         if not full_text or len(full_text) < 100:
-            return json.dumps({"shared_atoms": [], "error": "Text too short for atom extraction"})
+            return json.dumps(
+                {"shared_atoms": [], "error": "Text too short for atom extraction"}
+            )
 
         client, model_id, _ = _get_openai_client()
         if client is None:
@@ -114,7 +130,7 @@ class CoordinatedLogicPlugin:
             "Output a JSON object with a single key 'propositions' mapping to a "
             "list of strings. Each string is an atomic proposition name in "
             "lowercase snake_case (e.g. 'is_mortal', 'foreign_threat').\n\n"
-            f"Text:\n{full_text[:4000]}"
+            f"Text:\n{selected_text(full_text, 4000, 'coordinated_pl_atoms')}"
         )
 
         try:
@@ -125,7 +141,9 @@ class CoordinatedLogicPlugin:
             raw = resp.choices[0].message.content or ""
             data = _parse_json_from_llm(raw)
             raw_atoms = data.get("propositions", [])
-            valid_atoms = [a for a in raw_atoms if re.match(r"^[a-zA-Z_][a-zA-Z0-9_]*$", a)]
+            valid_atoms = [
+                a for a in raw_atoms if re.match(r"^[a-zA-Z_][a-zA-Z0-9_]*$", a)
+            ]
 
             logger.info(f"PL Pass 1: {len(valid_atoms)} atoms extracted from full text")
             return json.dumps({"shared_atoms": valid_atoms, "count": len(valid_atoms)})
@@ -143,11 +161,20 @@ class CoordinatedLogicPlugin:
     )
     async def extract_shared_fol_signature(self, full_text: str) -> str:
         if not full_text or len(full_text) < 100:
-            return json.dumps({"sorts": {}, "predicates": {}, "constants": {}, "error": "Text too short"})
+            return json.dumps(
+                {
+                    "sorts": {},
+                    "predicates": {},
+                    "constants": {},
+                    "error": "Text too short",
+                }
+            )
 
         client, model_id, _ = _get_openai_client()
         if client is None:
-            return json.dumps({"sorts": {}, "predicates": {}, "constants": {}, "error": "No API key"})
+            return json.dumps(
+                {"sorts": {}, "predicates": {}, "constants": {}, "error": "No API key"}
+            )
 
         prompt = (
             "You are a formal logic expert. Analyze the text and extract a "
@@ -164,7 +191,7 @@ class CoordinatedLogicPlugin:
             "- Predicates: CamelCase, list arg sorts\n"
             "- Constants: lowercase\n"
             '- If unsure about sort, use "Thing"\n\n'
-            f"Text:\n{full_text[:4000]}"
+            f"Text:\n{selected_text(full_text, 4000, 'coordinated_fol_signature')}"
         )
 
         try:
@@ -185,10 +212,14 @@ class CoordinatedLogicPlugin:
                 f"FOL Pass 1: {len(sorts)} sorts, {len(predicates)} predicates, "
                 f"{sum(len(v) for v in sorts.values())} constants"
             )
-            return json.dumps({"sorts": sorts, "predicates": predicates, "constants": constants})
+            return json.dumps(
+                {"sorts": sorts, "predicates": predicates, "constants": constants}
+            )
         except Exception as e:
             logger.debug(f"FOL signature extraction failed: {e}")
-            return json.dumps({"sorts": {}, "predicates": {}, "constants": {}, "error": str(e)})
+            return json.dumps(
+                {"sorts": {}, "predicates": {}, "constants": {}, "error": str(e)}
+            )
 
     @kernel_function(
         name="extract_shared_modal_signature",
@@ -206,17 +237,23 @@ class CoordinatedLogicPlugin:
     async def extract_shared_modal_signature(self, full_text: str) -> str:
         empty = json.dumps({"atoms": [], "modal_present": False})
         if not full_text or len(full_text) < 100:
-            return json.dumps({"atoms": [], "modal_present": False, "error": "Text too short"})
+            return json.dumps(
+                {"atoms": [], "modal_present": False, "error": "Text too short"}
+            )
 
         # Anti-theater #1019 (#1396): a modal-free source yields an honest-empty
         # inventory WITHOUT burning an LLM call. This is the cue-gate.
         if not _has_modal_cues(full_text):
-            logger.info("Modal Pass 1: no modal cues -> honest-empty signature (no LLM call)")
+            logger.info(
+                "Modal Pass 1: no modal cues -> honest-empty signature (no LLM call)"
+            )
             return empty
 
         client, model_id, _ = _get_openai_client()  # type: ignore[no-untyped-call]  # 5th call site (#1396)
         if client is None:
-            return json.dumps({"atoms": [], "modal_present": False, "error": "No API key"})
+            return json.dumps(
+                {"atoms": [], "modal_present": False, "error": "No API key"}
+            )
 
         prompt = (
             "You are a formal logic expert. Analyze the text and extract a "
@@ -226,7 +263,7 @@ class CoordinatedLogicPlugin:
             "Output a JSON object with:\n"
             '- "atoms": list of atom identifiers, each matching [A-Za-z][A-Za-z0-9]* '
             "(NO underscores -- Tweety MlParser rejects them). CamelCase or "
-            "lowercase alphanum, e.g. [\"citizen\", \"obeysLaw\", \"peace\"].\n"
+            'lowercase alphanum, e.g. ["citizen", "obeysLaw", "peace"].\n'
             '- "modal_flavors": list subset of ["alethic", "deontic"] present.\n\n'
             "Rules:\n"
             "- Atoms are PROPOSITIONS (what is necessary/possible/obligatory), "
@@ -247,10 +284,14 @@ class CoordinatedLogicPlugin:
             sig_data = _parse_json_from_llm(raw)
             raw_atoms = sig_data.get("atoms", []) or []
             # Defense-in-depth: filter to legal MlParser identifiers (#1327).
-            valid_atoms = [a for a in raw_atoms if re.match(r"^[A-Za-z][A-Za-z0-9]*$", a)]
+            valid_atoms = [
+                a for a in raw_atoms if re.match(r"^[A-Za-z][A-Za-z0-9]*$", a)
+            ]
             flavors = sig_data.get("modal_flavors", []) or []
 
-            logger.info(f"Modal Pass 1: {len(valid_atoms)} modal atoms, flavors={flavors}")
+            logger.info(
+                f"Modal Pass 1: {len(valid_atoms)} modal atoms, flavors={flavors}"
+            )
             return json.dumps(
                 {
                     "atoms": valid_atoms,
@@ -282,7 +323,11 @@ class CoordinatedLogicPlugin:
             return json.dumps({"formulas": [], "error": "No API key"})
 
         try:
-            atoms = json.loads(shared_atoms) if isinstance(shared_atoms, str) else shared_atoms
+            atoms = (
+                json.loads(shared_atoms)
+                if isinstance(shared_atoms, str)
+                else shared_atoms
+            )
         except json.JSONDecodeError:
             return json.dumps({"formulas": [], "error": "Invalid shared_atoms JSON"})
 
@@ -298,7 +343,7 @@ class CoordinatedLogicPlugin:
             "- Operators: ! (not), && (and), || (or), => (implies), <=> (iff)\n"
             "- Output a JSON object with a single key 'formulas' mapping to a "
             "list of formula strings.\n\n"
-            f"Text:\n{argument_text[:2000]}\n\n"
+            f"Text:\n{selected_text(argument_text, 2000, 'coordinated_pl_formulas')}\n\n"
             f"Allowed propositions:\n{atoms_json}"
         )
 
@@ -311,7 +356,9 @@ class CoordinatedLogicPlugin:
             data = _parse_json_from_llm(raw)
             formulas = [f for f in data.get("formulas", []) if f]
 
-            logger.info(f"PL Pass 2: {len(formulas)} formulas with {len(atoms)} shared atoms")
+            logger.info(
+                f"PL Pass 2: {len(formulas)} formulas with {len(atoms)} shared atoms"
+            )
             return json.dumps({"formulas": formulas, "used_atoms": atoms})
         except Exception as e:
             logger.debug(f"PL formula generation failed: {e}")
@@ -334,9 +381,15 @@ class CoordinatedLogicPlugin:
             return json.dumps({"formulas": [], "error": "No API key"})
 
         try:
-            sig = json.loads(shared_signature) if isinstance(shared_signature, str) else shared_signature
+            sig = (
+                json.loads(shared_signature)
+                if isinstance(shared_signature, str)
+                else shared_signature
+            )
         except json.JSONDecodeError:
-            return json.dumps({"formulas": [], "error": "Invalid shared_signature JSON"})
+            return json.dumps(
+                {"formulas": [], "error": "Invalid shared_signature JSON"}
+            )
 
         if not sig or not argument_text:
             return json.dumps({"formulas": []})
@@ -352,7 +405,7 @@ class CoordinatedLogicPlugin:
             "- Quantifiers: forall X: (...), exists X: (...)\n"
             "- Operators: ! (not), && (and), || (or), => (implies)\n"
             "- Output JSON with key 'formulas' (list of formula strings)\n\n"
-            f"Text:\n{argument_text[:2000]}\n\n"
+            f"Text:\n{selected_text(argument_text, 2000, 'coordinated_fol_formulas')}\n\n"
             f"Signature:\n{sig_json}"
         )
 

--- a/argumentation_analysis/plugins/narrative_synthesis_plugin.py
+++ b/argumentation_analysis/plugins/narrative_synthesis_plugin.py
@@ -158,8 +158,7 @@ def build_narrative(state: Any) -> str:
             f"hypothese(s) de lecture predefinie(s): {coherent} coherente(s), "
             f"{incoherent} incoherente(s)."
             + (
-                f" {unclassified} non classifiable(s) "
-                f"(cle 'coherent' absente)."
+                f" {unclassified} non classifiable(s) " f"(cle 'coherent' absente)."
                 if unclassified
                 else ""
             )
@@ -195,6 +194,44 @@ def build_narrative(state: Any) -> str:
         formal_str = ", ".join(formal_parts)
         parts.append(
             f"L'analyse formelle a produit {formal_count} resultat(s) ({formal_str})."
+        )
+
+    # ── Reading-window status (#1737) ───────────────────────────────
+    # The reader side of the status contract: a status nobody reads is the
+    # #1019 shape. This block sits BEFORE the empty-parts guard on purpose:
+    # a non-prose head typically ALSO empties the analysis (everything is
+    # extracted from the same head), so the warning must survive alone —
+    # the "no data" fallback would otherwise swallow the very signal that
+    # explains why there is no data.
+    rw = getattr(state, "reading_window_status", {})
+    flagged = {
+        site: v
+        for site, v in rw.items()
+        if isinstance(v, dict) and v.get("status") != "selected"
+    }
+    moved = {
+        site: v
+        for site, v in rw.items()
+        if isinstance(v, dict)
+        and v.get("status") == "selected"
+        and v.get("offset", 0) > 0
+    }
+    if flagged:
+        detail = ", ".join(
+            f"{site}={v.get('status')}" for site, v in sorted(flagged.items())
+        )
+        parts.append(
+            f"Avertissement fenetre de lecture: {detail}. "
+            f"Les sites concernes n'ont pas trouve de span ponctue de la "
+            f"taille de leur fenetre — verifier la nature du document en tete."
+        )
+    if moved and not flagged:
+        detail = ", ".join(
+            f"{site} (offset {v.get('offset')})" for site, v in sorted(moved.items())
+        )
+        parts.append(
+            f"Fenetre de lecture: la tete du document n'etait pas de la prose "
+            f"analyisable; la lecture a ete deplacee pour {detail}."
         )
 
     if not parts:
@@ -576,9 +613,7 @@ def _build_prose_prompt(synthesis_result: Dict[str, Any]) -> str:
 
     # Epic #1258 / Track 1 #1259 — drop the opaque-ID rule when deanonymized.
     deanonymized = bool(synthesis_result.get("deanonymized", True))
-    instructions = _PROSE_INSTRUCTIONS + (
-        "" if deanonymized else _PROSE_OPAQUE_RULE
-    )
+    instructions = _PROSE_INSTRUCTIONS + ("" if deanonymized else _PROSE_OPAQUE_RULE)
 
     return (
         f"{instructions}\n\n"

--- a/argumentation_analysis/services/ai_shield/layers/llm_validator.py
+++ b/argumentation_analysis/services/ai_shield/layers/llm_validator.py
@@ -10,6 +10,7 @@ import os
 from typing import Any, Dict, Optional
 
 from argumentation_analysis.services.ai_shield.shield import ShieldLayer, LayerResult
+from argumentation_analysis.core.reading_window import selected_text
 
 logger = logging.getLogger(__name__)
 
@@ -43,12 +44,16 @@ class LLMValidatorLayer(ShieldLayer):
         use_openrouter = bool(openrouter_base_url and openrouter_api_key)
         if use_openrouter and not api_key:
             self._api_key = openrouter_api_key
-            self._model = model or os.environ.get("OPENROUTER_CHAT_MODEL_ID", "gpt-5-mini")
+            self._model = model or os.environ.get(
+                "OPENROUTER_CHAT_MODEL_ID", "gpt-5-mini"
+            )
             self._base_url = openrouter_base_url
         else:
             self._api_key = api_key or os.environ.get("OPENAI_API_KEY", "")
             self._model = model or os.environ.get("OPENAI_CHAT_MODEL_ID", "gpt-5-mini")
-            self._base_url = os.environ.get("OPENAI_BASE_URL", "https://api.openai.com/v1")
+            self._base_url = os.environ.get(
+                "OPENAI_BASE_URL", "https://api.openai.com/v1"
+            )
 
     def validate(self, text: str, **kwargs) -> LayerResult:
         """Validate input using LLM analysis.
@@ -85,7 +90,10 @@ class LLMValidatorLayer(ShieldLayer):
                             '"explanation": "brief reason"}'
                         ),
                     },
-                    {"role": "user", "content": text[:2000]},  # Cap input length
+                    {
+                        "role": "user",
+                        "content": selected_text(text, 2000, "ai_shield_llm_validator"),
+                    },  # Cap input length
                 ],
                 max_tokens=200,
             )

--- a/argumentation_analysis/services/nl_to_logic.py
+++ b/argumentation_analysis/services/nl_to_logic.py
@@ -21,6 +21,8 @@ import re
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Tuple
 
+from argumentation_analysis.core.reading_window import selected_text
+
 logger = logging.getLogger(__name__)
 
 # ── Operator mappings ────────────────────────────────────────────────────
@@ -410,11 +412,16 @@ class NLToLogicTranslator:
                 ]
 
                 if attempt == 1:
-                    messages.append({"role": "user", "content": text[:2000]})
+                    messages.append(
+                        {
+                            "role": "user",
+                            "content": selected_text(text, 2000, "nl_to_logic"),
+                        }
+                    )
                 else:
                     retry_msg = retry_template.format(
                         error=last_error,
-                        original=text[:1000],
+                        original=selected_text(text, 1000, "nl_to_logic_retry"),
                         formula=last_formula,
                         formulas=last_formula,
                     )

--- a/argumentation_analysis/utils/analysis_config.py
+++ b/argumentation_analysis/utils/analysis_config.py
@@ -24,6 +24,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 
 from argumentation_analysis.config.settings import settings
+from argumentation_analysis.core.reading_window import selected_text
 
 
 class AnalysisMode(Enum):
@@ -309,8 +310,9 @@ class UnifiedAnalysisPipeline:
             agent.setup_agent_components(llm_service_id="openai")
 
             # Analyse selon le mode - utiliser la méthode appropriée
+            # #1737: reading window instead of a fixed head slice
             analysis_result = await agent.analyze_text(
-                text[:1000]
+                selected_text(text, 1000, "analysis_informal")
             )  # Limite pour performance
 
             return {

--- a/scripts/measure_1737_axis_remesure.py
+++ b/scripts/measure_1737_axis_remesure.py
@@ -1,0 +1,259 @@
+"""#1737 step 4 — before/after re-measure of the #1710 attack axes on corpus_B.
+
+#1710 measured a famine of ATTACK proposals (dung / weighted / setaf / aspic
+contradictions) on corpus_B. Those measurements read the corpus_B TOC head
+(offset 0) — every reading site sliced ``text[:3000]`` without checking what
+the head is. Step 3 wired the reading sites to the computed selection
+(``reading_window.selected_text``), so the SAME axes now read prose at the
+selected offset (~15001).
+
+This harness measures the axes BEFORE and AFTER with the SAME script and the
+SAME inputs: run it on main (sites unwired, offset 0) for BEFORE, run it on
+the wired branch for AFTER. The key design point: the full text is passed
+everywhere — on main the unwired sites truncate to the head (the old
+behaviour), on the wired branch the selector moves the window (the new
+behaviour). No branch-dependent input, nothing pre-truncated.
+
+Per draw (production path, no prompt variant, no seed):
+  1. real ``_invoke_fact_extraction(text)`` -> inventory size
+  2. for each attack axis (dung_attacks, weighted_attacks, setaf_attacks,
+     aspic_rules): real ``translate_to_*_attacks`` -> raw proposals / edges
+  3. selection probe: the computed offset + status (deterministic)
+
+probe2 (R814): the deterministic selection part runs twice and must hash
+identically — never compare axes if the window itself is not reproducible.
+
+Privacy HARD: in-memory corpus, opaque IDs, artifact under gitignored
+``evaluation/results/real_analysis/``.
+
+Usage:
+    conda run -n projet-is-roo-new --no-capture-output python scripts/measure_1737_axis_remesure.py --n 8 --label before
+    conda run -n projet-is-roo-new --no-capture-output python scripts/measure_1737_axis_remesure.py --n 8 --label after
+"""
+
+import argparse
+import asyncio
+import hashlib
+import json
+import math
+import os
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+os.chdir(Path(__file__).parent.parent)
+
+_env_path = Path(__file__).parent.parent / ".env"
+if _env_path.exists():
+    with open(_env_path, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line and not line.startswith("#") and "=" in line:
+                key, _, val = line.partition("=")
+                os.environ.setdefault(key.strip(), val.strip())
+
+from argumentation_analysis.core.utils.crypto_utils import derive_encryption_key  # noqa: E402
+from argumentation_analysis.core.io_manager import load_extract_definitions  # noqa: E402
+from argumentation_analysis.orchestration import structured_arg_translator as tr  # noqa: E402
+from argumentation_analysis.orchestration.invoke_callables import (  # noqa: E402
+    _invoke_fact_extraction,
+)
+from argumentation_analysis.orchestration.structured_arg_translator import (  # noqa: E402
+    translate_to_aspic_rules,
+    translate_to_dung_attacks,
+    translate_to_setaf_attacks,
+    translate_to_weighted_attacks,
+)
+from argumentation_analysis.core.reading_window import select_reading_head  # noqa: E402
+
+DATASET_PATH = Path("argumentation_analysis/data/extract_sources.json.gz.enc")
+CORPUS_B_SRC_IDX = 3
+RESULTS_DIR = Path("argumentation_analysis/evaluation/results/real_analysis")
+
+# How much of corpus_B is loaded. 30000 chars is past the TOC (prose starts
+# ~15000); +3000 window covers any selected offset with its full span.
+MAX_CHARS = 40000
+EXTRACTION_WINDOW = 3000
+
+AXES = {
+    "dung_attacks": translate_to_dung_attacks,
+    "weighted_attacks": translate_to_weighted_attacks,
+    "setaf_attacks": translate_to_setaf_attacks,
+    "aspic_rules": translate_to_aspic_rules,
+}
+
+_raw_llm: Dict[str, Dict[str, Any]] = {}
+_orig_llm = tr._llm_extract_relations
+
+
+async def _capture_llm(
+    input_text: str, arguments: List[str], relation_kind: str
+) -> Dict[str, Any]:
+    data = await _orig_llm(input_text, arguments, relation_kind)
+    _raw_llm[relation_kind] = data if isinstance(data, dict) else {}
+    return data
+
+
+tr._llm_extract_relations = _capture_llm
+
+
+def load_corpus_b(max_chars: int) -> str:
+    key = derive_encryption_key(os.environ["TEXT_CONFIG_PASSPHRASE"])
+    defs = load_extract_definitions(DATASET_PATH, key)
+    entry = defs[CORPUS_B_SRC_IDX]
+    text = entry.get("full_text", "") or ""
+    return text[:max_chars]
+
+
+def selection_probe(text: str, window: int) -> Dict[str, Any]:
+    sel = select_reading_head(text, window)
+    return {
+        "offset": sel.offset,
+        "status": sel.status,
+        "window": window,
+        "slice_hash": hashlib.sha256(
+            text[sel.offset : sel.offset + window].encode("utf-8")
+        ).hexdigest()[:16],
+    }
+
+
+def inventory_texts(extraction: Dict[str, Any]) -> List[str]:
+    out: List[str] = []
+    for a in extraction.get("arguments", []):
+        if isinstance(a, dict) and a.get("text"):
+            out.append(str(a["text"]))
+        elif a:
+            out.append(str(a))
+    return out
+
+
+async def one_draw(text: str) -> Dict[str, Any]:
+    _raw_llm.clear()
+    extraction = await _invoke_fact_extraction(text, {"_state_object": None})
+    arguments = inventory_texts(extraction)
+    rec: Dict[str, Any] = {
+        "n_arguments": len(arguments),
+        "extraction_status": extraction.get("extraction_status"),
+    }
+    if not arguments:
+        rec["axes"] = {
+            axis: {"raw_proposals": 0, "validated_edges": 0, "cause": "no_inventory"}
+            for axis in AXES
+        }
+        return rec
+    rec["axes"] = {}
+    for axis, translate in AXES.items():
+        outcome = await translate(text, arguments)
+        proposals = _raw_llm.get(axis, {}).get("attacks", [])
+        if not proposals and axis == "aspic_rules":
+            # ASPIC returns {"rules"/"contradictions"/"undercuts"}; the raw
+            # proposal count is the union of the three lists.
+            raw = _raw_llm.get(axis, {})
+            proposals = (
+                raw.get("rules", [])
+                + raw.get("contradictions", [])
+                + raw.get("undercuts", [])
+            )
+        rec["axes"][axis] = {
+            "raw_proposals": len(proposals) if isinstance(proposals, list) else 0,
+            "validated_edges": len(outcome.relations),
+            "cause": outcome.cause,
+        }
+    return rec
+
+
+def summarize(values: List[float]) -> Dict[str, Any]:
+    n = len(values)
+    mean = sum(values) / n if n else 0.0
+    var = sum((v - mean) ** 2 for v in values) / n if n else 0.0
+    return {
+        "values": values,
+        "min": min(values) if values else None,
+        "max": max(values) if values else None,
+        "mean": round(mean, 2),
+        "std": round(math.sqrt(var), 2),
+        "zero_rate": round(sum(1 for v in values if v == 0) / n, 3) if n else None,
+        "n": n,
+    }
+
+
+async def main_async(n: int, label: str, probe2: bool) -> None:
+    text = load_corpus_b(MAX_CHARS)
+    probe1 = selection_probe(text, EXTRACTION_WINDOW)
+
+    probe2_hash = None
+    if probe2:
+        probe2 = selection_probe(text, EXTRACTION_WINDOW)
+        h1 = hashlib.sha256(json.dumps(probe1, sort_keys=True).encode()).hexdigest()[:16]
+        h2 = hashlib.sha256(json.dumps(probe2, sort_keys=True).encode()).hexdigest()[:16]
+        if h1 != h2:
+            print("NON-DETERMINISM IN SELECTION — do not compare (R814)")
+            sys.exit(1)
+        probe2_hash = h2
+
+    draws: List[Dict[str, Any]] = []
+    for d in range(1, n + 1):
+        t0 = time.time()
+        rec = await one_draw(text)
+        rec["wall_s"] = round(time.time() - t0, 1)
+        draws.append(rec)
+        ax = ", ".join(
+            f"{a}={rec['axes'][a]['raw_proposals']}/{rec['axes'][a]['validated_edges']}"
+            for a in AXES
+        )
+        print(
+            f"[1737-{label}] corpus_B draw{d}: args={rec['n_arguments']} "
+            f"{ax} ({rec['wall_s']}s)"
+        )
+
+    summaries = {
+        axis: {
+            "raw_proposals": summarize([d["axes"][axis]["raw_proposals"] for d in draws]),
+            "validated_edges": summarize([d["axes"][axis]["validated_edges"] for d in draws]),
+        }
+        for axis in AXES
+    }
+    summaries["n_arguments"] = summarize([d["n_arguments"] for d in draws])
+
+    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    artifact = RESULTS_DIR / f"measure_1737_axis_remesure_{label}_{ts}.json"
+    with open(artifact, "w", encoding="utf-8") as f:
+        json.dump(
+            {
+                "generated": ts,
+                "label": label,
+                "corpus": "corpus_B",
+                "max_chars": MAX_CHARS,
+                "n_draws": n,
+                "selection": probe1,
+                "probe2_hash": probe2_hash,
+                "draws": draws,
+                "summaries": summaries,
+            },
+            f,
+            indent=2,
+        )
+
+    print(f"\n=== #1737 step-4 {label} — corpus_B (offset 0 head, unwired) ===" if label == "before" else f"\n=== #1737 step-4 {label} — corpus_B (selected offset {probe1['offset']}) ===")
+    print(f"selection: {probe1}")
+    for axis in AXES:
+        for metric in ("raw_proposals", "validated_edges"):
+            m = summaries[axis][metric]
+            print(
+                f"    {axis}.{metric}: {m['values']} | mean={m['mean']} "
+                f"std={m['std']} zero_rate={m['zero_rate']}"
+            )
+    print(f"artifact: {artifact}")
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--n", type=int, default=8, help="draws per axis (default 8)")
+    ap.add_argument("--label", required=True, choices=["before", "after"])
+    ap.add_argument("--probe2", action="store_true")
+    a = ap.parse_args()
+    asyncio.run(main_async(a.n, a.label, a.probe2))

--- a/tests/unit/argumentation_analysis/core/test_reading_window_wiring.py
+++ b/tests/unit/argumentation_analysis/core/test_reading_window_wiring.py
@@ -1,0 +1,156 @@
+# -*- coding: utf-8 -*-
+"""#1737 step 3 — wiring tests: site -> shared state -> report reader.
+
+The DoD's load-bearing test is the chain: a non-prose head must produce a
+STATUS that is recorded on the shared state by the site's helper call AND
+rendered by the report's reader (a status nobody displays is the #1019
+shape). The reader is verified at the report construction site
+(``build_narrative``), not in the module that writes the status.
+
+Non-regression at site level: on an already-prose corpus the helper must
+return EXACTLY the old fixed-head slice (``text[:N]``) — nothing moves.
+"""
+
+import pytest
+
+from argumentation_analysis.core.reading_window import (
+    STATUS_NO_PUNCTUATED_SPAN,
+    STATUS_SELECTED,
+    reading_state_from_context,
+    selected_text,
+)
+from argumentation_analysis.plugins.narrative_synthesis_plugin import (
+    build_narrative,
+)
+from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+
+
+def _prose_like(n_chars: int) -> str:
+    """Synthetic prose: long VARIED sentences (see test_reading_window.py)."""
+    sentences = [
+        "Le raisonnement déployé ici soutient une thèse précise, "
+        "appuyée sur des prémisses explicites, que l'auditoire peut examiner",
+        "Cette argumentation progressait par étapes successives, "
+        "chacune annoncée comme décisive, et pourtant toujours révisable",
+        "L'orateur concédait volontiers l'apparence d'une objection, "
+        "avant d'en retourner la force contre celui qui l'avait formulée",
+        "Une pareille construction suppose un auditoire patient, "
+        "disposé à suivre l'enchaînement des preuves jusqu'à sa conclusion",
+        "Le propos ne cherchait pas la conciliation, mais l'épreuve, "
+        "et cette préférence se lisait dans chaque transition du discours",
+        "Face à cette accumulation d'arguments circonstanciels, "
+        "la conclusion paraissait inévitable, bien qu'elle ne fût jamais dite",
+    ]
+    out = []
+    total = 0
+    i = 0
+    while total < n_chars:
+        out.append(sentences[i % len(sentences)] + ". ")
+        total += len(sentences[i % len(sentences)]) + 2
+        i += 1
+    return "".join(out)
+
+
+def _toc_like(n_chars: int) -> str:
+    """Synthetic TOC: short title lines (one per line), no sub-clause
+    punctuation — the corpus_B head shape (dates + page numbers)."""
+    entries = [
+        "Discours de Marseille 14 juillet 1990",
+        "Discours de Lyon 8 juin 1991",
+        "Allocution de Paris 12 mai 1992",
+        "Déclaration de Lille 3 mars 1993",
+    ]
+    out = []
+    total = 0
+    i = 0
+    while total < n_chars:
+        line = entries[i % len(entries)] + " page " + str(10 + i) + "\n"
+        out.append(line)
+        total += len(line)
+        i += 1
+    return "".join(out)
+
+
+class TestChainToReader:
+    """The status travels site -> state -> report and is VISIBLE there."""
+
+    def test_toc_head_status_is_rendered_by_the_report(self):
+        state = UnifiedAnalysisState(_toc_like(500))
+        toc = _toc_like(12000)
+
+        captured = selected_text(toc, 3000, "fact_extraction", state=state)
+
+        recorded = state.reading_window_status["fact_extraction"]
+        assert recorded["status"] == STATUS_NO_PUNCTUATED_SPAN
+        assert recorded["offset"] == 0
+        # Old behaviour preserved on a refused head: offset stays 0.
+        assert captured == toc[:3000]
+
+        narrative = build_narrative(state)
+        assert "Avertissement fenetre de lecture" in narrative
+        assert "fact_extraction=no_punctuated_span_found" in narrative
+
+    def test_prose_head_is_not_flagged_and_slice_is_identical(self):
+        state = UnifiedAnalysisState(_prose_like(500))
+        prose = _prose_like(12000)
+
+        captured = selected_text(prose, 3000, "fact_extraction", state=state)
+
+        recorded = state.reading_window_status["fact_extraction"]
+        assert recorded["status"] == STATUS_SELECTED
+        assert recorded["offset"] == 0
+        # Site-level non-regression: exactly the old fixed-head slice.
+        assert captured == prose[:3000]
+
+        narrative = build_narrative(state)
+        assert "Avertissement fenetre de lecture" not in narrative
+        assert "Fenetre de lecture" not in narrative
+
+    def test_moved_window_is_reported_as_information(self):
+        state = UnifiedAnalysisState(_prose_like(500))
+        text = _toc_like(10000) + _prose_like(10000)
+
+        selected_text(text, 3000, "fact_extraction", state=state)
+
+        recorded = state.reading_window_status["fact_extraction"]
+        assert recorded["status"] == STATUS_SELECTED
+        assert recorded["offset"] > 0
+
+        narrative = build_narrative(state)
+        assert "la lecture a ete deplacee" in narrative
+        assert "fact_extraction (offset" in narrative
+
+    def test_multiple_sites_all_surface(self):
+        state = UnifiedAnalysisState(_toc_like(500))
+        toc = _toc_like(12000)
+
+        selected_text(toc, 2000, "governance", state=state)
+        selected_text(toc, 1500, "debate_analysis", state=state)
+
+        narrative = build_narrative(state)
+        assert "governance=no_punctuated_span_found" in narrative
+        assert "debate_analysis=no_punctuated_span_found" in narrative
+
+
+class TestStateResolutionAndFailLoud:
+    """The wiring helper resolves the state; an unrelated object fails loud."""
+
+    def test_reading_state_from_context_prefers_state_object(self):
+        state = UnifiedAnalysisState("seed")
+        assert reading_state_from_context({"_state_object": state}) is state
+
+    def test_reading_state_from_context_falls_back_to_unified_state(self):
+        state = UnifiedAnalysisState("seed")
+        assert reading_state_from_context({"unified_state": state}) is state
+
+    def test_reading_state_from_context_none_without_state(self):
+        assert reading_state_from_context({}) is None
+        assert reading_state_from_context(None) is None
+        assert reading_state_from_context({"unified_state": "not-a-state"}) is None
+
+    def test_unrelated_state_object_fails_loud(self):
+        class NotAState:
+            pass
+
+        with pytest.raises(TypeError, match="has no record_reading_window"):
+            selected_text(_prose_like(500), 1000, "x", state=NotAState())


### PR DESCRIPTION
## Summary

#1737 étape 3 : les sites de lecture passent par la fenêtre **calculée** (étape 2), plus jamais une tranche fixe, et le statut tri-état remonte jusqu'à un **lecteur qui l'affiche** — l'étape 4 (re-mesure #1710 avant/après) est publiée ci-dessous.

## La liste des sites (le livrable de la DoD)

Tous passent par `selected_text(text, window, site, state)` (`argumentation_analysis/core/reading_window.py`) qui calcule la fenêtre (étape 2, déterministe, indépendant du classifieur) et enregistre la sélection sur `state.reading_window_status` quand un état partagé est joignable.

### 8 sites invoke (avec state — `reading_state_from_context(context)`)

| Site | Fenêtre | Où |
|---|---|---|
| `fact_extraction` | 3000 | `_invoke_fact_extraction` — extraction de faits |
| `governance` | 2000 | `_invoke_governance` — fallback délibération |
| `debate_analysis` | 1500 | `_invoke_debate_analysis` — fallback matériau de débat |
| `counter_argument` | 500 | `_invoke_counter_argument` — fallback cible quand l'extraction n'a rien rendu |
| `propositional_logic` | 4000 | `_invoke_propositional_logic` — UNE sélection, deux feeds (pass 1 inventaire + pass whole-text) |
| `fol_reasoning` | 4000 | `_invoke_fol_reasoning` — ⚠ sélection sur le texte ORIGINAL, capturé AVANT le préfixe de directives stratégiques : sinon le sélecteur jugerait les directives (prose ponctuée) et lirait quand même la TOC |
| `propositional_batch_atoms` | 2000 | `_invoke_propositional_logic` — pass 2 batch mono-argument |
| `fol_batch_signature` | 2000 | `_invoke_fol_reasoning` — pass 2 batch mono-argument |

### 15 sites composants (sans state — la sélection est quand même calculée)

| Site | Fenêtre | Fichier |
|---|---|---|
| `collaborative_debate` | 1500 | `orchestration/collaborative_debate.py` (a `context` → state) |
| `coordinated_pl_atoms` | 4000 | `plugins/coordinated_logic_plugin.py` pass 1 PL |
| `coordinated_fol_signature` | 4000 | idem pass 1 FOL |
| `coordinated_pl_formulas` | 2000 | idem pass 2 PL (argument) |
| `coordinated_fol_formulas` | 2000 | idem pass 2 FOL (argument) |
| `nl_to_logic` / `nl_to_logic_retry` | 2000/1000 | `services/nl_to_logic.py` |
| `ai_shield_llm_validator` | 2000 | `services/ai_shield/layers/llm_validator.py` |
| `judge` | 2000 | `evaluation/judge.py` — le juge regarde le MÊME texte que l'analysé |
| `stakes_extractor` | 3000 | `agents/core/political/stakes_extractor.py` |
| `analysis_informal` | 1000 | `utils/analysis_config.py` |
| `strategic_objectives` | 2000 | `orchestration/hierarchical/strategic/manager.py` (state = `self._unified_state`) |
| `detect_language` | 3000 | `orchestration/conversational_orchestrator.py` |
| `french_fallacy_llm` | 3000 | `adapters/french_fallacy_adapter.py` |
| `structured_arg_relations` | 3000 | `orchestration/structured_arg_translator.py` — l'excerpt des relations d'attaque |

## Le lecteur (statut ≠ #1019)

`build_narrative` (`plugins/narrative_synthesis_plugin.py`) rend le statut **au site de construction du rapport** :
- un statut ≠ `selected` → « Avertissement fenetre de lecture: fact_extraction=no_punctuated_span_found. Les sites concernes n'ont pas trouve de span ponctue... »
- une fenêtre `selected` déplacée (offset > 0) → « Fenetre de lecture: la tete du document n'etait pas de la prose analyisable; la lecture a ete deplacee pour fact_extraction (offset 15001). »

⚠ Le bloc fenêtre de lecture est placé **AVANT** le garde empty-parts : une tête non-prose vide AUSSI l'analyse (tout est extrait de la même tête) — le fallback « pas suffisamment de donnees » avalerait le signal qui explique le vide. C'est exactement l'entrée TOC : sur corpus_B avant correction, toute la chaîne rend des chiffres bien formés sur une table des matières.

## Non-régression au niveau des sites

`tests/unit/argumentation_analysis/core/test_reading_window_wiring.py` (8 tests) : sur un corpus **déjà en prose**, `selected_text` rend **exactement** l'ancienne tranche `text[:N]` (offset 0, statut `selected`, pas d'avertissement) — rien ne bouge pour les corpus qui lisent déjà de la prose. Sur une tête TOC synthétique, le statut `no_punctuated_span_found` est enregistré sur l'état partagé **et rendu** par le rapport (assertion sur la sortie). Un objet d'état qui ne sait pas enregistrer → TypeError loud (fail-loud #1019).

## Exclusions justifiées (hors liste de l'issue, ce ne sont pas des têtes de document)

- Libellés/snippets d'arguments **déjà extraits** (ex. `input_text[:200]` fallback target d'un contre-argument isolé, labels de mapping, libellés de topics/formules)
- Chaînes de programme formatées (`str(program)[:500]`)
- Troncature de stockage de sortie (`result[:500]`)
- Graines de titre d'état (`UnifiedAnalysisState(input_text[:200])` — jamais lues par un LLM)

## Étape 4 — re-mesure #1710 sur corpus_B (avant/après)

Anti-pendule respecté : #1710 est clos et sa conclusion tient ; « aucun changement » serait une réponse valide. Harness : `scripts/measure_1737_axis_remesure.py` — même script, même input (texte complet), main = avant (sites non câblés → tête), branche = après (sélecteur → prose). probe2 sur la sélection (hash identique). Artefacts sous `evaluation/results/real_analysis/` (gitignoré).

n=8 draws, corpus_B, même script/input. Sélection identique aux deux branches — offset 15001, slice hash `6cf840f5d03b97fa` dans les deux artefacts (le sélecteur est sur main depuis l'étape 2 ; la différence avant/après = le câblage, pas le sélecteur). probe2 sur le run après : sélection déterministe exécutée 2×, probe2_hash `cee9385edb120517`.

| axe | AVANT (sites non câblés → tête TOC, offset 0) | APRÈS (sites câblés → prose, offset 15001) |
|---|---|---|
| `n_arguments` | mean **4.12** (std 1.90) | mean **11.12** (std 5.06) |
| `dung_attacks` | mean **0.12** (std 0.33), zero-rate **0.875** | mean **5.12** (std 2.71), zero-rate 0.125 |
| `weighted_attacks` | mean **0.62** (std 1.11), zero-rate **0.75** | mean **9.50** (std 4.27), zero-rate 0.125 |
| `setaf_attacks` | mean **0.12** (std 0.33), zero-rate **0.875** | mean **6.50** (std 3.28), zero-rate 0.125 |
| `aspic_rules` | mean **2.38** (std 1.49), zero-rate 0.125 — règles de base seules, **0 contradiction / 0 undercut sur 8 draws** | mean **8.75** (std 4.35), zero-rate 0.125 — **23 contradictions + 7 undercuts sur 7/8 draws** |

Lecture BEFORE (tête TOC) : les axes d'attaque sont en famine quasi-totale (zero-rate 0.75-0.875), mais pas en zéro absolu — weighted émet 2 draws/8 (1 draw sur 8 pour dung/setaf), des tirages rares (leçon #1710 : famine, pas zéro). ASPIC ne rend que des règles de base : **aucun** des 8 draws ne produit une contradiction ou un undercut (= aucune attaque ASPIC).

Lecture APRÈS (prose, câblage) : le câblage à la fenêtre calculée fait passer les axes d'attaque de la famine à un rendement riche — dung ×43, weighted ×15, setaf ×54, et surtout ASPIC produit **23 contradictions + 7 undercuts sur 7/8 draws** (0 avant) : l'attaque ASPIC n'existe qu'au contact de la prose, jamais sur la TOC. L'unique draw à zéro (draw2 après, draw4 avant) est un échec d'extraction (JSON non parsable ×3 → fallback heuristique → inventaire vide), pas un effet de contenu : le zero-rate 0.125 de l'aspic aux deux branches reflète le taux d'échec d'extraction, pas la fenêtre.

## Validation

- 204 tests ciblés verts (wiring 8, narrative 25, nl_to_logic/ai_shield 48, structured/workflow/conversational 131)
- black ✓ · flake8 ✓ · mypy strict ✓ (modules core)
- Privacy : IDs opaques, aucun contenu corpus dans la PR, artefacts gitignorés
