### PR TITLE
fix(tests): track A mock-jpype reload no longer leaks into downstream JVM consumers (#1785)

### DIFF
--- a/tests/unit/argumentation_analysis/agents/core/logic/test_track_a_handlers.py
+++ b/tests/unit/argumentation_analysis/agents/core/logic/test_track_a_handlers.py
@@ -33,6 +33,76 @@ def _make_mock_jpype():
     return mock_jpype, class_registry
 
 
+_HANDLER_MODULES = (
+    "argumentation_analysis.agents.core.logic.ranking_handler",
+    "argumentation_analysis.agents.core.logic.bipolar_handler",
+    "argumentation_analysis.agents.core.logic.aba_handler",
+    "argumentation_analysis.agents.core.logic.adf_handler",
+    "argumentation_analysis.agents.core.logic.aspic_handler",
+    "argumentation_analysis.agents.core.logic.belief_revision_handler",
+    "argumentation_analysis.agents.core.logic.probabilistic_handler",
+    "argumentation_analysis.agents.core.logic.dialogue_handler",
+)
+
+
+def _restore_module_globals(mod, snapshot):
+    """Un-mutate a handler module reloaded under mock jpype (#1785).
+
+    ``reload(mod)`` under a patched ``sys.modules`` mutates the module in
+    place: its ``jpype`` global becomes the mock and its handler class is
+    redefined on mock JClasses. The module object is the one referenced by
+    ``sys.modules`` and by earlier importers (``tweety_bridge``, the lazy
+    ``analyze_aba`` import), so the mutation leaks downstream — CI renders
+    mock artifacts (e.g. ``extensions: []``) where the real JVM renders
+    ``[[]]``. Popping ``sys.modules`` is NOT enough: ``patch.dict`` exits by
+    restoring a full snapshot taken at entry, which re-inserts the same
+    mutated object. Restoring the pre-reload globals un-mutates it in place.
+    """
+    mod.__dict__.clear()
+    mod.__dict__.update(snapshot)
+
+
+def _evict_mock_module(mod):
+    """Drop a handler module that entered ``sys.modules`` under the mock.
+
+    For a module NOT yet imported at test start there is no pristine
+    snapshot to restore — the import itself ran under the mocked ``jpype``.
+    Evict it instead so the next import re-executes with the real ``jpype``.
+    Safe at teardown: ``patch.dict`` has already exited, so nothing will
+    re-insert the mutated object afterwards.
+    """
+    sys.modules.pop(mod.__name__, None)
+    parent_name, _, child = mod.__name__.rpartition(".")
+    parent = sys.modules.get(parent_name)
+    if parent is not None and hasattr(parent, child):
+        delattr(parent, child)
+
+
+@pytest.fixture(autouse=True)
+def _restore_handler_modules_after_each_test():
+    """Keep handler modules pristine for downstream consumers in this session.
+
+    The restore must happen AFTER the test body (the mock-based handler
+    instance the test uses reads the module's ``jpype`` global at call time),
+    so it runs as teardown, not inside ``_make_handler``.
+    """
+    snapshots = {}
+    missing = []
+    for name in _HANDLER_MODULES:
+        mod = sys.modules.get(name)
+        if mod is not None:
+            snapshots[mod] = dict(mod.__dict__)
+        else:
+            missing.append(name)
+    yield
+    for mod, snapshot in snapshots.items():
+        _restore_module_globals(mod, snapshot)
+    for name in missing:
+        mod = sys.modules.get(name)
+        if mod is not None:
+            _evict_mock_module(mod)
+
+
 # =====================================================================
 # Ranking Handler Tests (#55)
 # =====================================================================
@@ -476,9 +546,7 @@ class TestBeliefRevisionHandler:
             in registry
         )
         # The fabricated DalalRevision / revops package must NOT be loaded.
