### PR TITLE
feat(cassettes): #1603 record job CI + cost artifact + audit metadata fix

### DIFF
--- a/.github/workflows/record-llm-cassettes.yml
+++ b/.github/workflows/record-llm-cassettes.yml
@@ -114,15 +114,22 @@ jobs:
           if-no-files-found: error
 
       # Optional: open the cassettes PR from this job when a PAT is configured.
-      # Without the secret the job ends at the artifact — a coordinator creates
-      # the PR from the download. The trigger PR (#1603 DoD 7) is NEVER opened
-      # by this job.
+      # Without the secret the step self-skips — the job ends at the artifact
+      # and a coordinator creates the PR from the download. The trigger PR
+      # (#1603 DoD 7) is NEVER opened by this job. NOTE: the `secrets` context
+      # is not allowed in a step-level `if:` (GitHub rejects the whole file —
+      # caught 2026-08-17 when both branch pushes failed with 0s parse runs),
+      # so the gate lives in the shell.
       - name: Open cassettes PR (optional, needs CASSETTES_PR_TOKEN)
-        if: ${{ secrets.CASSETTES_PR_TOKEN != '' }}
+        if: always()
         shell: pwsh
         env:
           CASSETTES_PR_TOKEN: ${{ secrets.CASSETTES_PR_TOKEN }}
         run: |
+          if (-not $env:CASSETTES_PR_TOKEN) {
+            Write-Host "CASSETTES_PR_TOKEN not configured — skipping the cassettes PR (artifact-only, per #1603 DoD 7 arbitration flow)."
+            exit 0
+          }
           $env:CASSETTES_PR_TOKEN | gh auth login --with-token
           $branch = "cassettes/llm-record-${{ github.run_id }}"
           git checkout -b $branch

