### PR TITLE
fix(plugins): KBToTweety FOL/modal routing calcule son verdict, etiquette inconnue = non evaluee (#1777)

### DIFF
--- a/argumentation_analysis/agents/core/logic/modal_handler.py
+++ b/argumentation_analysis/agents/core/logic/modal_handler.py
@@ -187,6 +187,23 @@ class ModalHandler:
             )
             return False, "An unexpected error occurred during validation."
 
+    def parse_belief_set(self, belief_set_content: str) -> "object":
+        """Parse a modal belief-set string with the shared MlParser (parse only).
+
+        Companion to ``execute_modal_query`` with NO reasoner run: raises
+        ``ValueError`` on unparseable syntax. The KB must use the canonical
+        declared form — ``type(p)`` 0-ary declarations + formulas, see
+        ``ModalLogicAgent._construct_modal_kb_from_json`` (#1213) — because
+        MlParser does not auto-declare atoms referenced by formulas (firsthand:
+        ``parseBeliefBase("[](p => q)")`` raises "Unknown object p", #1777).
+        """
+        belief_set_content = self._normalize_for_parse(belief_set_content)
+        try:
+            StringReader = jpype.JClass("java.io.StringReader")
+            return self._modal_parser.parseBeliefBase(StringReader(belief_set_content))
+        except jpype.JException as e:
+            raise ValueError(f"Erreur de parsing modal: {e.getMessage()}") from e
+
     def execute_modal_query(self, belief_set_content: str, query_string: str) -> str:
         """
         Executes a modal logic query against a given belief set.

--- a/argumentation_analysis/plugins/kb_to_tweety_plugin.py
+++ b/argumentation_analysis/plugins/kb_to_tweety_plugin.py
@@ -28,7 +28,11 @@ class TweetyTranslationResult(BaseModel):
     original_text: str = Field(..., description="Source KB text")
     formula: str = Field(..., description="Tweety-compatible formula")
     logic_type: str = Field(..., description="PL, FOL, Modal, Dung, or ASPIC")
-    is_valid: bool = Field(False, description="Whether Tweety validation passed")
+    # #1777: tri-state (#1634). None = the label was never evaluated (unknown
+    # logic type); True/False = a validator actually parsed the formula.
+    is_valid: Optional[bool] = Field(
+        None, description="Whether Tweety validation passed"
+    )
     attempts: int = Field(1, description="Number of translate-validate attempts")
     validation_message: Optional[str] = Field(None)
     signature: Optional[Dict[str, List[str]]] = Field(
@@ -159,17 +163,36 @@ def _validate_pl(formula: str) -> Tuple[bool, str]:
         return False, str(e)
 
 
-def _validate_fol(formula: str, belief_set: str = "") -> Tuple[bool, str]:
+def _validate_fol(
+    formula: str,
+    belief_set: str = "",
+    signature: Optional[Dict[str, List[str]]] = None,
+) -> Tuple[bool, str]:
     if not _jvm_available():
         return False, "JVM unavailable — validation not performed"
     try:
         from argumentation_analysis.agents.core.logic.tweety_bridge import TweetyBridge
 
         bridge = TweetyBridge.get_instance()
-        is_valid, msg = bridge.check_consistency(
-            belief_set or formula, logic_type="fol"
-        )
-        return is_valid, msg
+        # #1777: is_valid measures parseability (uniform with _validate_pl), not
+        # consistency. The old "fol" label never routed (bridge expects
+        # "first_order") -> (None, "Unknown logic type") -> 3 retries on a
+        # well-formed formula. A well-formed contradictory formula parses.
+        #
+        # FolParser does NOT auto-declare predicates ("Predicate 'Human' has
+        # not been declared", firsthand #1777) — the signature must be built
+        # first. create_belief_set_programmatically (fol_handler) constructs
+        # the Java FolSignature from the plugin's signature dict and
+        # defensively declares predicates used-but-undeclared in the formula,
+        # then raises ValueError on unparseable syntax.
+        sig = signature or {}
+        builder_data = {
+            "_sorts": {"thing": list(sig.get("constants") or [])},
+            "_predicates": {p: ["thing"] for p in (sig.get("predicates") or [])},
+            "_formulas": [belief_set or formula],
+        }
+        bridge.fol_handler.create_belief_set_programmatically(builder_data)
+        return True, "Valid FOL formula"
     except Exception as e:
         return False, str(e)
 
@@ -181,10 +204,19 @@ def _validate_modal(formula: str, belief_set: str = "") -> Tuple[bool, str]:
         from argumentation_analysis.agents.core.logic.tweety_bridge import TweetyBridge
 
         bridge = TweetyBridge.get_instance()
-        is_valid, msg = bridge.check_consistency(
-            belief_set or formula, logic_type="modal_k"
-        )
-        return is_valid, msg
+        # #1777: same parse-validity semantics; the old "modal_k" label never
+        # routed (bridge expects naked codes K/T/S4/S5).
+        #
+        # MlParser does NOT auto-declare atoms ("Unknown object p", firsthand
+        # #1777): propositions are 0-ary predicates declared inline as
+        # ``type(p)`` (#1213) — every atom referenced by the formula must be
+        # declared first (mirrors _construct_modal_kb_from_json).
+        text = belief_set or formula
+        atoms = sorted(set(re.findall(r"\b[a-z_][a-z0-9_]*\b", text)))
+        declared = "\n".join(f"type({a})" for a in atoms)
+        kb_text = f"{declared}\n{text}" if declared else text
+        bridge.modal_handler.parse_belief_set(kb_text)
+        return True, "Valid modal formula"
     except Exception as e:
         return False, str(e)
 
@@ -213,7 +245,7 @@ async def _translate_with_retry(
             formula, sig = _build_fol_formula(belief_text, signature)
             if not formula:
                 continue
-            valid, msg = _validate_fol(formula)
+            valid, msg = _validate_fol(formula, signature=sig)
             if valid and sig["predicates"]:
                 return TweetyTranslationResult(
                     original_text=belief_text[:200],
@@ -230,8 +262,19 @@ async def _translate_with_retry(
                 continue
             valid, msg = _validate_modal(formula)
         else:
-            formula = _build_pl_formula(belief_text)
-            valid, msg = True, "Unknown logic type — heuristic formula"
+            # #1777: an unknown logic type is neither valid nor invalid — it
+            # was never evaluated (tri-state #1634). No fabrication, no retry
+            # (the label cannot change between attempts).
+            return TweetyTranslationResult(
+                original_text=belief_text[:200],
+                formula="",
+                logic_type=logic_type,
+                is_valid=None,
+                attempts=1,
+                validation_message=(
+                    f"Unknown logic type: {logic_type} — not evaluated"
+                ),
+            )
 
         if valid:
             return TweetyTranslationResult(

--- a/tests/unit/argumentation_analysis/plugins/test_kb_to_tweety_routing_tri_state.py
+++ b/tests/unit/argumentation_analysis/plugins/test_kb_to_tweety_routing_tri_state.py
@@ -1,0 +1,88 @@
+"""#1777 — l'axe FOL/modal de KBToTweetyPlugin rend un verdict calculé, et une
+étiquette inconnue rend « non évalué » (tri-état #1634), jamais un verdict.
+
+Red control (DoD item 2, on main at branch time, JVM up): the validators pass
+labels the bridge does not route (``"fol"`` vs ``"first_order"``, ``"modal_k"``
+vs naked codes ``K/T/S4/S5``), so every call lands in the bridge's else-branch
+-> ``(None, "Unknown logic type: …")`` -> 3 retries -> ``is_valid: false`` on a
+well-formed formula. An unknown ``logic_type`` additionally renders
+``is_valid: true`` from the else-branch of ``_translate_with_retry`` without
+any computation (the #1773 form surviving in the very file of the fix).
+
+This module requires the real JVM session (like the #1774 vocabulary tests):
+the JVM-free suite cannot reach this path, which is precisely why the defect
+survived.
+"""
+
+import json
+
+import pytest
+
+from argumentation_analysis.plugins.kb_to_tweety_plugin import (
+    KBToTweetyPlugin,
+    _validate_fol,
+    _validate_modal,
+)
+
+pytestmark = pytest.mark.tweety
+
+
+class TestFolModalRoutingRendersComputedVerdict:
+    """DoD item 2 + semantic decision: a well-formed FOL/modal formula parses.
+
+    ``is_valid`` measures parseability into Tweety (uniform with ``_validate_pl``),
+    not consistency — a well-formed contradictory formula is valid syntax.
+    """
+
+    async def test_validate_fol_parses_valid_formula(
+        self, tweety_bridge_fixture
+    ) -> None:
+        is_valid, msg = _validate_fol("forall X: (Human(X) => Mortal(X))")
+        assert is_valid is True, f"well-formed FOL rejected: {msg}"
+        assert "Unknown logic type" not in msg
+
+    async def test_validate_modal_parses_valid_formula(
+        self, tweety_bridge_fixture
+    ) -> None:
+        is_valid, msg = _validate_modal("[](p => q)")
+        assert is_valid is True, f"well-formed modal rejected: {msg}"
+        assert "Unknown logic type" not in msg
+
+    async def test_translate_fol_renders_computed_verdict(
+        self, tweety_bridge_fixture
+    ) -> None:
+        plugin = KBToTweetyPlugin()
+        result = json.loads(
+            await plugin.translate_to_tweety(
+                json.dumps({"text": "Socrate est mortel", "logic_type": "fol"})
+            )
+        )
+        assert result["is_valid"] is True, result["validation_message"]
+        assert "Unknown logic type" not in result["validation_message"]
+        assert result["attempts"] == 1
+
+    async def test_well_formed_contradiction_is_valid_parses(
+        self, tweety_bridge_fixture
+    ) -> None:
+        """``p && !p`` is well-formed: validity is not consistency, no retries."""
+        is_valid, msg = _validate_fol("forall X: (Human(X) => !Mortal(X))")
+        assert is_valid is True, f"well-formed contradictory FOL rejected: {msg}"
+
+
+class TestUnknownLogicTypeIsNotEvaluated:
+    """Constat B (DoD item 3): an unknown label is not valid and not invalid —
+    it was never evaluated (tri-state #1634), and the message names it.
+    """
+
+    async def test_unknown_logic_type_is_null_not_true(
+        self, tweety_bridge_fixture
+    ) -> None:
+        plugin = KBToTweetyPlugin()
+        result = json.loads(
+            await plugin.translate_to_tweety(
+                json.dumps({"text": "Socrate est mortel", "logic_type": "zzz"})
+            )
+        )
+        assert result["is_valid"] is None, result["validation_message"]
+        assert "zzz" in result["validation_message"]
+        assert "heuristic" not in result["validation_message"]


### PR DESCRIPTION
## Summary

Refs #1777. L'axe FOL/modal de `KBToTweetyPlugin` rendait un verdict négatif sur des formules bien formées (étiquettes non routables → 3 retries pour rien → `is_valid: false`), et la branche `else` fabriquait `is_valid: true` sans aucun calcul ("Unknown logic type — heuristic formula").

- **Décision sémantique** (postée sur l'issue, DoD 1) : `is_valid` = bien-formé (parsable Tweety), uniforme PL/FOL/modal ; la cohérence reste l'API séparée `check_consistency`.
- **`_validate_fol`** : parse signature-aware via `fol_handler.create_belief_set_programmatically` — FolParser n'auto-déclare pas les prédicats (mesure firsthand), le dict `signature` du plugin + scan défensif déclarent avant parse. `ValueError` → `False`.
- **`_validate_modal`** : chaque atome déclaré en `type(p)` (#1213) avant `parseBeliefBase`, via le nouveau helper public `modal_handler.parse_belief_set` (parse-only, normalisation #1326).
- **Branche `else`** : `is_valid: null` (tri-état #1634) + message nommant l'étiquette — ni valide ni invalide, non évaluée.
- **`TweetyTranslationResult.is_valid`** → `Optional[bool]` (DoD 5).
- **Sweep constat-B** (DoD 4, livrable = liste) posté sur l'issue : 2 survivants listés (`tweety_logic_plugin.query_conditional_logic` → lane #1774/#1775 ; `logic_agent_plugin.validate_formula` fol/modal → conflit cohérence/validité + exigence signature, même racine).

## Test plan

- [x] Red control : 5 tests rouge sur main (JVM réelle, `pytest.mark.tweety`), 5/5 verts après fix — `tests/unit/argumentation_analysis/plugins/test_kb_to_tweety_routing_tri_state.py`
- [x] Suite plugins JVM-free : 636 passed (1 échec pré-existant `test_translate_to_modal_antitheater` — flake d'ordre dépendant de `--disable-jvm-session`, présent sur main, non reproduit en mode CI, hors scope)
- [x] Suite `agents/core/logic` JVM : 7/7 (test_1178_handler_fixes)
- [x] mypy strict : 15 → 14 erreurs (net -1 : les 2 retours `Tuple[bool,str]` menteurs disparaissent, +1 annotation sur `parse_belief_set`) — 0 nouvelle
- [x] black : appliqué

## Files changed

- `argumentation_analysis/plugins/kb_to_tweety_plugin.py` — validateurs signature-aware, tri-state
- `argumentation_analysis/agents/core/logic/modal_handler.py` — `parse_belief_set` (parse-only)
- `tests/unit/argumentation_analysis/plugins/test_kb_to_tweety_routing_tri_state.py` — red-control 5 tests

## Notes

- Le flake `test_translate_to_modal_antitheater` (ordre + `--disable-jvm-session`, hors CI) est documenté sur l'issue ; le harnais CI ne passe pas ce flag.
