### PR TITLE
feat(tests): #1787 LLM egress counter — observation-only instrument, non-vacuity proven, gate measured at 26 leaks / 19 tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,6 +239,7 @@ jobs:
           name: pytest-results
           path: |
             pytest_report.xml
+            llm_egress_report.json
             **/*.log
           if-no-files-found: warn
 

--- a/.gitignore
+++ b/.gitignore
@@ -247,3 +247,7 @@ docs/reports/spectacular_vs_baseline.md
 /trace_fallacy_*
 /reanalysis_arg_*
 
+
+# LLM egress counter artifact (#1787) - test names + counts, stays local
+llm_egress_report.json
+pytest_report.xml

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -310,6 +310,19 @@ def pytest_configure(config):
         )
         _dotenv_patcher.start()
 
+    # LLM egress counter (#1787) — observation-only instrument. Counts outgoing
+    # httpx requests to LLM hosts for the whole session (SK kernel path, direct
+    # AsyncOpenAI path, embeddings: all transit through httpx). Installed AFTER
+    # env loading above so endpoint env vars are visible for host resolution.
+    # Never blocks; report lands in the terminal summary + llm_egress_report.json
+    # next to the junitxml. Non-vacuity control: tests/unit/test_llm_egress_counter.py.
+    from tests.llm_egress_counter import LLMEgressPlugin, activate
+
+    _llm_egress = activate()
+    config.pluginmanager.register(
+        LLMEgressPlugin(_llm_egress), name="llm_egress_counter"
+    )
+
 
 def pytest_unconfigure(config):
     """

--- a/tests/llm_egress_counter.py
+++ b/tests/llm_egress_counter.py
@@ -1,0 +1,239 @@
+"""LLM egress counter (#1787) — observation-only instrument for pytest sessions.
+
+Counts outgoing HTTP requests to LLM endpoints while the gate runs. The success
+value is 0: the gate runs under ``-m "not slow and not requires_api"``, so a test
+that legitimately needs a model carries the marker and is already excluded — any
+outgoing request during the gate is a leak by construction (#1591, #1787).
+
+Because 0 is also what the counter reads when it is NOT wired (hook not
+installed, transport replaced, client on an uninstrumented path), the non-vacuity
+control in ``tests/unit/test_llm_egress_counter.py`` is part of the instrument:
+it emits one request through each covered path and asserts the counter sees it.
+That test runs inside the gate, so every gate report self-attests liveness: its
+own row in the per-test breakdown must show the control requests.
+
+Observation only — never blocks. Blocking is a gate (legitimate after #1591),
+not an instrument. No pricing: a count, not an amount.
+"""
+
+import json
+import os
+import threading
+from collections import OrderedDict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+from urllib.parse import urlparse
+
+DEFAULT_HOSTS = ("api.openai.com", "openrouter.ai")
+
+# Env vars that carry an LLM endpoint URL (defaults + configured endpoints,
+# including local/self-hosted ones — they cost no OpenRouter credits but are
+# LLM egress and count).
+_ENV_URL_VARS = (
+    "OPENAI_BASE_URL",
+    "BASE_URL",
+    "OPENROUTER_BASE_URL",
+    "AZURE_OPENAI_ENDPOINT",
+    "OPENAI_BASE_URL_2",
+    "OPENAI_BASE_URL_3",
+    "OPENAI_BASE_URL_4",
+    "SELF_HOSTED_LLM_ENDPOINT",
+    "SELF_HOSTED_LLM_MINI_ENDPOINT",
+)
+
+SESSION_BUCKET = "(session)"
+
+
+def llm_hosts_from_env() -> frozenset:
+    """Default LLM hosts + hosts parsed from endpoint env vars (deduped)."""
+    hosts = set(DEFAULT_HOSTS)
+    for var in _ENV_URL_VARS:
+        raw = os.getenv(var, "").strip()
+        if not raw:
+            continue
+        candidate = urlparse(raw if "://" in raw else f"https://{raw}").hostname
+        if candidate:
+            hosts.add(candidate.lower())
+    return frozenset(hosts)
+
+
+class LLMEgressCounter:
+    """Thread-safe tally of outgoing requests to LLM hosts, per test.
+
+    Records (test, host, method, path) per request — never bodies or headers
+    (privacy discipline: test names and URL paths only, no corpus content).
+    """
+
+    def __init__(self, hosts: frozenset) -> None:
+        self._hosts = hosts
+        self._lock = threading.Lock()
+        self._requests: List[Dict[str, str]] = []
+        self._per_test: "OrderedDict[str, int]" = OrderedDict()
+        self.current_test: Optional[str] = None
+        self._installed = False
+        self._orig_client_send = None
+        self._orig_async_send = None
+
+    # ── observation core ──────────────────────────────────────────────
+
+    def _matches(self, host: Optional[str]) -> bool:
+        if not host:
+            return False
+        host = host.lower()
+        for known in self._hosts:
+            if host == known or host.endswith("." + known):
+                return True
+        return False
+
+    def observe_request(self, url: Any, method: str) -> None:
+        """Called from the httpx send wrappers. Must never raise into a test."""
+        try:
+            raw = str(url)
+            parsed = urlparse(raw)
+            host = parsed.hostname
+            if not self._matches(host):
+                return
+            entry = {
+                "test": self.current_test or SESSION_BUCKET,
+                "host": host,
+                "method": method,
+                "path": parsed.path or "/",
+            }
+            with self._lock:
+                self._requests.append(entry)
+                self._per_test[entry["test"]] = self._per_test.get(entry["test"], 0) + 1
+        except Exception:  # noqa: BLE001 — instrument must not break the measured run
+            pass
+
+    # ── install / uninstall (class-level httpx patch) ─────────────────
+
+    def install(self) -> None:
+        if self._installed:
+            return
+        import httpx
+
+        counter = self
+
+        def _client_send(client_self, request, **kwargs):
+            counter.observe_request(request.url, request.method)
+            return counter._orig_client_send(client_self, request, **kwargs)
+
+        async def _async_send(client_self, request, **kwargs):
+            counter.observe_request(request.url, request.method)
+            return await counter._orig_async_send(client_self, request, **kwargs)
+
+        self._orig_client_send = httpx.Client.send
+        self._orig_async_send = httpx.AsyncClient.send
+        httpx.Client.send = _client_send  # type: ignore[assignment]
+        httpx.AsyncClient.send = _async_send  # type: ignore[assignment]
+        self._installed = True
+
+    def uninstall(self) -> None:
+        if not self._installed:
+            return
+        import httpx
+
+        httpx.Client.send = self._orig_client_send  # type: ignore[assignment]
+        httpx.AsyncClient.send = self._orig_async_send  # type: ignore[assignment]
+        self._orig_client_send = None
+        self._orig_async_send = None
+        self._installed = False
+
+    # ── reporting ─────────────────────────────────────────────────────
+
+    def total(self) -> int:
+        with self._lock:
+            return len(self._requests)
+
+    def per_test(self) -> Dict[str, int]:
+        with self._lock:
+            return dict(self._per_test)
+
+    def snapshot(self) -> Dict[str, Any]:
+        with self._lock:
+            requests = [dict(r) for r in self._requests]
+            per_test = dict(self._per_test)
+        return {
+            "total": len(requests),
+            "hosts_watched": sorted(self._hosts),
+            "per_test": per_test,
+            "requests": requests,
+        }
+
+
+# ── session singleton ──────────────────────────────────────────────────
+
+_SESSION_COUNTER: Optional[LLMEgressCounter] = None
+
+
+def activate() -> LLMEgressCounter:
+    """Install the counter for this pytest session (idempotent)."""
+    global _SESSION_COUNTER
+    if _SESSION_COUNTER is None:
+        _SESSION_COUNTER = LLMEgressCounter(llm_hosts_from_env())
+        _SESSION_COUNTER.install()
+    return _SESSION_COUNTER
+
+
+def get_counter() -> Optional[LLMEgressCounter]:
+    """The session counter, or None when not activated (plain pytest import)."""
+    return _SESSION_COUNTER
+
+
+def write_report(counter: LLMEgressCounter, config: Any) -> Optional[Path]:
+    """Write ``llm_egress_report.json`` next to the junitxml artifact (or CWD)."""
+    data = counter.snapshot()
+    data["generated"] = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    xmlpath = getattr(getattr(config, "option", None), "xmlpath", None)
+    target_dir = Path(xmlpath).parent if xmlpath else Path(".")
+    out = target_dir / "llm_egress_report.json"
+    try:
+        out.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
+        return out
+    except OSError:
+        return None
+
+
+class LLMEgressPlugin:
+    """Pytest plugin wiring the counter: attribution, report, artifact."""
+
+    def __init__(self, counter: LLMEgressCounter) -> None:
+        self.counter = counter
+
+    def pytest_runtest_setup(self, item: Any) -> None:
+        self.counter.current_test = item.nodeid
+
+    def pytest_runtest_teardown(self, item: Any) -> None:
+        # Post-test emissions (session-scope fixture teardown, loop cleanup)
+        # bucket to "(session)" — attributing them to the just-finished test
+        # would miscount.
+        self.counter.current_test = None
+
+    def pytest_terminal_summary(self, terminalreporter: Any, exitstatus: Any) -> None:
+        snap = self.counter.snapshot()
+        total = snap["total"]
+        line = f"LLM egress (#1787): {total} request(s) to LLM hosts during this session (gate expectation: 0)"
+        terminalreporter.write_sep("=", line)
+        if total:
+            terminalreporter.write_line("Per-test breakdown (test -> requests):")
+            for test, count in sorted(snap["per_test"].items(), key=lambda kv: -kv[1]):
+                terminalreporter.write_line(f"  {count:5d}  {test}")
+            hosts = sorted({r["host"] for r in snap["requests"]})
+            terminalreporter.write_line(f"Hosts hit: {', '.join(hosts)}")
+            report_path = write_report(self.counter, terminalreporter.config)
+            if report_path:
+                terminalreporter.write_line(f"Full report: {report_path}")
+        else:
+            terminalreporter.write_line(
+                "0 — indistinguishable from an unwired counter unless the "
+                "non-vacuity control (tests/unit/test_llm_egress_counter.py) "
+                "ran in this session and shows its control requests in the "
+                "report/artifact."
+            )
+            report_path = write_report(self.counter, terminalreporter.config)
+            if report_path:
+                terminalreporter.write_line(f"Report (empty): {report_path}")
+
+    def pytest_sessionfinish(self, session: Any) -> None:
+        self.counter.uninstall()

--- a/tests/unit/test_llm_egress_counter.py
+++ b/tests/unit/test_llm_egress_counter.py
@@ -1,0 +1,136 @@
+"""Non-vacuity controls for the LLM egress counter (#1787).
+
+The counter's success value is 0 — exactly what it reads when unwired. These
+controls are therefore part of the instrument, not optional coverage: each
+emits ONE request through a covered path (via httpx.MockTransport — zero real
+network) and asserts the session counter sees exactly one.
+
+They also cover BOTH production paths named in the DoD:
+- raw path: direct ``AsyncOpenAI`` → ``client.chat.completions.create``
+  (the extract/governance/quality/fallacy/counter-arg funnel)
+- SK path: ``CachedChatCompletion`` wrapping an SK ``OpenAIChatCompletion``
+  (the kernel/agents funnel — conversational & cluedo modes)
+
+Because these tests run inside the gate, every gate report self-attests the
+counter is live: this file's rows must appear in the per-test breakdown.
+"""
+
+import httpx
+import pytest
+from openai import AsyncOpenAI
+
+from tests.llm_egress_counter import get_counter
+
+FAKE_OPENAI_HOST = "https://api.openai.com/v1"
+NON_LLM_URL = "https://example.com/ping"
+
+_CHAT_COMPLETION_PAYLOAD = {
+    "id": "chatcmpl-egress-control",
+    "object": "chat.completion",
+    "created": 1700000000,
+    "model": "gpt-5-mini",
+    "choices": [
+        {
+            "index": 0,
+            "message": {"role": "assistant", "content": "ok"},
+            "finish_reason": "stop",
+        }
+    ],
+    "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+}
+
+
+def _mock_transport() -> httpx.MockTransport:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=_CHAT_COMPLETION_PAYLOAD)
+
+    return httpx.MockTransport(handler)
+
+
+def _session_counter():
+    counter = get_counter()
+    assert counter is not None, (
+        "session counter not activated — tests/conftest.py pytest_configure "
+        "must call activate() (#1787)"
+    )
+    return counter
+
+
+async def test_counter_sees_raw_openai_sdk_request():
+    """Chemin brut: 1 request via direct AsyncOpenAI → counter +1 (not 0, not 2)."""
+    counter = _session_counter()
+    client = AsyncOpenAI(
+        api_key="sk-egress-control",
+        base_url=FAKE_OPENAI_HOST,
+        http_client=httpx.AsyncClient(transport=_mock_transport()),
+    )
+    before = counter.total()
+    response = await client.chat.completions.create(
+        model="gpt-5-mini",
+        messages=[{"role": "user", "content": "egress control"}],
+    )
+    assert response.choices[0].message.content == "ok"
+    assert counter.total() == before + 1, (
+        f"non-vacuity FAILED on the raw path: expected {before + 1}, "
+        f"counter reads {counter.total()} — the counter is blind to the "
+        "direct AsyncOpenAI path"
+    )
+
+
+async def test_counter_sees_sk_wrapper_request():
+    """Chemin SK: 1 request via CachedChatCompletion(OpenAIChatCompletion) → counter +1."""
+    pytest.importorskip("semantic_kernel")
+    from semantic_kernel.connectors.ai.open_ai import OpenAIChatCompletion
+
+    from argumentation_analysis.services.llm_cache import CachedChatCompletion
+
+    counter = _session_counter()
+    inner = OpenAIChatCompletion(
+        ai_model_id="gpt-5-mini",
+        api_key="sk-egress-control",
+        async_client=AsyncOpenAI(
+            api_key="sk-egress-control",
+            base_url=FAKE_OPENAI_HOST,
+            http_client=httpx.AsyncClient(transport=_mock_transport()),
+        ),
+    )
+    wrapped = CachedChatCompletion(inner=inner, mode="off")
+
+    from semantic_kernel.connectors.ai.prompt_execution_settings import (
+        PromptExecutionSettings,
+    )
+    from semantic_kernel.contents import ChatHistory
+
+    history = ChatHistory()
+    history.add_user_message("egress control")
+    before = counter.total()
+    result = await wrapped.get_chat_message_contents(
+        chat_history=history,
+        settings=PromptExecutionSettings(ai_model_id="gpt-5-mini"),
+    )
+    assert result and getattr(result[0], "content", None) == "ok"
+    assert counter.total() == before + 1, (
+        f"non-vacuity FAILED on the SK wrapper path: expected {before + 1}, "
+        f"counter reads {counter.total()} — the counter is blind to the "
+        "CachedChatCompletion/kernel path"
+    )
+
+
+async def test_counter_sees_bare_httpx_request():
+    """Transport floor: a bare httpx request to an LLM host is counted."""
+    counter = _session_counter()
+    async with httpx.AsyncClient(transport=_mock_transport()) as client:
+        before = counter.total()
+        await client.post(
+            f"{FAKE_OPENAI_HOST}/chat/completions", json={"probe": "egress"}
+        )
+    assert counter.total() == before + 1
+
+
+async def test_counter_ignores_non_llm_host():
+    """Specificity: a request to a non-LLM host leaves the count unchanged."""
+    counter = _session_counter()
+    async with httpx.AsyncClient(transport=_mock_transport()) as client:
+        before = counter.total()
+        await client.get(NON_LLM_URL)
+    assert counter.total() == before


### PR DESCRIPTION
## Summary

#1787 : le gate a désormais un compteur de requêtes sortantes vers les endpoints LLM. Valeur attendue **0** — le gate tourne sous `-m "not slow and not requires_api"`, donc tout appel qui sort est une fuite par construction (#1591). Observation pure : l'instrument ne bloque jamais, ne tarife pas, n'arme aucun gate (après #1591) et ne touche aucun test existant.

## L'instrument

`tests/llm_egress_counter.py` — patch classe-level de `httpx.Client.send` / `httpx.AsyncClient.send` installé pour toute session pytest (via `tests/conftest.py` `pytest_configure`). **Pourquoi httpx** : tous les chemins LLM du dépôt y convergent — le SDK openai appelle `self._client.send(...)` (`openai._base_client`), le connecteur SK construit ses clients sur ce même SDK, les 20+ sites `AsyncOpenAI` directs aussi, et les embeddings `OpenAI()` sync. Le non-httpx restant (downloads JVM/outil, Tika) n'est pas du LLM egress.

- **Hôtes surveillés** : `api.openai.com`, `openrouter.ai` + hôtes parsés des endpoints configurés (`OPENAI_BASE_URL`, `OPENROUTER_BASE_URL`, `AZURE_OPENAI_ENDPOINT`, `OPENAI_BASE_URL_2..4`, `SELF_HOSTED_LLM_*`).
- **Attribution par test** : chaque requête est créditée au test en cours (`pytest_runtest_setup/teardown`) ; les émissions hors test (fixtures de session, cleanup) vont dans le bucket `(session)`.
- **Publication** : ligne `LLM egress (#1787): N request(s)...` dans le résumé terminal du job + artefact `llm_egress_report.json` (total, hôtes surveillés, ventilation par test, liste requêtes test/host/method/path — jamais de bodies ni headers) écrit à côté de `pytest_report.xml` et ajouté à l'upload CI.

## Le piège central traité en premier : 0 propre ≡ 0 débranché

La valeur de succès de l'instrument est 0 — exactement ce qu'il affiche s'il n'est pas branché. Le contrôle de non-vacuité est donc **livré dans la même PR** (`tests/unit/test_llm_egress_counter.py`, 4 tests, MockTransport = zéro réseau réel) :

| contrôle | attendu | résultat |
|---|---|---|
| chemin brut : `AsyncOpenAI` direct → `chat.completions.create` | 1 émise → compteur +1 | ✅ |
| chemin SK : `CachedChatCompletion(OpenAIChatCompletion)` → `get_chat_message_contents` | 1 émise → compteur +1 | ✅ |
| plancher transport : httpx nu vers un hôte LLM | compteur +1 | ✅ |
| spécificité : requête vers un hôte non-LLM | compteur inchangé | ✅ |

**Effet canari** : ces contrôles tournent DANS le gate — chaque rapport de gate atteste la vivacité du compteur par ses propres lignes dans la ventilation. Si un jour le fichier de contrôle affiche 0 requêtes comptées dans un run de gate, l'instrument est cassé, pas le gate propre.

## Compte sur un run de gate réel (valeur communiquée telle quelle)

Run local, commande CI exacte (`pytest tests/unit/ tests/scripts/ -m "not slow and not requires_api" --junitxml=pytest_report.xml --timeout=900 --timeout-method=thread`), clés réelles chargées (conditions de fuite reproduites), branche = cette PR (l'instrument actif) :

- **Total : 29 requête(s) sortante(s)** — dont 3 émises par les contrôles de non-vacuité ci-dessus (auto-attestation : leurs 3 lignes sont dans la ventilation).
- **Fuite réelle : 26 requêtes depuis 19 tests existants distincts.**
- Ventilation par hôte :

| requêtes | hôte | nature |
|---|---|---|
| 12 | `openrouter.ai` | **crédits réels — le leak que l'utilisateur ne veut plus** |
| 9 | `api.medium.text-generation-webui.myia.io` | self-hosted (coût nul mais egress LLM) |
| 5 | `localhost` | endpoints locaux configurés |
| 3 | `api.openai.com` | les contrôles de non-vacuité de cette PR |

- Ventilation par test (extraits ; artefact complet = `llm_egress_report.json`, joint au run CI) : `test_unified_pipeline` 3 tests ×2, `test_camembert_invoke` 3 tests ×2, `test_bipolar_honest_degraded_1645` 4 tests → openrouter.ai, `test_nli_hierarchical` 2 tests → self-hosted, `test_router` 2 tests, `test_local_llm_service` 2, `test_pl_2pass_pipeline` 2, `test_architecture_compliance` 1. Chaque test fuiteur émet 1-2 requêtes — la distribution est plate, pas concentrée (différent du ~90-dans-un-test vu par #1591 sur un autre périmètre).

Comparaison avec le relevé #1579 (21 tests sortants, comptage httpx ad hoc jamais instrumenté) : **19 ici**. L'écart de 2 est cohérent avec les 54 échecs locaux pré-existants (mcp_server, compare_orchestration sans clés) — des tests #1579 ont pu mourir avant d'émettre en local. Le compte définitif attendu : celui du run CI de cette PR.

⚠ Limites honnêtes du run local : 54 tests échouent localement (pré-existants, vérifiés indépendants de cette PR qui ne touche aucun test — mcp_server_v2 à l'import, compare_orchestration sans clés, proof_bo2b) — leurs éventuelles requêtes n'ont pas pu partir ; le compte CI peut donc être ≥ à celui-ci. Les requêtes émises par des sous-processus spawnés par des tests ne sont pas vues (patch in-process). Le chiffre définitif sera celui du run CI de cette PR (ligne `LLM egress` dans le log + artefact joint).

## Périmètre respecté

- **Aucun test existant modifié** (seuls fichiers touchés : l'instrument nouveau, son test nouveau, l'activation conftest, 2 lignes .gitignore, 1 ligne upload ci.yml).
- Pas de blocage réseau, pas de gate armé, pas de tarif, pas de marquage `requires_api`/`slow` de fuites.
- Privacy : la ventilation nomme des tests et des URL paths — jamais de contenu de corpus, jamais de bodies.

Closes #1787