-        assert (
-            "org.tweetyproject.beliefdynamics.revops.DalalRevision" not in registry
-        )
+        assert "org.tweetyproject.beliefdynamics.revops.DalalRevision" not in registry
 
     def test_revise_dalal(self):
         handler, _, registry = self._make_handler()


### PR DESCRIPTION
## Summary

Fixes the mock-leak behind #1785: after `test_track_a_handlers.py` runs, the handler modules stay mutated (mocked jpype) for the rest of the session, so downstream lazy imports (`tweety_logic_plugin.analyze_aba`, JVM-up pins) resolve the **mocked** handler and render mock artifacts — CI rendered `extensions: []` (zero extensions) on an explicitly-empty ABA framework where the real JVM renders `[[]]` (exactly one extension: the empty set). Family #1019: a fabricated verdict from environment divergence, not a computation.

## Root cause (measured, two layers)

**Layer 1 — reload mutates the shared module object in place.** Each `TestXHandler._make_handler` does `reload(mod)` under `patch.dict(sys.modules, {"jpype": mock})`. `reload()` re-executes the module body **into the same module object**: its `jpype` global becomes the MagicMock and the handler class is redefined on mock JClasses. That module object is the one referenced by `sys.modules`, the parent package attribute, and earlier importers (`tweety_bridge.py:33-40`, the pin's collection-time import, the lazy `analyze_aba` import at `tweety_logic_plugin.py:358`). Even the *pre-reload* class objects keep working — their methods read `__globals__["jpype"]`, which the reload replaced with the mock.

**Layer 2 — evicting `sys.modules` cannot fix it.** `patch.dict.__exit__` → `_unpatch_dict()` (unittest/mock.py:1897) does `_clear_dict(sys.modules)` then `update(self._original)` where `_original` is a **full snapshot of sys.modules taken at entry**. The snapshot holds a reference to the same (now mutated) module object, so the exit re-inserts it. Probed post-eviction: `aba_handler in sys.modules: True`, module `jpype` global = `<MagicMock>`, "fresh" `from ...aba_handler import ABAHandler` returns the mutated module, `plugin.analyze_aba(empty)` renders `[]`.

## Fix

An autouse fixture in the test file (`_restore_handler_modules_after_each_test`):

- **before each test**: snapshot the 8 handler modules' `__dict__` (those already imported);
- **after each test**: restore the snapshots (de-mutates the shared object in place — covers `sys.modules`, parent attribute and all existing references at once);
- for a module **not yet imported** at snapshot time (its first import ran under the mock — no pristine state exists): evict it from `sys.modules` + parent attribute at teardown, which is safe there because `patch.dict` has already exited.

Teardown runs after the test body on purpose: the mock-based handler instance the test uses reads the module's `jpype` global at method-call time, so restoring inside `_make_handler` would break the tests themselves (verified: 12 failed when tried).

## Proof

Same session, `test_track_a_handlers.py` then the JVM-up pin `tests/agents/core/logic/test_1774_aba_empty_semantics.py`:

| | handler pin (`extensions == [[]]`) | plugin pin (`analyze_aba` → `[[]]`) |
|---|---|---|
| before | FAILED (`assert [] == [[]]`) | FAILED (`assert [] == [[]]`) |
| after | passed | passed |

- Same-session batch (track_a + pin #1774 + `test_tweety_logic_plugin_error_vocabulary.py` + `test_state_writers_1648.py`): **146 passed**, off fresh `origin/main` (5dcba3e8).
- Full sweep `tests/unit/argumentation_analysis/agents/core/logic/` + `plugins/` + `orchestration/`: see comment (all green, one unrelated pre-existing standalone failure).

## Out of scope (noted, not fixed here)

`tests/agents/core/logic/test_modal_logic_agent_authentic.py::test_text_to_belief_set_authentic_modal` fails **standalone on main** with `AttributeError: 'TweetyBridge' object has no attribute 'validate_modal_belief_set'` — pre-existing (modal routing gap, candidate #1774 lane), unrelated to this fix.

## Files removed and why

None.