--- a/.github/workflows/record-llm-cassettes.yml
+++ b/.github/workflows/record-llm-cassettes.yml
@@ -1,0 +1,128 @@
+name: Record LLM Cassettes (#1603)
+
+# Manual-only record lane. The run BILLS REAL API USAGE — it must never be
+# auto-triggered. A run records the given pytest lane in `record` cache mode,
+# exports the resulting diskcache DB to JSON cassettes under a blocking
+# privacy audit (scripts/cassettes/privacy.py), and emits a cost artifact.
+#
+# The cassettes do NOT get committed by this job by default: they are
+# uploaded as an artifact. A separate PR flow (coordinator-arbitrated) turns
+# the artifact into tests/fixtures/llm_cassettes additions. If a
+# CASSETTES_PR_TOKEN secret is configured, the job opens that PR itself.
+#
+# Mode is EXPLICIT (LLM_CACHE_MODE=record on the record step only); nothing
+# here catches LLMCacheMiss or provisions the key for any replay step.
+
+on:
+  workflow_dispatch:
+    inputs:
+      lane:
+        description: 'pytest -m expression for the record lane'
+        required: false
+        default: 'slow or requires_api'
+      extra_args:
+        description: 'Extra pytest args (e.g. a specific file, -k filter)'
+        required: false
+        default: ''
+      record_db:
+        description: 'Runtime diskcache dir for the record run'
+        required: false
+        default: '.cache/llm_record_ci'
+      max_minutes:
+        description: 'Hard time cap for the record step (bills real API)'
+        required: false
+        default: '60'
+      token_cap:
+        description: 'Fail-loud token cap (prompt+completion) for the run'
+        required: false
+        default: '2000000'
+
+concurrency:
+  group: record-llm-cassettes
+  # cancel-in-progress: false — cancelling a billable run wastes the spend
+  cancel-in-progress: false
+
+jobs:
+  record:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+
+      - name: Setup Miniconda
+        uses: conda-incubator/setup-miniconda@v2
+        timeout-minutes: 15
+        with:
+          python-version: "3.10"
+          environment-file: environment.yml
+          activate-environment: projet-is
+          use-mamba: true
+          auto-update-conda: false
+
+      - name: Record run (bills real API usage)
+        shell: pwsh
+        timeout-minutes: ${{ fromJson(inputs.max_minutes) }}
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          TEXT_CONFIG_PASSPHRASE: ${{ secrets.TEXT_CONFIG_PASSPHRASE }}
+          LLM_CACHE_MODE: record
+          LLM_CACHE_DIR: ${{ inputs.record_db }}
+        run: |
+          conda run -n projet-is --no-capture-output pytest tests/unit/ -m "${{ inputs.lane }}" --ignore=tests/unit/services/test_mcp_server_v2 --allow-dotenv ${{ inputs.extra_args }} --junitxml=pytest_report.xml -v --timeout=900 --timeout-method=thread
+
+      - name: Export cassettes + blocking privacy audit
+        shell: pwsh
+        run: |
+          python scripts/cassettes/export.py ${{ inputs.record_db }} staging_cassettes
+          Write-Host "Exported cassettes: $((Get-ChildItem staging_cassettes -Filter *.json | Measure-Object).Count)"
+
+      - name: Cost artifact + fail-loud token cap
+        shell: pwsh
+        env:
+          LLM_CACHE_DIR: ${{ inputs.record_db }}
+        run: |
+          python scripts/cassettes/cost_report.py ${{ inputs.record_db }} --json | Out-File -Encoding utf8 cost_report.json
+          python scripts/cassettes/cost_report.py ${{ inputs.record_db }} | Out-File -Encoding utf8 cost_report.md
+          $tokens = python -c "import json;print(json.load(open('cost_report.json'))['prompt_tokens'] + json.load(open('cost_report.json'))['completion_tokens'])"
+          Write-Host "Total tokens: $tokens (cap: ${{ inputs.token_cap }})"
+          if ([int]$tokens -gt [int]${{ inputs.token_cap }}) {
+            Write-Host "❌ FAIL-LOUD: record run exceeded the token cap (see #1603 DoD 6)."
+            exit 1
+          }
+
+      - name: Upload artifacts (cassettes + cost + junit)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: llm-cassettes
+          path: |
+            staging_cassettes/
+            cost_report.json
+            cost_report.md
+            pytest_report.xml
+          if-no-files-found: error
+
+      # Optional: open the cassettes PR from this job when a PAT is configured.
+      # Without the secret the job ends at the artifact — a coordinator creates
+      # the PR from the download. The trigger PR (#1603 DoD 7) is NEVER opened
+      # by this job.
+      - name: Open cassettes PR (optional, needs CASSETTES_PR_TOKEN)
+        if: ${{ secrets.CASSETTES_PR_TOKEN != '' }}
+        shell: pwsh
+        env:
+          CASSETTES_PR_TOKEN: ${{ secrets.CASSETTES_PR_TOKEN }}
+        run: |
+          $env:CASSETTES_PR_TOKEN | gh auth login --with-token
+          $branch = "cassettes/llm-record-${{ github.run_id }}"
+          git checkout -b $branch
+          Copy-Item staging_cassettes/*.json tests/fixtures/llm_cassettes/
+          git add tests/fixtures/llm_cassettes/
+          git -c user.name='cassettes-bot' -c user.email='noreply@github.com' commit -m "chore(cassettes): record lane for #1603 (run ${{ github.run_id }})"
+          git push origin $branch
+          gh pr create --title "chore(cassettes): LLM cassettes from record run ${{ github.run_id }} (#1603)" --body "Cassettes recorded in CI (workflow_dispatch). NOT merged without arbitration — see #1603 DoD 7."

--- a/.github/workflows/record-llm-cassettes.yml
+++ b/.github/workflows/record-llm-cassettes.yml
@@ -99,13 +99,14 @@ jobs:
           LLM_CACHE_MODE: record
           LLM_CACHE_DIR: ${{ inputs.record_db }}
         run: |
-          # Deselected — env-shape mismatches of the RECORD lane (not LLM work):
-          #  - test_create_llm_service_openai_authentic: asserts isinstance
-          #    OpenAIChatCompletion, but record mode wraps the service in
-          #    CachedChatCompletion (the wrap is the point of the lane).
-          #  - test_dashboard: needs the React build (built by the main CI
-          #    job, not here — irrelevant to recording).
-          conda run -n projet-is --no-capture-output pytest tests/unit/ -m "${{ inputs.lane }}" --ignore=tests/unit/services/test_mcp_server_v2 --allow-dotenv ${{ inputs.extra_args }} --deselect "tests/unit/argumentation_analysis/test_llm_service.py::TestLLMService::test_create_llm_service_openai_authentic" --deselect "tests/unit/interface_web/test_dashboard.py::TestDashboardRouteRegistration::test_starlette_app_has_dashboard_route" --deselect "tests/unit/interface_web/test_dashboard.py::TestDashboardEndpointBehavior::test_starlette_dashboard_returns_html" --junitxml=pytest_report.xml -v --timeout=900 --timeout-method=thread
+          # Deselected — env-shape mismatch of the RECORD lane (not LLM work):
+          # test_create_llm_service_openai_authentic asserts isinstance
+          # OpenAIChatCompletion, but record mode wraps the service in
+          # CachedChatCompletion (the wrap is the point of the lane). The
+          # dashboard tests are NOT deselected: the React build parity
+          # steps above make them pass (measured: first record run failed
+          # them without the build, the CI pipeline builds it).
+          conda run -n projet-is --no-capture-output pytest tests/unit/ -m "${{ inputs.lane }}" --ignore=tests/unit/services/test_mcp_server_v2 --allow-dotenv ${{ inputs.extra_args }} --deselect "tests/unit/argumentation_analysis/test_llm_service.py::TestLLMService::test_create_llm_service_openai_authentic" --junitxml=pytest_report.xml -v --timeout=900 --timeout-method=thread
 
       - name: Export cassettes + blocking privacy audit
         shell: pwsh

--- a/.github/workflows/record-llm-cassettes.yml
+++ b/.github/workflows/record-llm-cassettes.yml
@@ -19,9 +19,14 @@ on:
       lane:
         description: 'pytest -m expression for the record lane'
         required: false
-        default: 'slow or requires_api'
+        # NOT 'requires_api': under pytest the SK path is mocked on
+        # PYTEST_CURRENT_TEST (llm_service.py:115) regardless of markers —
+        # those tests record NOTHING (#1603 constat A). The recordable band
+        # is the raw-path consumers (_guarded_chat_completion), reachable
+        # through ordinary unmarked pipeline tests.
+        default: 'not slow and not requires_api'
       extra_args:
-        description: 'Extra pytest args (e.g. a specific file, -k filter)'
+        description: 'Extra pytest args (e.g. a specific file, -k filter). Default runs the whole non-slow unit band — only raw-path consumers bill (~500-1000 calls, ~$1-5 projection, gpt-5-mini). Narrow explicitly for a cheap probe.'
         required: false
         default: ''
       record_db:

--- a/.github/workflows/record-llm-cassettes.yml
+++ b/.github/workflows/record-llm-cassettes.yml
@@ -70,6 +70,26 @@ jobs:
           use-mamba: true
           auto-update-conda: false
 
+      # Parity with ci.yml:75-93 — without the React build, the record run
+      # fails 2 interface_web dashboard tests at module import (Starlette
+      # mounts StaticFiles on the gitignored build dir; measured on the first
+      # #1603 CI record run: 'Directory .../build does not exist'). The CI
+      # pipeline on the same SHA is green because it builds the frontend.
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: services/web_api/interface-web-argumentative/package-lock.json
+
+      - name: Build React frontend
+        working-directory: services/web_api/interface-web-argumentative
+        shell: pwsh
+        run: |
+          npm ci --no-audit --no-fund
+          npm run build
+          Write-Host "✅ React build produced: $((Get-ChildItem -Recurse build | Measure-Object).Count) files"
+
       - name: Record run (bills real API usage)
         shell: pwsh
         timeout-minutes: ${{ fromJson(inputs.max_minutes) }}
@@ -79,7 +99,13 @@ jobs:
           LLM_CACHE_MODE: record
           LLM_CACHE_DIR: ${{ inputs.record_db }}
         run: |
-          conda run -n projet-is --no-capture-output pytest tests/unit/ -m "${{ inputs.lane }}" --ignore=tests/unit/services/test_mcp_server_v2 --allow-dotenv ${{ inputs.extra_args }} --junitxml=pytest_report.xml -v --timeout=900 --timeout-method=thread
+          # Deselected — env-shape mismatches of the RECORD lane (not LLM work):
+          #  - test_create_llm_service_openai_authentic: asserts isinstance
+          #    OpenAIChatCompletion, but record mode wraps the service in
+          #    CachedChatCompletion (the wrap is the point of the lane).
+          #  - test_dashboard: needs the React build (built by the main CI
+          #    job, not here — irrelevant to recording).
+          conda run -n projet-is --no-capture-output pytest tests/unit/ -m "${{ inputs.lane }}" --ignore=tests/unit/services/test_mcp_server_v2 --allow-dotenv ${{ inputs.extra_args }} --deselect "tests/unit/argumentation_analysis/test_llm_service.py::TestLLMService::test_create_llm_service_openai_authentic" --deselect "tests/unit/interface_web/test_dashboard.py::TestDashboardRouteRegistration::test_starlette_app_has_dashboard_route" --deselect "tests/unit/interface_web/test_dashboard.py::TestDashboardEndpointBehavior::test_starlette_dashboard_returns_html" --junitxml=pytest_report.xml -v --timeout=900 --timeout-method=thread
 
       - name: Export cassettes + blocking privacy audit
         shell: pwsh

--- a/.github/workflows/replay-llm-lane.yml
+++ b/.github/workflows/replay-llm-lane.yml
@@ -1,0 +1,97 @@
+name: Replay LLM Lane (#1603)
+
+# Manual-only replay lane: runs a pytest lane against the committed
+# cassettes with NO API key provisioned (the anti-#1019 property is
+# structural — there is nothing to fall through to), then enforces the
+# anti-vacuité gate (live==0, hit>=1, miss_replay==0).
+#
+# DoD 7 (arming this on PR pushes) is a SEPARATE trigger PR, arbitrated —
+# this workflow stays workflow_dispatch until then.
+#
+# A red gate here means one of:
+#   - live>0   : impossible by construction (no key) — a wrap leaked
+#   - hit==0   : the lane no longer consults the cache (vacuous green)
+#   - miss>0   : a cassette is missing / its key drifted (record/replay
+#                asymmetry — see #1603 constat C — or substitution)
+
+on:
+  workflow_dispatch:
+    inputs:
+      lane_args:
+        description: 'pytest args selecting the replay lane (file and -k)'
+        required: false
+        default: 'tests/unit/argumentation_analysis/orchestration/test_workflow_robustness.py -k "test_empty_whitespace and light"'
+      replay_db:
+        description: 'Runtime diskcache dir for the replay DB'
+        required: false
+        default: '.cache/llm_replay_lane'
+
+concurrency:
+  group: replay-llm-lane
+  cancel-in-progress: true
+
+jobs:
+  replay:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+
+      - name: Setup Miniconda
+        uses: conda-incubator/setup-miniconda@v2
+        timeout-minutes: 15
+        with:
+          python-version: "3.10"
+          environment-file: environment.yml
+          activate-environment: projet-is
+          use-mamba: true
+          auto-update-conda: false
+
+      - name: Count committed cassettes (guard against a vacuous lane)
+        shell: pwsh
+        run: |
+          $n = (Get-ChildItem tests/fixtures/llm_cassettes -Filter *.json | Measure-Object).Count
+          Write-Host "Committed cassettes: $n"
+          if ($n -lt 1) {
+            Write-Host "FAIL-LOUD: no cassettes committed — the replay lane would be vacuous (hit would be 0)."
+            exit 1
+          }
+
+      - name: Import cassettes into the runtime replay DB
+        shell: pwsh
+        run: |
+          python scripts/cassettes/import.py tests/fixtures/llm_cassettes ${{ inputs.replay_db }} --purge
+          python scripts/cassettes/cost_report.py ${{ inputs.replay_db }} | Select-Object -First 3
+
+      # NO OPENAI_API_KEY is provisioned on this step or this job — replay
+      # must hold with nothing to fall back to (anti-#1019, structural).
+      - name: Replay lane (no key provisioned)
+        shell: pwsh
+        timeout-minutes: 30
+        env:
+          LLM_CACHE_MODE: replay
+          LLM_CACHE_DIR: ${{ inputs.replay_db }}
+          REPLAY_GATE: '1'
+          REPLAY_STATS_OUT: replay_stats.json
+        run: |
+          conda run -n projet-is --no-capture-output pytest ${{ inputs.lane_args }} --ignore=tests/unit/services/test_mcp_server_v2 -p scripts.cassettes.replay_stats_plugin -v --junitxml=pytest_report.xml
+
+      - name: Anti-vacuité gate (live==0, hit>=1, miss_replay==0)
+        shell: pwsh
+        run: python -m scripts.cassettes.replay_gate_check replay_stats.json
+
+      - name: Upload lane report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: replay-lane-report
+          path: |
+            replay_stats.json
+            pytest_report.xml
+          if-no-files-found: warn

--- a/argumentation_analysis/services/llm_cache.py
+++ b/argumentation_analysis/services/llm_cache.py
@@ -297,7 +297,21 @@ class CachedChatCompletion(ChatCompletionClientBase):
             chat_history=chat_history, settings=settings, **kwargs
         )
         _cache_stats.live += 1
-        self._cache.set(key, _serialize_response(response))
+        # Record is an observer: it must never change the caller's outcome.
+        # A response that cannot be serialized/pickled (mock responses in
+        # unit tests) is passed through unrecorded rather than failing the
+        # call — proven live by the #1603 CI record run (PicklingError on
+        # MagicMock broke 6 budget-guard tests and, swallowed upstream,
+        # emptied 16 counter/extract assertions).
+        try:
+            self._cache.set(key, _serialize_response(response))
+        except Exception as exc:  # noqa: BLE001 — best-effort recording
+            logger.warning(
+                "Cache RECORD: response not storable (key %s..., %s) — "
+                "passed through unrecorded",
+                key[:16],
+                type(exc).__name__,
+            )
         return response
 
     # Delegate attribute access to inner service
@@ -456,5 +470,16 @@ async def cached_raw_chat_completion(client: Any, **kwargs: Any) -> Any:
     _cache_stats.miss_record += 1
     response = await client.chat.completions.create(**kwargs)
     _cache_stats.live += 1
-    cache.set(key, _serialize_chat_completion(response))
+    # Same observer contract as the SK path: an unstorable response (mock
+    # objects in tests) passes through unrecorded instead of raising from
+    # inside the cache (#1603).
+    try:
+        cache.set(key, _serialize_chat_completion(response))
+    except Exception as exc:  # noqa: BLE001 — best-effort recording
+        logger.warning(
+            "Raw cache RECORD: response not storable (key %s..., %s) — "
+            "passed through unrecorded",
+            key[:16],
+            type(exc).__name__,
+        )
     return response

--- a/scripts/cassettes/cost_report.py
+++ b/scripts/cassettes/cost_report.py
@@ -1,0 +1,113 @@
+"""Cost artifact for a record run (#1603, DoD 6).
+
+Reads a runtime record-mode diskcache DB and emits a truthful spend summary:
+
+- total entries (unique cache keys = unique LLM requests made during the run)
+- raw-path entries (dict values from ``_serialize_chat_completion``) carry the
+  OpenAI ``usage`` block (prompt/completion tokens) — summed here.
+- SK-path entries (list values from ``_serialize_response``) do NOT carry usage
+  (the serialized ChatMessageContent has no token counters) — counted only.
+
+A dollar estimate is printed ONLY when ``LLM_PRICE_PER_1M_IN`` /
+``LLM_PRICE_PER_1M_OUT`` are set (per-1M-token USD); without them the report
+stays token-only rather than guessing a price. The record job's cost gate uses
+the token totals; the operator prices them against the provider's current
+rate card.
+
+Usage::
+
+    python scripts/cassettes/cost_report.py <record_db_dir> [--json]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
+import diskcache
+
+
+def analyze(db_dir: Path) -> Dict[str, Any]:
+    """Return the spend summary for a record-mode diskcache DB."""
+    db = diskcache.Cache(str(db_dir))
+    try:
+        total = len(db)
+        sk_path = 0
+        raw_path = 0
+        prompt_tokens = 0
+        completion_tokens = 0
+        for key in db.iterkeys():
+            value = db[key]
+            if isinstance(value, list):
+                sk_path += 1
+            elif isinstance(value, dict):
+                raw_path += 1
+                usage = value.get("usage") or {}
+                if isinstance(usage, dict):
+                    prompt_tokens += int(usage.get("prompt_tokens") or 0)
+                    completion_tokens += int(usage.get("completion_tokens") or 0)
+            else:
+                raise ValueError(
+                    f"Unexpected cache value type {type(value)!r} for {key[:16]}"
+                )
+    finally:
+        db.close()
+
+    in_price = os.getenv("LLM_PRICE_PER_1M_IN")
+    out_price = os.getenv("LLM_PRICE_PER_1M_OUT")
+    est_usd: float | None = None
+    if in_price and out_price:
+        est_usd = prompt_tokens / 1_000_000 * float(
+            in_price
+        ) + completion_tokens / 1_000_000 * float(out_price)
+    return {
+        "db_dir": str(db_dir),
+        "total_requests": total,
+        "sk_path_requests": sk_path,
+        "raw_path_requests": raw_path,
+        "prompt_tokens": prompt_tokens,
+        "completion_tokens": completion_tokens,
+        "est_usd": est_usd,
+        "price_note": (
+            "est_usd computed from LLM_PRICE_PER_1M_IN/OUT env vars (per-1M-token USD)"
+            if est_usd is not None
+            else "est_usd absent — set LLM_PRICE_PER_1M_IN/OUT to price the token totals"
+        ),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    p.add_argument("db_dir", type=Path, help="Runtime diskcache dir of the record run")
+    p.add_argument("--json", action="store_true", help="Emit JSON instead of markdown")
+    args = p.parse_args(argv)
+
+    if not args.db_dir.exists():
+        print(f"DB dir does not exist: {args.db_dir}", file=sys.stderr)
+        return 1
+
+    report = analyze(args.db_dir)
+    if args.json:
+        print(json.dumps(report, indent=2))
+        return 0
+
+    print(f"# Cost artifact — {report['db_dir']}")
+    print(f"- Total requests (unique cache keys): {report['total_requests']}")
+    print(f"- Raw-path (usage available): {report['raw_path_requests']}")
+    print(f"- SK-path (usage unavailable, counted only): {report['sk_path_requests']}")
+    print(f"- Prompt tokens: {report['prompt_tokens']}")
+    print(f"- Completion tokens: {report['completion_tokens']}")
+    if report["est_usd"] is not None:
+        print(f"- Estimated cost: ${report['est_usd']:.4f}")
+    print(f"- {report['price_note']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/cassettes/privacy.py
+++ b/scripts/cassettes/privacy.py
@@ -15,6 +15,7 @@ field listed raises and refuses to write.
 Why blocking rather than warning: a silent privacy leak onto a tracked
 surface (GitHub search index) is a release-blocker, not a lint warning.
 """
+
 from __future__ import annotations
 
 import json
@@ -24,13 +25,15 @@ from typing import Any, Iterable
 
 # Forbidden plaintext keys — checked recursively in any dict / list element.
 # Names mirror `argumentation_analysis.core.io_manager` extraction schema.
-FORBIDDEN_KEYS = frozenset((
-    "raw_text",
-    "full_text",
-    "full_text_segment",
-    "raw_text_snippet",
-    "passphrase",  # never commit derived secrets
-))
+FORBIDDEN_KEYS = frozenset(
+    (
+        "raw_text",
+        "full_text",
+        "full_text_segment",
+        "raw_text_snippet",
+        "passphrase",  # never commit derived secrets
+    )
+)
 
 # Heuristic: politically sensitive corpus sources the dataset can contain.
 # If any name appears in a cassette, the audit fails.
@@ -39,14 +42,49 @@ FORBIDDEN_KEYS = frozenset((
 # This list is intentionally narrow — broader NER catches false positives.
 # Last update: 2026-08-06 (#1603 R758).
 SOURCE_NAME_HINTS = (
-    "Trump", "Biden", "Macron", "Le Pen", "Mélenchon", "Melenchon",
-    "Poutine", "Zelensky", "Zelenskyy", "Mussolini", "Hitler",
-    "Pétain", "Petain", "Staline", "Stalin",
-    "Bachelet", "Milei", "Bolsonaro", "Orbán", "Orban",
+    "Trump",
+    "Biden",
+    "Macron",
+    "Le Pen",
+    "Mélenchon",
+    "Melenchon",
+    "Poutine",
+    "Zelensky",
+    "Zelenskyy",
+    "Mussolini",
+    "Hitler",
+    "Pétain",
+    "Petain",
+    "Staline",
+    "Stalin",
+    "Bachelet",
+    "Milei",
+    "Bolsonaro",
+    "Orbán",
+    "Orban",
 )
 
 # Historical political date range — corpus contains (year: 1933-2026).
 DATE_RE = re.compile(r"\b(19[3-9]\d|20[0-2]\d)\b")
+
+# Response-metadata fields where the year/name heuristics are meaningless:
+# the OpenAI `model` id is versioned ("gpt-5-mini-2025-08-07") and would trip
+# the date rule on every raw-path cassette; `id`/`created`/`system_fingerprint`
+# are opaque service stamps. Forbidden-key checks still apply to dict KEYS
+# everywhere; only the string heuristics are skipped on these fields. #1603.
+METADATA_KEYS = frozenset(
+    (
+        "model",
+        "id",
+        "created",
+        "object",
+        "service_tier",
+        "system_fingerprint",
+        "finish_reason",
+        "index",
+        "role",
+    )
+)
 
 
 def audit_value(value: Any, *, source: str = "<unknown>") -> list[str]:
@@ -62,9 +100,7 @@ def audit_value(value: Any, *, source: str = "<unknown>") -> list[str]:
         if isinstance(node, dict):
             for k, v in node.items():
                 if k in FORBIDDEN_KEYS:
-                    violations.append(
-                        f"{source}: forbidden key {k!r} at {path}.{k}"
-                    )
+                    violations.append(f"{source}: forbidden key {k!r} at {path}.{k}")
                 walk(v, f"{path}.{k}" if path else k)
         elif isinstance(node, list):
             for i, item in enumerate(node):
@@ -73,6 +109,14 @@ def audit_value(value: Any, *, source: str = "<unknown>") -> list[str]:
             # Source name / date hints — only on text-sized strings, not on
             # the role field etc. (which is short anyway).
             if len(node) < 20:
+                return
+            # Skip response-metadata keys (versioned model ids, opaque stamps)
+            # — never corpus prose.
+            last = path.split(".")[-1]
+            m = re.match(r"(.+)\[\d+\]$", last)
+            if m:
+                last = m.group(1)
+            if last in METADATA_KEYS:
                 return
             for name in SOURCE_NAME_HINTS:
                 if name in node:

--- a/scripts/cassettes/replay_gate_check.py
+++ b/scripts/cassettes/replay_gate_check.py
@@ -1,0 +1,89 @@
+"""Fail-loud gate for the LLM replay lane (#1603, DoD 4/5).
+
+Reads the stats JSON written by ``replay_stats_plugin`` and enforces the
+anti-vacuité contract of a replay run:
+
+- ``live == 0`` — no outbound API call happened (anti-#1019);
+- ``hit >= 1`` — the lane actually replayed from the cassettes. A lane
+  that never consults the cache would be vacuously green;
+- ``miss_replay == 0`` — every lookup found its cassette. A miss means a
+  cassette is missing or its key drifted (the degenerate substitution of
+  DoD 5); the lane must go red, not silently degrade — the extract phase
+  swallows ``LLMCacheMiss`` into a heuristic fallback, so pytest alone
+  stays green on a substituted cassette (constat D, #1603).
+
+Usage::
+
+    python -m scripts.cassettes.replay_gate_check <stats.json>
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+_REQUIRED_COUNTERS = ("live", "hit", "miss_record", "miss_replay")
+
+
+def check(stats: Dict[str, Any]) -> List[str]:
+    """Return the list of violations (empty == the lane replayed honestly)."""
+    violations: List[str] = []
+    if stats.get("live", 0) != 0:
+        violations.append(
+            f"live={stats['live']}: outbound API call(s) during replay — "
+            "anti-#1019 (a cache miss fell through to the provider)"
+        )
+    if stats.get("hit", 0) < 1:
+        violations.append(
+            f"hit={stats.get('hit', 0)}: the lane never replayed from the "
+            "cassettes — vacuous green (lane does not consult the cache)"
+        )
+    if stats.get("miss_replay", 0) != 0:
+        violations.append(
+            f"miss_replay={stats['miss_replay']}: replay cache miss(es) — "
+            "a cassette is missing or its key drifted (degenerate "
+            "substitution, or record/replay key asymmetry); the run "
+            "degraded silently, not replayed"
+        )
+    return violations
+
+
+def main(argv: List[str] | None = None) -> int:
+    argv = list(sys.argv[1:] if argv is None else argv)
+    if len(argv) != 1:
+        print(
+            "usage: python -m scripts.cassettes.replay_gate_check <stats.json>",
+            file=sys.stderr,
+        )
+        return 2
+    path = Path(argv[0])
+    if not path.exists():
+        print(
+            f"stats file not found: {path} — did the lane run with -p scripts.cassettes.replay_stats_plugin and REPLAY_GATE=1?",
+            file=sys.stderr,
+        )
+        return 2
+    stats = json.loads(path.read_text(encoding="utf-8"))
+    missing = [c for c in _REQUIRED_COUNTERS if c not in stats]
+    if missing:
+        print(f"stats file {path} lacks counters: {missing}", file=sys.stderr)
+        return 2
+
+    print(
+        f"[replay-gate] live={stats['live']} hit={stats['hit']} "
+        f"miss_record={stats['miss_record']} miss_replay={stats['miss_replay']}"
+    )
+    violations = check(stats)
+    if violations:
+        print("REPLAY GATE FAILED:", file=sys.stderr)
+        for v in violations:
+            print(f"  - {v}", file=sys.stderr)
+        return 1
+    print("replay gate OK: live==0, hit>=1, miss_replay==0")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/cassettes/replay_stats_plugin.py
+++ b/scripts/cassettes/replay_stats_plugin.py
@@ -1,0 +1,49 @@
+"""Pytest plugin: capture llm_cache counters for the replay lane (#1603).
+
+Active only when ``REPLAY_GATE=1`` (explicit mode — a plain run is
+untouched). At session start it resets the ``llm_cache`` counters so the
+dump reflects THIS session only; at session finish it writes the counters
+to ``REPLAY_STATS_OUT`` (JSON, default ``.cache/replay_stats.json``).
+
+The enforcement lives in ``replay_gate_check.py``, a separate CLI step in
+the lane workflow. A ``pytest_sessionfinish`` hook cannot reliably fail
+the session's exit status, and embedding the check where it cannot fire
+would make the gate look armed when it is not (family #1556: 0 propre is
+indistinguishable from 0 débranché).
+
+Load with::
+
+    pytest ... -p scripts.cassettes.replay_stats_plugin
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+
+def pytest_sessionstart(session: Any) -> None:
+    if os.getenv("REPLAY_GATE") != "1":
+        return
+    import argumentation_analysis.services.llm_cache as llm_cache
+
+    llm_cache.reset_cache_stats()
+
+
+def pytest_sessionfinish(session: Any, exitstatus: Any) -> None:
+    if os.getenv("REPLAY_GATE") != "1":
+        return
+    import argumentation_analysis.services.llm_cache as llm_cache
+
+    stats = llm_cache.get_cache_stats()
+    out = Path(os.getenv("REPLAY_STATS_OUT", ".cache/replay_stats.json"))
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(stats, indent=2), encoding="utf-8")
+    # Loud one-line summary so the lane log carries the verdict even before
+    # the gate check step runs.
+    print(
+        f"\n[replay-stats] live={stats['live']} hit={stats['hit']} "
+        f"miss_record={stats['miss_record']} miss_replay={stats['miss_replay']}"
+    )

--- a/tests/fixtures/llm_cassettes/README.md
+++ b/tests/fixtures/llm_cassettes/README.md
@@ -56,6 +56,26 @@ The pytest test `tests/unit/.../test_cassette_round_trip.py` runs the
 full record → export → import → replay loop and asserts `live == 0` in
 replay (the anti-#1019 metric).
 
+## What a record run actually captures (measured #1603 R826)
+
+`create_llm_service` mocks on `PYTEST_CURRENT_TEST in os.environ`
+(`core/llm_service.py:115`) — every SK-service call in a pytest run is
+mocked (fast, deterministic) and records NOTHING, unless the call site
+passes `force_authentic=True`. The direct path
+(`_guarded_chat_completion` → `cached_raw_chat_completion`,
+`orchestration/invoke_callables.py:439`) is NEVER mocked: with a key
+present it calls the real API through the raw cache layer and records
+cassettes. So a record run over the unit lane captures the raw-path
+consumers (extract / governance / quality / fallacy / counter-arg phases,
+i.e. the pipeline tests) — the SK-path tests (e.g. the narrate integration
+test) stay mocked and record nothing, which is correct: they run mocked in
+pytest anyway and need no cassette to pass in replay.
+
+Raw-path cassette values are the OpenAI `ChatCompletion.model_dump()` dict
+and carry a `usage` block (prompt/completion tokens) — the record job's
+cost artifact (`scripts/cassettes/cost_report.py`) sums it. SK-path values
+are role/content lists without usage.
+
 ## Privacy contract
 
 Cassettes committed here MUST be:
@@ -69,6 +89,12 @@ Cassettes committed here MUST be:
 - Audited by `scripts/cassettes/privacy.py` at export. The audit is
   blocking — a violation raises `PrivacyViolation` and the cassette is
   refused.
+- The audit exempts response-metadata keys (`model`, `id`, `created`,
+  `object`, `service_tier`, `system_fingerprint`, `finish_reason`,
+  `index`, `role`) from the year/name heuristics: the versioned model id
+  (`gpt-5-mini-2025-08-07`) would otherwise trip the historical-date rule
+  on every raw-path cassette. Forbidden-key checks still apply to dict
+  keys everywhere.
 
 If a legitimate-cassette use case conflicts with the privacy contract,
 do NOT bypass with `--allow-unsafe` — open an issue and discuss

--- a/tests/unit/argumentation_analysis/plugins/test_cassette_round_trip.py
+++ b/tests/unit/argumentation_analysis/plugins/test_cassette_round_trip.py
@@ -15,6 +15,7 @@ The intent is to *verify* the export/import scripts, not to re-record the
 fixture — re-recording is a manual workflow described in
 ``tests/fixtures/llm_cassettes/README.md``.
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -27,16 +28,34 @@ from pathlib import Path
 
 import pytest
 
-
 REPO = Path(__file__).resolve().parents[4]  # tests/unit/.../test_*.py -> repo root
 SCRIPTS = REPO / "scripts" / "cassettes"
 FIXTURES_DIR = REPO / "tests" / "fixtures" / "llm_cassettes"
 
 
-def _list_cassette_keys() -> list[str]:
-    """Return cassette file stems (sha256 keys) sorted by mtime, newest first."""
+def _list_cassette_keys(*, value_is: str | None = None) -> list[str]:
+    """Return cassette file stems (sha256 keys) sorted by mtime, newest first.
+
+    ``value_is="list"`` filters to SK-path cassettes (role/content lists — the
+    shape ``_deserialize_response`` expects); ``value_is="dict"`` filters to
+    raw-path cassettes (``ChatCompletion.model_dump()`` dicts). The fixture
+    dir now mixes both shapes since the pipeline lane records raw-path values
+    (#1603) — shape-aware callers must not feed a dict to the SK replay path.
+    """
+    stems = [p.stem for p in FIXTURES_DIR.glob("*.json") if p.name != "README.md"]
+    if value_is is not None:
+        stems = [
+            s
+            for s in stems
+            if isinstance(
+                json.loads((FIXTURES_DIR / f"{s}.json").read_text(encoding="utf-8"))[
+                    "value"
+                ],
+                list if value_is == "list" else dict,
+            )
+        ]
     return sorted(
-        (p.stem for p in FIXTURES_DIR.glob("*.json")),
+        stems,
         key=lambda stem: (FIXTURES_DIR / f"{stem}.json").stat().st_mtime,
         reverse=True,
     )
@@ -140,9 +159,12 @@ class TestCassetteReplayHitsCache:
 
     def test_replay_path_uses_cache(self, monkeypatch, tmp_path: Path):
         """Given a populated cache, replay yields `hit=1, live=0`."""
-        keys = _list_cassette_keys()
+        # The SK-service path deserializes LIST values (role/content). A
+        # raw-path DICT cassette would iterate its keys and crash — filter to
+        # list-shaped cassettes for this replay proof (#1603).
+        keys = _list_cassette_keys(value_is="list")
         if not keys:
-            pytest.skip("no cassette committed")
+            pytest.skip("no SK-path (list-valued) cassette committed")
         first_key = keys[0]
 
         # Configure llm_cache to use a fresh DB populated from the cassette.
@@ -162,6 +184,7 @@ class TestCassetteReplayHitsCache:
         # Patch the module attribute too so the CachedChatCompletion wrap opens
         # the populated replay_db, not an empty default.
         import argumentation_analysis.services.llm_cache as llm_cache_mod
+
         monkeypatch.setattr(llm_cache_mod, "CACHE_DIR", replay_db)
         llm_cache_mod.reset_raw_cache()
 
@@ -170,6 +193,7 @@ class TestCassetteReplayHitsCache:
 
         # Spy on httpx so any outbound call would raise.
         import httpx
+
         real_send = httpx.AsyncClient.send
 
         async def anti_theatre(self, request, *a, **kw):
@@ -194,12 +218,10 @@ class TestCassetteReplayHitsCache:
             # force_authentic=True: bypass the test-env mock so we exercise
             # the real CachedChatCompletion wrap (the cassette is the layer
             # under test, not the LLM provider).
-            svc = create_llm_service(
-                "narration_test_replay_unit", force_authentic=True
-            )
-            assert getattr(svc, "mode", None) == "replay", (
-                "service was not wrapped in replay mode — cache wiring failed"
-            )
+            svc = create_llm_service("narration_test_replay_unit", force_authentic=True)
+            assert (
+                getattr(svc, "mode", None) == "replay"
+            ), "service was not wrapped in replay mode — cache wiring failed"
             kernel.add_service(svc)
             plugin = NarrativeSynthesisPlugin(kernel=kernel)
 
@@ -226,9 +248,7 @@ def _populate_db_from_first_cassette(db_dir: Path, key: str) -> None:
     """Materialize the first cassette into a fresh diskcache DB."""
     import diskcache  # type: ignore[import-not-found]
 
-    cassette = json.loads(
-        (FIXTURES_DIR / f"{key}.json").read_text(encoding="utf-8")
-    )
+    cassette = json.loads((FIXTURES_DIR / f"{key}.json").read_text(encoding="utf-8"))
     cache = diskcache.Cache(str(db_dir))
     try:
         cache.set(cassette["key"], cassette["value"])

--- a/tests/unit/argumentation_analysis/services/test_llm_cache.py
+++ b/tests/unit/argumentation_analysis/services/test_llm_cache.py
@@ -439,8 +439,12 @@ class TestComputeRawCacheKey:
         assert compute_raw_cache_key(**kw) == compute_raw_cache_key(**kw)
 
     def test_different_messages_different_key(self):
-        k1 = compute_raw_cache_key(model="m", messages=[{"role": "user", "content": "a"}])
-        k2 = compute_raw_cache_key(model="m", messages=[{"role": "user", "content": "b"}])
+        k1 = compute_raw_cache_key(
+            model="m", messages=[{"role": "user", "content": "a"}]
+        )
+        k2 = compute_raw_cache_key(
+            model="m", messages=[{"role": "user", "content": "b"}]
+        )
         assert k1 != k2
 
     def test_different_model_different_key(self):
@@ -513,6 +517,37 @@ class TestCachedRawChatCompletion:
                     messages=[{"role": "user", "content": "never seen"}],
                 )
             assert client.calls == 0  # fail-loud: must NOT silently call the API
+
+    @pytest.mark.asyncio
+    async def test_record_mode_unstorable_response_passes_through(
+        self, isolated_raw_cache
+    ):
+        """#1603: record is an observer — a response that cannot be pickled
+        (MagicMock from mock-client unit tests) must pass through unrecorded,
+        not break the caller. Regression: the CI record run failed 6 tests
+        with PicklingError and emptied 16 more (swallowed upstream)."""
+
+        class UnstorableClient:
+            calls = 0
+
+            class chat:  # noqa: N801 — mirrors openai client shape
+                class completions:
+                    @staticmethod
+                    async def create(**kwargs):
+                        UnstorableClient.calls += 1
+                        return MagicMock()  # model_dump() -> MagicMock -> unpicklable
+
+        with patch.dict(os.environ, {"LLM_CACHE_MODE": "record"}):
+            reset_raw_cache()
+            client = UnstorableClient()
+            kw = {"model": "m", "messages": [{"role": "user", "content": "q"}]}
+            r = await cached_raw_chat_completion(client, **kw)  # must NOT raise
+            assert r is not None
+            assert UnstorableClient.calls == 1
+            # Nothing was recorded: a fresh replay lookup must miss.
+            cache = get_raw_cache()
+            assert cache is not None
+            assert cache.get(compute_raw_cache_key(**kw)) is None
 
     @pytest.mark.asyncio
     async def test_tool_calls_roundtrip(self, isolated_raw_cache):

--- a/tests/unit/scripts/test_cassette_privacy.py
+++ b/tests/unit/scripts/test_cassette_privacy.py
@@ -1,0 +1,72 @@
+"""Privacy audit tests for LLM cassettes (#1603).
+
+Covers the blocking rules in ``scripts/cassettes/privacy.py`` plus the
+metadata-key exemption added for versioned model ids ("gpt-5-mini-2025-08-07"
+must NOT trip the historical-date heuristic — it is a model version stamp,
+not corpus prose).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.cassettes.privacy import audit_value
+
+
+def test_forbidden_key_is_blocked() -> None:
+    viol = audit_value({"raw_text": "secret", "value": "ok"}, source="t")
+    assert any("forbidden key 'raw_text'" in v for v in viol)
+
+
+def test_source_name_hint_is_blocked() -> None:
+    viol = audit_value(
+        {"content": "Cet argument reprend la position de Macron sur le sujet."},
+        source="t",
+    )
+    assert any("source-name hint" in v for v in viol)
+
+
+def test_historical_year_in_prose_is_blocked() -> None:
+    viol = audit_value(
+        {"content": "Le discours du 15 mars 1940 marque un tournant."},
+        source="t",
+    )
+    assert any("historical-year hint" in v for v in viol)
+
+
+def test_versioned_model_id_does_not_trip_date_heuristic() -> None:
+    # Regression #1603: raw-path cassettes carry model="gpt-5-mini-2025-08-07"
+    # (>= 20 chars, contains the current year) — the metadata exemption must
+    # keep the whole cassette clean.
+    raw = {
+        "model": "gpt-5-mini-2025-08-07",
+        "id": "chatcmpl-ABC2025def",
+        "created": 1755436800,
+        "object": "chat.completion",
+        "system_fingerprint": "fp_2025_abc",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "Réponse synthétique."},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 10,
+            "completion_tokens": 5,
+            "total_tokens": 15,
+        },
+    }
+    assert audit_value(raw, source="t") == []
+
+
+def test_content_inside_choices_is_still_audited() -> None:
+    raw = {
+        "model": "gpt-5-mini-2025-08-07",
+        "choices": [
+            {"message": {"role": "assistant", "content": "Macron a parlé en 1940."}}
+        ],
+    }
+    viol = audit_value(raw, source="t")
+    assert any("source-name hint" in v for v in viol)
+    assert any("historical-year hint" in v for v in viol)

--- a/tests/unit/scripts/test_cost_report.py
+++ b/tests/unit/scripts/test_cost_report.py
@@ -1,0 +1,77 @@
+"""Unit tests for the record-run cost artifact (#1603 DoD 6)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
+import diskcache
+import pytest
+
+from scripts.cassettes import cost_report
+
+
+def _seed_db(db_dir: Path, entries: Dict[str, Any]) -> None:
+    db = diskcache.Cache(str(db_dir))
+    try:
+        for key, value in entries.items():
+            db.set(key, value)
+    finally:
+        db.close()
+
+
+def test_analyze_sums_raw_path_usage_and_counts_sk_path(tmp_path: Path) -> None:
+    entries = {
+        "a"
+        * 64: {  # raw path — carries usage
+            "model": "gpt-5-mini",
+            "usage": {"prompt_tokens": 100, "completion_tokens": 20},
+        },
+        "b"
+        * 64: {  # raw path — usage absent
+            "model": "gpt-5-mini",
+        },
+        "c"
+        * 64: [  # SK path — list value, no usage
+            {"role": "assistant", "content": "hello"},
+        ],
+    }
+    _seed_db(tmp_path / "db", entries)
+
+    report = cost_report.analyze(tmp_path / "db")
+
+    assert report["total_requests"] == 3
+    assert report["raw_path_requests"] == 2
+    assert report["sk_path_requests"] == 1
+    assert report["prompt_tokens"] == 100
+    assert report["completion_tokens"] == 20
+    assert report["est_usd"] is None  # no pricing env → token-only report
+
+
+def test_analyze_estimates_usd_when_pricing_env_set(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("LLM_PRICE_PER_1M_IN", "1.0")
+    monkeypatch.setenv("LLM_PRICE_PER_1M_OUT", "4.0")
+    _seed_db(
+        tmp_path / "db",
+        {"a" * 64: {"usage": {"prompt_tokens": 500_000, "completion_tokens": 250_000}}},
+    )
+
+    report = cost_report.analyze(tmp_path / "db")
+
+    assert report["est_usd"] == pytest.approx(0.5 + 1.0)  # 0.5M*$1 + 0.25M*$4
+
+
+def test_analyze_rejects_unexpected_value_type(tmp_path: Path) -> None:
+    _seed_db(tmp_path / "db", {"a" * 64: 42})
+    with pytest.raises(ValueError):
+        cost_report.analyze(tmp_path / "db")
+
+
+def test_analyze_empty_db(tmp_path: Path) -> None:
+    _seed_db(tmp_path / "db", {})
+    report = cost_report.analyze(tmp_path / "db")
+    assert report["total_requests"] == 0
+    assert report["prompt_tokens"] == 0
+    assert report["completion_tokens"] == 0

--- a/tests/unit/scripts/test_replay_gate_check.py
+++ b/tests/unit/scripts/test_replay_gate_check.py
@@ -9,7 +9,7 @@ import pytest
 from scripts.cassettes import replay_gate_check
 
 
-def _ok() -> dict:
+def _ok() -> dict[str, int]:
     return {"live": 0, "hit": 7, "miss_record": 0, "miss_replay": 0}
 
 
@@ -48,7 +48,7 @@ def test_all_counters_violate_together() -> None:
     assert len(replay_gate_check.check(stats)) == 3
 
 
-def test_main_exit_codes(tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+def test_main_exit_codes(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     ok_file = tmp_path / "ok.json"
     ok_file.write_text('{"live": 0, "hit": 3, "miss_record": 0, "miss_replay": 0}')
     assert replay_gate_check.main([str(ok_file)]) == 0

--- a/tests/unit/scripts/test_replay_gate_check.py
+++ b/tests/unit/scripts/test_replay_gate_check.py
@@ -1,0 +1,61 @@
+"""Gate check tests for the LLM replay lane (#1603 DoD 4/5)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.cassettes import replay_gate_check
+
+
+def _ok() -> dict:
+    return {"live": 0, "hit": 7, "miss_record": 0, "miss_replay": 0}
+
+
+def test_honest_replay_passes() -> None:
+    assert replay_gate_check.check(_ok()) == []
+
+
+def test_live_call_is_a_violation() -> None:
+    stats = _ok() | {"live": 1}
+    viol = replay_gate_check.check(stats)
+    assert len(viol) == 1
+    assert "live=1" in viol[0]
+
+
+def test_zero_hits_is_a_violation() -> None:
+    """Anti-vacuité (family #1556): a lane that never consults the cache
+    is not a replay — hit must be >= 1."""
+    stats = _ok() | {"hit": 0}
+    viol = replay_gate_check.check(stats)
+    assert len(viol) == 1
+    assert "vacuous" in viol[0]
+
+
+def test_replay_miss_is_a_violation() -> None:
+    """DoD 5: a substituted (key-drifted) cassette makes the lane red —
+    the extract phase swallows LLMCacheMiss into a heuristic fallback, so
+    pytest alone stays green (constat D). The gate must not."""
+    stats = _ok() | {"miss_replay": 21}
+    viol = replay_gate_check.check(stats)
+    assert len(viol) == 1
+    assert "miss_replay=21" in viol[0]
+
+
+def test_all_counters_violate_together() -> None:
+    stats = _ok() | {"live": 3, "hit": 0, "miss_replay": 5}
+    assert len(replay_gate_check.check(stats)) == 3
+
+
+def test_main_exit_codes(tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+    ok_file = tmp_path / "ok.json"
+    ok_file.write_text('{"live": 0, "hit": 3, "miss_record": 0, "miss_replay": 0}')
+    assert replay_gate_check.main([str(ok_file)]) == 0
+
+    bad_file = tmp_path / "bad.json"
+    bad_file.write_text('{"live": 0, "hit": 0, "miss_record": 0, "miss_replay": 2}')
+    assert replay_gate_check.main([str(bad_file)]) == 1
+
+    assert replay_gate_check.main([str(tmp_path / "absent.json")]) == 2
+    assert replay_gate_check.main([]) == 2


### PR DESCRIPTION
## Summary

Refs #1603. Premier livrable du câblage replay LLM en CI : la tooling record + les mesures qui dimensionnent le reste (constats postés sur l'issue, commentaire 5315344440).

- **`scripts/cassettes/privacy.py`** : exemption des clés metadata dans les heuristiques date/nom. L'id versionné `gpt-5-mini-2025-08-07` (≥20 chars, contient l'année courante) tripait le faux positif `historical-year` sur **chaque** cassette raw-path (mesuré : 14/14 refusées → 14/14 exportées après fix). Les checks de clés interdites restent appliqués partout.
- **`scripts/cassettes/cost_report.py`** (nouveau) : artefact coût d'un run record. Somme les tokens `usage` du path raw (prouvé présent : `ChatCompletion.model_dump()` embarque le bloc), compte le path SK (pas d'usage), `est_usd` optionnel via `LLM_PRICE_PER_1M_IN/OUT`.
- **`.github/workflows/record-llm-cassettes.yml`** (nouveau) : job `workflow_dispatch` manual-only qui facture — mode `record` explicite, time cap + token cap fail-loud, export + audit bloquant, artefacts (cassettes + coût + junit). N'arme **aucun** déclencheur (DoD 7 séparé, arbitré).
- **`test_cassette_round_trip.py`** : sélection shape-aware — le replay SK-path casse si la cassette la plus récente est un dict raw-path ; filtre désormais par forme (`value_is="list"`).
- **README fixtures** : documente ce qu'un record capture réellement (raw path jamais mocké ; SK mocké par `PYTEST_CURRENT_TEST in os.environ` → n'enregistre rien) + l'exemption metadata.

## Mesures (DoD 1-5)

- Bande auto-skip sans clés : **258 skips stable ×2** (raisons JVM/orphan/nbformat — zéro skip « clé absente »).
- Clés stables : 14/14 identiques sur 2 runs record.
- Replay : `live=0` (mesuré), hit=7 / miss_replay=21 — asymétrie extract (constat C, spécifique route OpenRouter local : `invoke_callables.py:6148-6170` drop les params au rejet live → clés post-drop ≠ pre-drop).
- Substitution dégénérée : la lane reste **verte avec hit=0** (constat D — l'extract avale `LLMCacheMiss`) → le contrôle anti-vacuité (hit>0 && miss_replay==0) est requis dans la lane replay.
- Coût projeté passe complète : ~$1-5, 1-2h (probe 14 appels ≈ 8.5k tokens).

## Test plan

- [x] 13 tests : `test_cassette_privacy` (5, dont le faux positif model) + `test_cost_report` (4) + `test_cassette_round_trip` (4, shape-aware)
- [x] mypy strict : 0 erreur sur les fichiers modifiés
- [x] black : appliqué (5 fichiers)
- [x] Re-export probe : 14/14 cassettes exportées après fix audit

## Notes

- Flake8 non dispo dans `projet-is` (CI le lance, continue-on-error).
- Constats A/C/D → arbitrage demandé au coord (fail-loud `LLMCacheMiss` dans les callables ; scope de la passe record : CI job recommandé).


---

## Deuxième livrable (commits `c4464b88` + `78be19f0`) — lane replay + garde anti-vacuité (DoD 2-4)

- **`scripts/cassettes/replay_stats_plugin.py`** : plugin pytest actif uniquement sous `REPLAY_GATE=1` — reset des compteurs `llm_cache` en début de session, dump vers `REPLAY_STATS_OUT` en fin. Séparé du gate parce qu'un hook `sessionfinish` ne peut pas faire échouer le status de façon fiable.
- **`scripts/cassettes/replay_gate_check.py`** : CLI fail-loud qui impose `live==0` (anti-#1019, aucune requête sortante), `hit>=1` (la lane replaye vraiment — pas de vert vacuous, famille #1556), `miss_replay==0` (aucune dégradation silencieuse ; constat D : l'extract avale `LLMCacheMiss`, pytest seul reste vert sur cassette substituée).
- **`.github/workflows/replay-llm-lane.yml`** : lane `workflow_dispatch` SANS clé API provisionnée (la propriété anti-fuite est structurelle — rien vers quoi tomber), import des cassettes committées vers la DB runtime, run pytest sous `LLM_CACHE_MODE=replay` + `REPLAY_GATE=1`, gate en étape CI séparée, artefacts (stats + junit). Aucun déclencheur armé (DoD 7 = PR séparée, arbitée).
- **Record default re-targeté** (constat A) : la bande `requires_api` n'enregistre RIEN (le path SK est mocké sur `PYTEST_CURRENT_TEST`, `llm_service.py:115`, indépendamment des marqueurs) → défaut du job record passé à `not slow and not requires_api` (la bande des consommateurs raw-path, seuls facturables), avec note de coût (~500-1000 appels, ~$1-5 projetés, sonde possible via `extra_args`).
- **Tests** : 6 tests du gate (`test_replay_gate_check.py`), mypy strict 0 erreur, black OK. Smoke plugin validé (reset → dump JSON → résumé loud).
