### PR TITLE
test(gate): close the LLM egress leaks — counter sees httpx2, 26→0 measured (#1591)

### DIFF
--- a/tests/llm_egress_counter.py
+++ b/tests/llm_egress_counter.py
@@ -1,16 +1,26 @@
-"""LLM egress counter (#1787) — observation-only instrument for pytest sessions.
+"""LLM egress counter (#1787, 3-state #1591) — observation-only pytest instrument.
 
-Counts outgoing HTTP requests to LLM endpoints while the gate runs. The success
-value is 0: the gate runs under ``-m "not slow and not requires_api"``, so a test
-that legitimately needs a model carries the marker and is already excluded — any
-outgoing request during the gate is a leak by construction (#1591, #1787).
+Counts outgoing HTTP requests during the gate in three classes, so that an
+absent env var produces "unknown host seen" instead of silence (#1591):
 
-Because 0 is also what the counter reads when it is NOT wired (hook not
-installed, transport replaced, client on an uninstrumented path), the non-vacuity
-control in ``tests/unit/test_llm_egress_counter.py`` is part of the instrument:
-it emits one request through each covered path and asserts the counter sees it.
-That test runs inside the gate, so every gate report self-attests liveness: its
-own row in the per-test breakdown must show the control requests.
+- ``llm``     — request to a watched LLM host. Watched = defaults
+                (api.openai.com, openrouter.ai) + hosts parsed from endpoint
+                env vars. THE gate metric: expectation 0 (the gate runs under
+                ``-m "not slow and not requires_api"``, so any LLM call is a
+                leak by construction, #1591/#1787).
+- ``nonllm``  — request to a known non-LLM host (test infra: tika, github,
+                pypi). Counted for completeness, not a leak.
+- ``unknown`` — anything else. NOT ignored: a request to a self-hosted/localhost
+                LLM endpoint whose env var is absent from this environment
+                lands here — visible, auditable, never silently dropped
+                (coordinator R825: "0 propre ≡ 0 débranché", un cran plus bas
+                — the hook is wired, but its host list shrinks with the env).
+
+Because the ``llm`` success value is 0 — exactly what an unwired counter
+reads — the non-vacuity controls in ``tests/unit/test_llm_egress_counter.py``
+are part of the instrument: they emit one request per covered path and assert
+the counter sees it. They run inside the gate, so every gate report
+self-attests liveness through their own rows.
 
 Observation only — never blocks. Blocking is a gate (legitimate after #1591),
 not an instrument. No pricing: a count, not an amount.
@@ -42,6 +52,24 @@ _ENV_URL_VARS = (
     "SELF_HOSTED_LLM_MINI_ENDPOINT",
 )
 
+# Non-LLM hosts the test infrastructure legitimately contacts. Deliberately
+# minimal: anything not here and not LLM-watched surfaces as "unknown".
+KNOWN_NON_LLM_HOSTS = frozenset(
+    {
+        "tika.open-webui.myia.io",
+        "api.github.com",
+        "github.com",
+        "raw.githubusercontent.com",
+        "objects.githubusercontent.com",
+        "pypi.org",
+        "files.pythonhosted.org",
+    }
+)
+
+CLASS_LLM = "llm"
+CLASS_NON_LLM = "nonllm"
+CLASS_UNKNOWN = "unknown"
+
 SESSION_BUCKET = "(session)"
 
 
@@ -59,17 +87,19 @@ def llm_hosts_from_env() -> frozenset:
 
 
 class LLMEgressCounter:
-    """Thread-safe tally of outgoing requests to LLM hosts, per test.
+    """Thread-safe tally of outgoing requests, 3-state classified, per test.
 
-    Records (test, host, method, path) per request — never bodies or headers
-    (privacy discipline: test names and URL paths only, no corpus content).
+    Records (test, host, method, path, class) per request — never bodies or
+    headers (privacy discipline: test names and URL paths only, no corpus
+    content).
     """
 
     def __init__(self, hosts: frozenset) -> None:
         self._hosts = hosts
         self._lock = threading.Lock()
         self._requests: List[Dict[str, str]] = []
-        self._per_test: "OrderedDict[str, int]" = OrderedDict()
+        self._per_test: "OrderedDict[str, int]" = OrderedDict()  # llm only
+        self._per_test_unknown: "OrderedDict[str, int]" = OrderedDict()
         self.current_test: Optional[str] = None
         self._installed = False
         self._orig_client_send = None
@@ -77,14 +107,17 @@ class LLMEgressCounter:
 
     # ── observation core ──────────────────────────────────────────────
 
-    def _matches(self, host: Optional[str]) -> bool:
+    def _classify(self, host: Optional[str]) -> Optional[str]:
+        """Return 'llm' | 'nonllm' | 'unknown', or None when host unparsable."""
         if not host:
-            return False
+            return None
         host = host.lower()
         for known in self._hosts:
             if host == known or host.endswith("." + known):
-                return True
-        return False
+                return CLASS_LLM
+        if host in KNOWN_NON_LLM_HOSTS:
+            return CLASS_NON_LLM
+        return CLASS_UNKNOWN
 
     def observe_request(self, url: Any, method: str) -> None:
         """Called from the httpx send wrappers. Must never raise into a test."""
@@ -92,17 +125,26 @@ class LLMEgressCounter:
             raw = str(url)
             parsed = urlparse(raw)
             host = parsed.hostname
-            if not self._matches(host):
+            klass = self._classify(host)
+            if klass is None:
                 return
             entry = {
                 "test": self.current_test or SESSION_BUCKET,
                 "host": host,
                 "method": method,
                 "path": parsed.path or "/",
+                "class": klass,
             }
             with self._lock:
                 self._requests.append(entry)
-                self._per_test[entry["test"]] = self._per_test.get(entry["test"], 0) + 1
+                if klass == CLASS_LLM:
+                    self._per_test[entry["test"]] = (
+                        self._per_test.get(entry["test"], 0) + 1
+                    )
+                elif klass == CLASS_UNKNOWN:
+                    self._per_test_unknown[entry["test"]] = (
+                        self._per_test_unknown.get(entry["test"], 0) + 1
+                    )
         except Exception:  # noqa: BLE001 — instrument must not break the measured run
             pass
 
@@ -143,10 +185,12 @@ class LLMEgressCounter:
     # ── reporting ─────────────────────────────────────────────────────
 
     def total(self) -> int:
+        """LLM-watched request count — the gate metric (expectation 0)."""
         with self._lock:
-            return len(self._requests)
+            return sum(1 for r in self._requests if r["class"] == CLASS_LLM)
 
     def per_test(self) -> Dict[str, int]:
+        """LLM-watched requests per test (leak ventilation)."""
         with self._lock:
             return dict(self._per_test)
 
@@ -154,10 +198,16 @@ class LLMEgressCounter:
         with self._lock:
             requests = [dict(r) for r in self._requests]
             per_test = dict(self._per_test)
+            per_test_unknown = dict(self._per_test_unknown)
+        totals = {c: 0 for c in (CLASS_LLM, CLASS_NON_LLM, CLASS_UNKNOWN)}
+        for r in requests:
+            totals[r["class"]] += 1
         return {
-            "total": len(requests),
+            "total": totals[CLASS_LLM],
+            "totals_by_class": totals,
             "hosts_watched": sorted(self._hosts),
             "per_test": per_test,
+            "per_test_unknown": per_test_unknown,
             "requests": requests,
         }
 
@@ -212,28 +262,41 @@ class LLMEgressPlugin:
 
     def pytest_terminal_summary(self, terminalreporter: Any, exitstatus: Any) -> None:
         snap = self.counter.snapshot()
-        total = snap["total"]
-        line = f"LLM egress (#1787): {total} request(s) to LLM hosts during this session (gate expectation: 0)"
+        t = snap["totals_by_class"]
+        line = (
+            f"LLM egress (#1787): {t['llm']} watched-LLM request(s) "
+            f"(gate expectation: 0) · {t['nonllm']} known non-LLM · "
+            f"{t['unknown']} UNKNOWN host"
+        )
         terminalreporter.write_sep("=", line)
-        if total:
-            terminalreporter.write_line("Per-test breakdown (test -> requests):")
+        if t["llm"]:
+            terminalreporter.write_line("Per-test LLM breakdown (test -> requests):")
             for test, count in sorted(snap["per_test"].items(), key=lambda kv: -kv[1]):
                 terminalreporter.write_line(f"  {count:5d}  {test}")
-            hosts = sorted({r["host"] for r in snap["requests"]})
-            terminalreporter.write_line(f"Hosts hit: {', '.join(hosts)}")
-            report_path = write_report(self.counter, terminalreporter.config)
-            if report_path:
-                terminalreporter.write_line(f"Full report: {report_path}")
-        else:
+            hosts = sorted({r["host"] for r in snap["requests"] if r["class"] == CLASS_LLM})
+            terminalreporter.write_line(f"LLM hosts hit: {', '.join(hosts)}")
+        elif not any(
+            "test_llm_egress_counter" in t_ for t_ in snap["per_test"]
+        ):
             terminalreporter.write_line(
-                "0 — indistinguishable from an unwired counter unless the "
-                "non-vacuity control (tests/unit/test_llm_egress_counter.py) "
-                "ran in this session and shows its control requests in the "
-                "report/artifact."
+                "0 LLM requests and the non-vacuity control did NOT run in this "
+                "session — this 0 is indistinguishable from an unwired counter "
+                "(tests/unit/test_llm_egress_counter.py must run for liveness)."
             )
-            report_path = write_report(self.counter, terminalreporter.config)
-            if report_path:
-                terminalreporter.write_line(f"Report (empty): {report_path}")
+        if t["unknown"]:
+            terminalreporter.write_line(
+                "UNKNOWN hosts seen (not watched-LLM, not known infra — if an "
+                "endpoint env var is absent here, its requests surface here):"
+            )
+            unknown_hosts: Dict[str, int] = {}
+            for r in snap["requests"]:
+                if r["class"] == CLASS_UNKNOWN:
+                    unknown_hosts[r["host"]] = unknown_hosts.get(r["host"], 0) + 1
+            for host, n in sorted(unknown_hosts.items(), key=lambda kv: -kv[1]):
+                terminalreporter.write_line(f"  {n:5d}  {host}")
+        report_path = write_report(self.counter, terminalreporter.config)
+        if report_path:
+            terminalreporter.write_line(f"Egress report: {report_path}")
 
     def pytest_sessionfinish(self, session: Any) -> None:
         self.counter.uninstall()

--- a/tests/llm_egress_counter.py
+++ b/tests/llm_egress_counter.py
@@ -103,6 +103,11 @@ class LLMEgressCounter:
         self.current_test: Optional[str] = None
         self._installed = False
         self._patched_mods: List[Any] = []
+        # Immutable snapshot of patched transport names, set at install and
+        # never cleared: uninstall() empties _patched_mods before the terminal
+        # report reads it (sessionfinish -> terminal_summary), which made
+        # `transports_patched` read [] in the report (#1591).
+        self._transports_names: List[str] = []
         self._orig_sends: Dict[Any, Any] = {}
 
     # ── observation core ──────────────────────────────────────────────
@@ -197,6 +202,7 @@ class LLMEgressCounter:
                 self._patched_mods.append(mod)
             except AttributeError:
                 continue
+        self._transports_names = [m.__name__ for m in self._patched_mods]
         self._installed = True
 
     def uninstall(self) -> None:
@@ -233,7 +239,7 @@ class LLMEgressCounter:
             "total": totals[CLASS_LLM],
             "totals_by_class": totals,
             "hosts_watched": sorted(self._hosts),
-            "transports_patched": [m.__name__ for m in self._patched_mods],
+            "transports_patched": list(self._transports_names),
             "per_test": per_test,
             "per_test_unknown": per_test_unknown,
             "requests": requests,

--- a/tests/llm_egress_counter.py
+++ b/tests/llm_egress_counter.py
@@ -102,8 +102,8 @@ class LLMEgressCounter:
         self._per_test_unknown: "OrderedDict[str, int]" = OrderedDict()
         self.current_test: Optional[str] = None
         self._installed = False
-        self._orig_client_send = None
-        self._orig_async_send = None
+        self._patched_mods: List[Any] = []
+        self._orig_sends: Dict[Any, Any] = {}
 
     # ── observation core ──────────────────────────────────────────────
 
@@ -148,38 +148,65 @@ class LLMEgressCounter:
         except Exception:  # noqa: BLE001 — instrument must not break the measured run
             pass
 
-    # ── install / uninstall (class-level httpx patch) ─────────────────
+    # ── install / uninstall (class-level httpx + httpx2 patch) ─────────
+    #
+    # openai>=3.x dropped its httpx dependency for httpx2 (requires_dist of
+    # openai 3.1.0: httpx2<3,>=2.7.0 — no httpx). CI resolves openai 3.1.0
+    # (environment.yml is unpinned), so every SDK call that does NOT inject
+    # an httpx client leaves via httpx2.AsyncClient.send there. Patching
+    # httpx only made the CI gate read a false 0 for exactly those calls
+    # (#1591 livrable 0: run 32048104455 "3 requests" = 3 controls only,
+    # while the 12 openrouter-class leaks fired uncounted). httpx2 is absent
+    # from local envs — hence the guarded import, not a hard dependency.
+
+    def _make_wrappers(self, mod):
+        counter = self
+
+        def _client_send(client_self, request, **kwargs):
+            counter.observe_request(request.url, request.method)
+            return counter._orig_sends[(mod, "sync")](client_self, request, **kwargs)
+
+        async def _async_send(client_self, request, **kwargs):
+            counter.observe_request(request.url, request.method)
+            return await counter._orig_sends[(mod, "async")](
+                client_self, request, **kwargs
+            )
+
+        return _client_send, _async_send
 
     def install(self) -> None:
         if self._installed:
             return
         import httpx
 
-        counter = self
+        self._orig_sends = {}
+        self._patched_mods = []
+        try:
+            import httpx2  # noqa: F401 — openai>=3.x transport (CI)
 
-        def _client_send(client_self, request, **kwargs):
-            counter.observe_request(request.url, request.method)
-            return counter._orig_client_send(client_self, request, **kwargs)
-
-        async def _async_send(client_self, request, **kwargs):
-            counter.observe_request(request.url, request.method)
-            return await counter._orig_async_send(client_self, request, **kwargs)
-
-        self._orig_client_send = httpx.Client.send
-        self._orig_async_send = httpx.AsyncClient.send
-        httpx.Client.send = _client_send  # type: ignore[assignment]
-        httpx.AsyncClient.send = _async_send  # type: ignore[assignment]
+            mods = (httpx, httpx2)
+        except ImportError:
+            mods = (httpx,)
+        for mod in mods:
+            try:
+                self._orig_sends[(mod, "sync")] = mod.Client.send
+                self._orig_sends[(mod, "async")] = mod.AsyncClient.send
+                client_send, async_send = self._make_wrappers(mod)
+                mod.Client.send = client_send  # type: ignore[assignment]
+                mod.AsyncClient.send = async_send  # type: ignore[assignment]
+                self._patched_mods.append(mod)
+            except AttributeError:
+                continue
         self._installed = True
 
     def uninstall(self) -> None:
         if not self._installed:
             return
-        import httpx
-
-        httpx.Client.send = self._orig_client_send  # type: ignore[assignment]
-        httpx.AsyncClient.send = self._orig_async_send  # type: ignore[assignment]
-        self._orig_client_send = None
-        self._orig_async_send = None
+        for mod in self._patched_mods:
+            mod.Client.send = self._orig_sends[(mod, "sync")]  # type: ignore[assignment]
+            mod.AsyncClient.send = self._orig_sends[(mod, "async")]  # type: ignore[assignment]
+        self._patched_mods = []
+        self._orig_sends = {}
         self._installed = False
 
     # ── reporting ─────────────────────────────────────────────────────
@@ -206,6 +233,7 @@ class LLMEgressCounter:
             "total": totals[CLASS_LLM],
             "totals_by_class": totals,
             "hosts_watched": sorted(self._hosts),
+            "transports_patched": [m.__name__ for m in self._patched_mods],
             "per_test": per_test,
             "per_test_unknown": per_test_unknown,
             "requests": requests,
@@ -273,11 +301,11 @@ class LLMEgressPlugin:
             terminalreporter.write_line("Per-test LLM breakdown (test -> requests):")
             for test, count in sorted(snap["per_test"].items(), key=lambda kv: -kv[1]):
                 terminalreporter.write_line(f"  {count:5d}  {test}")
-            hosts = sorted({r["host"] for r in snap["requests"] if r["class"] == CLASS_LLM})
+            hosts = sorted(
+                {r["host"] for r in snap["requests"] if r["class"] == CLASS_LLM}
+            )
             terminalreporter.write_line(f"LLM hosts hit: {', '.join(hosts)}")
-        elif not any(
-            "test_llm_egress_counter" in t_ for t_ in snap["per_test"]
-        ):
+        elif not any("test_llm_egress_counter" in t_ for t_ in snap["per_test"]):
             terminalreporter.write_line(
                 "0 LLM requests and the non-vacuity control did NOT run in this "
                 "session — this 0 is indistinguishable from an unwired counter "

--- a/tests/llm_egress_counter.py
+++ b/tests/llm_egress_counter.py
@@ -54,6 +54,9 @@ _ENV_URL_VARS = (
 
 # Non-LLM hosts the test infrastructure legitimately contacts. Deliberately
 # minimal: anything not here and not LLM-watched surfaces as "unknown".
+# "testserver" is the ASGI/starlette TestClient base host — in-process loopback
+# exercising the app object, never external egress (first CI run with the
+# 3-state counter showed 141 of them drowning the unknown bucket).
 KNOWN_NON_LLM_HOSTS = frozenset(
     {
         "tika.open-webui.myia.io",
@@ -63,6 +66,7 @@ KNOWN_NON_LLM_HOSTS = frozenset(
         "objects.githubusercontent.com",
         "pypi.org",
         "files.pythonhosted.org",
+        "testserver",
     }
 )
 

--- a/tests/unit/argumentation_analysis/adapters/test_nli_hierarchical.py
+++ b/tests/unit/argumentation_analysis/adapters/test_nli_hierarchical.py
@@ -355,10 +355,15 @@ class TestAdapterHierarchicalIntegration:
         assert adapter._nli_hierarchical is True
 
     def test_adapter_detect_calls_nli_with_hierarchical(self):
+        # enable_self_hosted_llm defaults to True: without disabling it, the
+        # ambient SELF_HOSTED_LLM_ENDPOINT tier fires a real completion during
+        # detect() (#1591, measured: 1 request) alongside the mocked NLI tier
+        # these tests are about.
         adapter = FrenchFallacyAdapter(
             enable_symbolic=False,
             enable_nli=True,
             enable_llm=False,
+            enable_self_hosted_llm=False,
             nli_hierarchical=True,
         )
         # Mock the NLI detector
@@ -378,10 +383,12 @@ class TestAdapterHierarchicalIntegration:
         assert "nli_hierarchical" in result["tiers_used"]
 
     def test_adapter_detect_calls_nli_flat_by_default(self):
+        # Same #1591 premise fix as the hierarchical test above.
         adapter = FrenchFallacyAdapter(
             enable_symbolic=False,
             enable_nli=True,
             enable_llm=False,
+            enable_self_hosted_llm=False,
         )
         mock_nli = MagicMock()
         mock_nli.is_available.return_value = True

--- a/tests/unit/argumentation_analysis/orchestration/test_bipolar_honest_degraded_1645.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_bipolar_honest_degraded_1645.py
@@ -42,6 +42,25 @@ _BRIDGE_BIPOLAR = (
 _FABRICATED = "JVM/Tweety required"  # the old relabeled diagnostic — must be GONE
 _INSTALL_HINT = "Install JVM"  # likewise
 
+# #1591 hermeticity: _invoke_bipolar calls the real LLM translator whenever
+# supports is empty (invoke_callables.py, late import from the source module).
+# None of the four JVM-state verdicts below read translator output, so the
+# mock returns a successful empty outcome — the honest shape the real
+# translator produces on this synthetic input, minus the 4 outgoing
+# requests (measured: 4 → 0).
+_TRANSLATOR_SRC = (
+    "argumentation_analysis.orchestration.structured_arg_translator"
+    ".translate_to_bipolar_supports"
+)
+
+
+def _translator_empty_outcome():
+    outcome = MagicMock()
+    outcome.relations = []
+    outcome.cause = "ok"
+    outcome.error = ""
+    return outcome
+
 
 def _run(coro):
     return asyncio.new_event_loop().run_until_complete(coro)
@@ -70,7 +89,9 @@ class TestJvmAbsentIsHonestAbsent:
         # BipolarHandler() construct + JClass would raise with no JVM; patch the
         # handler to raise so the except path is exercised, AND force
         # isJVMStarted False so the fix routes to honest-absent.
-        with patch(_BRIDGE_BIPOLAR, side_effect=RuntimeError("no JVM")), patch(
+        with patch(
+            _TRANSLATOR_SRC, new=AsyncMock(return_value=_translator_empty_outcome())
+        ), patch(_BRIDGE_BIPOLAR, side_effect=RuntimeError("no JVM")), patch(
             "jpype.isJVMStarted", return_value=False
         ):
             result = _run(_invoke_bipolar("text", _ctx()))
@@ -89,7 +110,9 @@ class TestJvmAbsentIsHonestAbsent:
             _invoke_bipolar,
         )
 
-        with patch(_BRIDGE_BIPOLAR, side_effect=RuntimeError("no JVM")), patch(
+        with patch(
+            _TRANSLATOR_SRC, new=AsyncMock(return_value=_translator_empty_outcome())
+        ), patch(_BRIDGE_BIPOLAR, side_effect=RuntimeError("no JVM")), patch(
             "jpype.isJVMStarted", return_value=False
         ):
             result = _run(_invoke_bipolar("text", _ctx()))
@@ -121,7 +144,9 @@ class TestJvmUpHandlerFailureFailsLoudRealCause:
         real_cause = TypeError("bad argument shape in analyze")
         mock_handler = MagicMock()
         mock_handler.analyze_bipolar_framework.side_effect = real_cause
-        with patch(_BRIDGE_BIPOLAR, return_value=mock_handler), patch(
+        with patch(
+            _TRANSLATOR_SRC, new=AsyncMock(return_value=_translator_empty_outcome())
+        ), patch(_BRIDGE_BIPOLAR, return_value=mock_handler), patch(
             "jpype.isJVMStarted", return_value=True
         ):
             with pytest.raises(RuntimeError) as exc_info:
@@ -148,7 +173,9 @@ class TestJvmUpHandlerFailureFailsLoudRealCause:
         mock_handler.analyze_bipolar_framework.side_effect = ValueError(
             "Tweety rejected the support relation"
         )
-        with patch(_BRIDGE_BIPOLAR, return_value=mock_handler), patch(
+        with patch(
+            _TRANSLATOR_SRC, new=AsyncMock(return_value=_translator_empty_outcome())
+        ), patch(_BRIDGE_BIPOLAR, return_value=mock_handler), patch(
             "jpype.isJVMStarted", return_value=True
         ):
             with pytest.raises(RuntimeError) as exc_info:
@@ -233,4 +260,3 @@ class TestTranslatorWorkSurvivesDegradedState:
             ["corpus_A", "prop_1"],
             ["corpus_B", "prop_2"],
         ], "writer must persist the translator's supports, not []"
-

--- a/tests/unit/argumentation_analysis/orchestration/test_camembert_invoke.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_camembert_invoke.py
@@ -40,6 +40,16 @@ def _patch_invokecallables_env_get(overrides):
     return patch.object(mod.os.environ, "get", side_effect=side_effect)
 
 
+# #1591 hermeticity: for the not-configured tests, overrides must be EXPLICIT
+# empties — an empty dict lets the ambient .env values through
+# (SELF_HOSTED_LLM_ENDPOINT/MODEL set on dev machines), which opens the
+# configured gate: the test then hits the real endpoint (measured: 2
+# requests each) AND asserts a verdict ("not configured") the run can no
+# longer produce (the 3 tests were red on any machine with the endpoint
+# configured). Empty overrides close the gate in every environment.
+_NOT_CONFIGURED = {"SELF_HOSTED_LLM_ENDPOINT": "", "SELF_HOSTED_LLM_MODEL": ""}
+
+
 class TestInvokeCamemBERTFallacy:
     """Tests for _invoke_camembert_fallacy (now self-hosted LLM)."""
 
@@ -53,7 +63,7 @@ class TestInvokeCamemBERTFallacy:
         # strings and takes the not-configured branch (the "real_get"
         # fallback may return ambient values, which are equally "" if
         # unconfigured).
-        with _patch_invokecallables_env_get({}):
+        with _patch_invokecallables_env_get(_NOT_CONFIGURED):
             result = await _invoke_camembert_fallacy("test text", {})
 
         assert result["total_fallacies"] == 0
@@ -126,7 +136,7 @@ class TestInvokeCamemBERTFallacy:
         )
 
         # Without endpoint, returns early regardless of text
-        with _patch_invokecallables_env_get({}):
+        with _patch_invokecallables_env_get(_NOT_CONFIGURED):
             result = await _invoke_camembert_fallacy("", {})
 
         assert result["total_fallacies"] == 0
@@ -161,7 +171,7 @@ class TestInvokeCamemBERTFallacy:
 
         # Without endpoint configured, the function returns early
         # without calling any async operations
-        with _patch_invokecallables_env_get({}):
+        with _patch_invokecallables_env_get(_NOT_CONFIGURED):
             result = await _invoke_camembert_fallacy("test", {})
 
         assert result["tiers_used"] == ["none"]

--- a/tests/unit/argumentation_analysis/orchestration/test_router.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_router.py
@@ -519,8 +519,15 @@ class TestRouterIntegration:
         # routing fallback) does not depend on. Patch the AsyncOpenAI ctor so
         # the fallback phases run honest-degraded. Router mock kept: it is what
         # triggers the fallback under test.
+        # #1591: LocalLLMService.is_available probes its localhost endpoint
+        # with direct httpx (measured: 1 GET /v1/models) — outside the
+        # AsyncOpenAI seam above. The probe's answer is not read by this
+        # verdict; make it answer False without building a request.
         with patch(
             "openai.AsyncOpenAI", side_effect=RuntimeError("no-network-1583")
+        ), patch(
+            "argumentation_analysis.services.local_llm_service.LocalLLMService.is_available",
+            new=AsyncMock(return_value=False),
         ), patch(
             "argumentation_analysis.orchestration.router.TextAnalysisRouter"
         ) as MockRouter:
@@ -561,7 +568,14 @@ class TestRouterIntegration:
         # path, "phases" is still produced, and the workflow_name mapping (the
         # in-test bite) is preserved. Network hermeticity is re-verified by the
         # #1579 instrumentation.
-        with patch("openai.AsyncOpenAI", side_effect=RuntimeError("no-network-1583")):
+        # #1591: same LocalLLMService localhost probe as the fallback test
+        # above (measured: 2 GET /v1/models across the three runs).
+        with patch(
+            "openai.AsyncOpenAI", side_effect=RuntimeError("no-network-1583")
+        ), patch(
+            "argumentation_analysis.services.local_llm_service.LocalLLMService.is_available",
+            new=AsyncMock(return_value=False),
+        ):
             for name in ("light", "standard", "full"):
                 result = await run_unified_analysis(
                     "Test text.",

--- a/tests/unit/argumentation_analysis/orchestration/test_unified_pipeline.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_unified_pipeline.py
@@ -459,6 +459,21 @@ class TestWorkflowExecution:
 class TestRunUnifiedAnalysis:
     """Test the convenience function run_unified_analysis."""
 
+    # #1591 hermeticity: these shape-verdict smoke tests used to run the
+    # light workflow against the real LLM (measured: 2 requests each →
+    # openrouter.ai / api.openai.com depending on env). No assertion reads
+    # LLM output, so the client factory is pinned to its designed no-key
+    # return (None, "") — every LLM-dependent callable then takes its
+    # honest-absent path, and the shape verdicts are preserved (measured:
+    # 6 requests → 0 across the three tests below).
+    @staticmethod
+    def _no_llm_client():
+        return patch(
+            "argumentation_analysis.orchestration.invoke_callables"
+            "._get_openai_client",
+            return_value=(None, ""),
+        )
+
     @pytest.mark.asyncio
     async def test_run_with_default_registry(self):
         """run_unified_analysis works with auto-created registry."""
@@ -466,7 +481,10 @@ class TestRunUnifiedAnalysis:
             run_unified_analysis,
         )
 
-        result = await run_unified_analysis("Test argument text", workflow_name="light")
+        with self._no_llm_client():
+            result = await run_unified_analysis(
+                "Test argument text", workflow_name="light"
+            )
         assert "workflow_name" in result
         assert "phases" in result
         assert "summary" in result
@@ -512,7 +530,8 @@ class TestRunUnifiedAnalysis:
             run_unified_analysis,
         )
 
-        result = await run_unified_analysis("Test argument", workflow_name="light")
+        with self._no_llm_client():
+            result = await run_unified_analysis("Test argument", workflow_name="light")
         summary = result["summary"]
         assert "completed" in summary
         assert "failed" in summary
@@ -530,7 +549,8 @@ class TestRunUnifiedAnalysis:
             run_unified_analysis,
         )
 
-        result = await run_unified_analysis("Test argument", workflow_name="light")
+        with self._no_llm_client():
+            result = await run_unified_analysis("Test argument", workflow_name="light")
         assert "capabilities_used" in result
         assert "capabilities_missing" in result
         assert isinstance(result["capabilities_used"], list)
@@ -655,11 +675,14 @@ class TestRealInvocationViaUnifiedAnalysis:
             run_unified_analysis,
         )
 
-        result = await run_unified_analysis(
-            "Argument test.",
-            workflow_name="light",
-            context={"custom_key": "custom_value"},
-        )
+        # Same #1591 hermeticity as TestRunUnifiedAnalysis: shape verdict only,
+        # no LLM output read — pin the client factory to its no-key return.
+        with TestRunUnifiedAnalysis._no_llm_client():
+            result = await run_unified_analysis(
+                "Argument test.",
+                workflow_name="light",
+                context={"custom_key": "custom_value"},
+            )
         # Workflow should complete — context param doesn't break anything
         assert result["summary"]["completed"] >= 1
 

--- a/tests/unit/argumentation_analysis/services/test_local_llm_service.py
+++ b/tests/unit/argumentation_analysis/services/test_local_llm_service.py
@@ -9,7 +9,19 @@ Tests validate:
 """
 
 import pytest
+import httpx
 from unittest.mock import AsyncMock, patch, MagicMock
+
+
+def _unreachable_async_client_factory():
+    """#1591 hermeticity: make AsyncClient CONSTRUCTION raise ConnectError —
+    the deterministic stand-in for the unreachable endpoint these
+    degraded-path tests exercise (was: an invalid port on localhost, which
+    still built and sent a request per call). NB: a MockTransport raising
+    inside the handler does NOT suffice — the egress counter observes at
+    send-entry, so a built request counts even when the transport never
+    touches the network. Zero egress means zero built requests."""
+    return MagicMock(side_effect=httpx.ConnectError("unreachable (hermetic)"))
 
 
 class TestLocalLLMImport:
@@ -133,7 +145,8 @@ class TestLocalLLMServiceAPI:
         )
 
         service = LocalLLMService(endpoint="http://localhost:99999/v1")
-        available = await service.is_available()
+        with patch("httpx.AsyncClient", _unreachable_async_client_factory()):
+            available = await service.is_available()
         assert available is False
 
     @pytest.mark.asyncio
@@ -144,9 +157,10 @@ class TestLocalLLMServiceAPI:
         )
 
         service = LocalLLMService(endpoint="http://localhost:99999/v1")
-        result = await service.chat_completion(
-            messages=[{"role": "user", "content": "test"}]
-        )
+        with patch("httpx.AsyncClient", _unreachable_async_client_factory()):
+            result = await service.chat_completion(
+                messages=[{"role": "user", "content": "test"}]
+            )
         assert "error" in result
 
     def test_repr(self):

--- a/tests/unit/argumentation_analysis/test_pl_2pass_pipeline.py
+++ b/tests/unit/argumentation_analysis/test_pl_2pass_pipeline.py
@@ -17,7 +17,6 @@ import pytest
 
 from argumentation_analysis.core.shared_state import UnifiedAnalysisState
 
-
 # ── Helper fixtures ──────────────────────────────────────────────────────
 
 
@@ -44,6 +43,7 @@ class TestParseJsonFromLlm:
         from argumentation_analysis.orchestration.invoke_callables import (
             _parse_json_from_llm,
         )
+
         raw = '{"propositions": ["a", "b"]}'
         result = _parse_json_from_llm(raw)
         assert result == {"propositions": ["a", "b"]}
@@ -52,6 +52,7 @@ class TestParseJsonFromLlm:
         from argumentation_analysis.orchestration.invoke_callables import (
             _parse_json_from_llm,
         )
+
         raw = '```json\n{"propositions": ["x"]}\n```'
         result = _parse_json_from_llm(raw)
         assert result == {"propositions": ["x"]}
@@ -60,6 +61,7 @@ class TestParseJsonFromLlm:
         from argumentation_analysis.orchestration.invoke_callables import (
             _parse_json_from_llm,
         )
+
         raw = 'Here is the result:\n{"formulas": ["p => q"]}\nDone.'
         result = _parse_json_from_llm(raw)
         assert result == {"formulas": ["p => q"]}
@@ -68,6 +70,7 @@ class TestParseJsonFromLlm:
         from argumentation_analysis.orchestration.invoke_callables import (
             _parse_json_from_llm,
         )
+
         result = _parse_json_from_llm("no json here")
         assert result == {}
 
@@ -75,6 +78,7 @@ class TestParseJsonFromLlm:
         from argumentation_analysis.orchestration.invoke_callables import (
             _parse_json_from_llm,
         )
+
         result = _parse_json_from_llm("")
         assert result == {}
 
@@ -127,15 +131,26 @@ class TestTwoPassPipeline:
         # Mock OpenAI to return atom inventory then formulas
         mock_resp_1 = MagicMock()
         mock_resp_1.choices = [MagicMock()]
-        mock_resp_1.choices[0].message.content = json.dumps({
-            "propositions": ["sovereignty_requires_action", "foreign_threat", "cooperation_better"]
-        })
+        mock_resp_1.choices[0].message.content = json.dumps(
+            {
+                "propositions": [
+                    "sovereignty_requires_action",
+                    "foreign_threat",
+                    "cooperation_better",
+                ]
+            }
+        )
 
         mock_resp_2 = MagicMock()
         mock_resp_2.choices = [MagicMock()]
-        mock_resp_2.choices[0].message.content = json.dumps({
-            "formulas": ["sovereignty_requires_action => foreign_threat", "!cooperation_better"]
-        })
+        mock_resp_2.choices[0].message.content = json.dumps(
+            {
+                "formulas": [
+                    "sovereignty_requires_action => foreign_threat",
+                    "!cooperation_better",
+                ]
+            }
+        )
 
         mock_client = AsyncMock()
         mock_client.chat.completions.create = AsyncMock(
@@ -171,9 +186,9 @@ class TestTwoPassPipeline:
 
         formula_resp = MagicMock()
         formula_resp.choices = [MagicMock()]
-        formula_resp.choices[0].message.content = json.dumps({
-            "formulas": ["sovereignty_action => !foreign_threat"]
-        })
+        formula_resp.choices[0].message.content = json.dumps(
+            {"formulas": ["sovereignty_action => !foreign_threat"]}
+        )
 
         mock_client = AsyncMock()
         mock_client.chat.completions.create = AsyncMock(
@@ -199,7 +214,19 @@ class TestTwoPassPipeline:
         state = UnifiedAnalysisState("Test argument.")
         ctx = _make_context(state.raw_text, state)
 
-        with patch.dict("os.environ", {"OPENAI_API_KEY": ""}):
+        # #1591 hermeticity: emptying OPENAI_API_KEY alone does not remove the
+        # key — the OpenRouter toggle (OPENROUTER_BASE_URL + OPENROUTER_API_KEY)
+        # bypasses it and the fallback-on-no-key premise never holds: the LLM
+        # fires (measured: 1 openrouter.ai request). Clearing the toggle makes
+        # the tested premise real; no mock needed.
+        with patch.dict(
+            "os.environ",
+            {
+                "OPENAI_API_KEY": "",
+                "OPENROUTER_API_KEY": "",
+                "OPENROUTER_BASE_URL": "",
+            },
+        ):
             result = asyncio.get_event_loop().run_until_complete(
                 _invoke_propositional_logic(state.raw_text, ctx)
             )
@@ -217,7 +244,9 @@ class TestTwoPassPipeline:
         ctx = _make_context(state.raw_text, state)
 
         mock_client = AsyncMock()
-        mock_client.chat.completions.create = AsyncMock(side_effect=Exception("LLM error"))
+        mock_client.chat.completions.create = AsyncMock(
+            side_effect=Exception("LLM error")
+        )
 
         with patch("openai.AsyncOpenAI", return_value=mock_client):
             with patch.dict("os.environ", {"OPENAI_API_KEY": "test-key"}):
@@ -292,7 +321,15 @@ class TestBackwardCompat:
             "arguments": ["test argument"],
         }
 
-        with patch.dict("os.environ", {"OPENAI_API_KEY": ""}):
+        # Same #1591 premise fix as TestTwoPassPipeline::test_fallback_when_no_api_key.
+        with patch.dict(
+            "os.environ",
+            {
+                "OPENAI_API_KEY": "",
+                "OPENROUTER_API_KEY": "",
+                "OPENROUTER_BASE_URL": "",
+            },
+        ):
             result = asyncio.get_event_loop().run_until_complete(
                 _invoke_propositional_logic("test text", ctx)
             )
@@ -330,9 +367,14 @@ class TestBatchedPass2:
 
         formula_resp = MagicMock()
         formula_resp.choices = [MagicMock()]
-        formula_resp.choices[0].message.content = json.dumps({
-            "formulas": ["sovereignty => vigilance", "national_interest && !cooperation"]
-        })
+        formula_resp.choices[0].message.content = json.dumps(
+            {
+                "formulas": [
+                    "sovereignty => vigilance",
+                    "national_interest && !cooperation",
+                ]
+            }
+        )
 
         mock_client = AsyncMock()
         # Pass 1 + 4 batches (ceil(10/3)) + whole-text = 6 calls
@@ -367,9 +409,9 @@ class TestBatchedPass2:
 
         formula_resp = MagicMock()
         formula_resp.choices = [MagicMock()]
-        formula_resp.choices[0].message.content = json.dumps({
-            "formulas": ["policy_a => policy_b"]
-        })
+        formula_resp.choices[0].message.content = json.dumps(
+            {"formulas": ["policy_a => policy_b"]}
+        )
 
         mock_client = AsyncMock()
         # Pass 1 + 1 batch (2 args fit in one) + whole-text = 3 calls
@@ -410,9 +452,9 @@ class TestBatchedPass2:
 
         good_resp = MagicMock()
         good_resp.choices = [MagicMock()]
-        good_resp.choices[0].message.content = json.dumps({
-            "formulas": ["claim_a => claim_b"]
-        })
+        good_resp.choices[0].message.content = json.dumps(
+            {"formulas": ["claim_a => claim_b"]}
+        )
 
         mock_client = AsyncMock()
         # Pass 1 + batch0(fail) + batch1(good) + batch2(good) + batch3(good) + wt

--- a/tests/unit/test_llm_egress_counter.py
+++ b/tests/unit/test_llm_egress_counter.py
@@ -128,9 +128,24 @@ async def test_counter_sees_bare_httpx_request():
 
 
 async def test_counter_ignores_non_llm_host():
-    """Specificity: a request to a non-LLM host leaves the count unchanged."""
+    """Specificity + 3-state vision (#1591): a request to an unwatched host
+    leaves the LLM count unchanged AND surfaces in the unknown bucket — an
+    absent endpoint env var must produce "unknown host seen", not silence."""
     counter = _session_counter()
     async with httpx.AsyncClient(transport=_mock_transport()) as client:
         before = counter.total()
         await client.get(NON_LLM_URL)
-    assert counter.total() == before
+    assert counter.total() == before, (
+        "a non-watched host must not count as LLM egress"
+    )
+    snap = counter.snapshot()
+    unknown_hits = [
+        r
+        for r in snap["requests"]
+        if r["host"] == "example.com" and r["class"] == "unknown"
+        and r["test"].endswith("test_counter_ignores_non_llm_host")
+    ]
+    assert unknown_hits, (
+        "3-state vision failed: the example.com request must be visible in "
+        "the unknown bucket (class='unknown'), not silently dropped"
+    )

--- a/tests/unit/test_llm_egress_counter.py
+++ b/tests/unit/test_llm_egress_counter.py
@@ -135,17 +135,41 @@ async def test_counter_ignores_non_llm_host():
     async with httpx.AsyncClient(transport=_mock_transport()) as client:
         before = counter.total()
         await client.get(NON_LLM_URL)
-    assert counter.total() == before, (
-        "a non-watched host must not count as LLM egress"
-    )
+    assert counter.total() == before, "a non-watched host must not count as LLM egress"
     snap = counter.snapshot()
     unknown_hits = [
         r
         for r in snap["requests"]
-        if r["host"] == "example.com" and r["class"] == "unknown"
+        if r["host"] == "example.com"
+        and r["class"] == "unknown"
         and r["test"].endswith("test_counter_ignores_non_llm_host")
     ]
     assert unknown_hits, (
         "3-state vision failed: the example.com request must be visible in "
         "the unknown bucket (class='unknown'), not silently dropped"
     )
+
+
+async def test_counter_sees_httpx2_request():
+    """openai>=3.x transport coverage (#1591 livrable 0): openai 3.1 (what CI
+    resolves from the unpinned environment.yml) sends via httpx2, not httpx.
+    The counter must patch it too, or every default-client SDK call is
+    invisible — CI read a false 0 this way (run 32048104455). Skipped where
+    httpx2 is absent (local envs run openai <3); CI is where this control
+    earns its keep."""
+    httpx2 = pytest.importorskip("httpx2")
+    counter = _session_counter()
+
+    def handler(request) -> "httpx2.Response":
+        return httpx2.Response(200, json=_CHAT_COMPLETION_PAYLOAD)
+
+    async with httpx2.AsyncClient(transport=httpx2.MockTransport(handler)) as client:
+        before = counter.total()
+        await client.post(f"{FAKE_OPENAI_HOST}/chat/completions", json={"p": 1})
+    assert counter.total() == before + 1, (
+        f"non-vacuity FAILED on the httpx2 path: expected {before + 1}, "
+        f"counter reads {counter.total()} — the counter is blind to "
+        "httpx2, the transport openai>=3.x uses in CI (false-zero family "
+        "#1556: an unpatched transport reads exactly like a clean gate)"
+    )
+    assert "httpx2" in counter.snapshot()["transports_patched"]

--- a/tests/unit/test_llm_egress_counter.py
+++ b/tests/unit/test_llm_egress_counter.py
@@ -150,6 +150,28 @@ async def test_counter_ignores_non_llm_host():
     )
 
 
+async def test_counter_classifies_asgi_testserver_nonllm():
+    """The ASGI TestClient host is known test infra, not an unknown host (#1591):
+    141 in-process "testserver" requests drowned the unknown bucket in the
+    first 3-state CI run — unknown must stay a signal, not the default."""
+    counter = _session_counter()
+    async with httpx.AsyncClient(transport=_mock_transport()) as client:
+        before = counter.total()
+        await client.get("https://testserver/api/egress-control")
+    assert counter.total() == before
+    snap = counter.snapshot()
+    seen = [
+        r
+        for r in snap["requests"]
+        if r["host"] == "testserver" and r["test"].endswith(
+            "test_counter_classifies_asgi_testserver_nonllm"
+        )
+    ]
+    assert seen and all(r["class"] == "nonllm" for r in seen), (
+        "testserver (ASGI TestClient) must classify as nonllm, not unknown"
+    )
+
+
 async def test_counter_sees_httpx2_request():
     """openai>=3.x transport coverage (#1591 livrable 0): openai 3.1 (what CI
     resolves from the unpinned environment.yml) sends via httpx2, not httpx.


### PR DESCRIPTION
## What

Closes the gate's LLM egress leaks (#1591): **26 → 0 requests measured**, all verdicts preserved, tally delta 0. Plus the instrument fix the reconciliation demanded: the counter now sees **httpx2**, the transport openai>=3.x actually uses in CI.

## Livrable 0 (verdict posted on #1591 before any test was touched — comment 5318914774 + correction 5318947561)

- The gate criterion is **env-independent** (user's arbitrage, 2026-08-17): a test whose verdict does not read the model output must not call the LLM, *in any environment*. Not a billing question — a test-hygiene question. The 26 local leaks stay waste everywhere; the hermetization below is the deliverable.
- The **~90** figure at the top of #1591 was stale — that test was hermetized long ago by #1594 (`23b4990d`, docstring "Measured: 94 req → 0 req").
- **26 local vs 3 CI**: the 3 was a **structural undercount of the instrument, not an absence of leaks**. CI resolves `openai-3.1.0` from the unpinned `environment.yml`; openai 3.x sends via **httpx2** (`requires_dist`: `httpx2<3,>=2.7.0`, no httpx dependency). The #1787 counter patched `httpx.*.send` only → blind to every default-client SDK call in CI. Verified from both sides: local `projet-is-roo-new` runs `openai 2.30.0` → `httpx<1` (that's why local counted 26); CI run 32048104455 log installs `openai-3.1.0 + httpx2-2.10.0`.
- Re the coordinator's correction (R825, "CI measures 0 openrouter leaks"): `openrouter.ai` being in the watched host set does not make the counter un-blind — a watched host is only counted if the request *reaches* `httpx.Client.send`. The patch sits at the transport; openai 3.1 SDK calls never arrive there. Empirical refutation: run B (CI's exact env vars only — `OPENAI_API_KEY` + `TEXT_CONFIG_PASSPHRASE`, `.env` aside) measured **12 api.openai.com requests** — the leaks fire with CI's env, re-routed to the default host. In CI the same calls leave via httpx2 → invisible. Whether they fire in CI is now **measurable for the first time**: the counter on this branch is httpx2-aware, so this PR's CI run will print the true number.
- Decomposition of the ~23: 12 fire in CI (openrouter-class, api.openai.com default) *invisibly*; 8 self-hosted are env-conditional (don't fire in CI, proven by run B); 5 localhost probes fire everywhere but were unwatched in the old report (now they surface as `unknown`).

## Instrument (commits 74bfc57d + 3ad9fc55 + 0510bb72)

- 3-state classification: `llm` (watched) / `nonllm` (known infra) / **`unknown`** — an absent endpoint env var now surfaces as "unknown host seen", never silence.
- `httpx2.Client/AsyncClient.send` patched alongside httpx (guarded import — httpx2 2.9.1 exists locally too, so the coverage is proven locally, not only in CI).
- Report self-attests transport coverage via `transports_patched` — fixed to survive the install/uninstall cycle (`0510bb72`), so the artifact reads `["httpx", "httpx2"]` instead of `[]`.
- 5 non-vacuity controls: raw SDK / SK wrapper / bare httpx / specificity+unknown / **httpx2** (the new one fails exactly when the counter is blind to the CI transport — the false-zero family #1556).

## Hermeticity — 8 files, 19 tests, per-family measured before → after

| family | before (run A) | after | seam |
|---|---|---|---|
| bipolar_1645 (4 tests) | 4 | **0** | patch `translate_to_bipolar_supports` — no JVM-state verdict reads translator output |
| unified_pipeline (4 tests) | 6 (+2 surfaced) | **0** | `_get_openai_client` pinned to its designed `(None, "")` — shape verdicts only |
| pl_2pass (2 tests) | 3 | **0** | clear the OPENROUTER toggle too — `OPENAI_API_KEY=""` alone never removed the key (the tests' no-key premise was false) |
| camembert (3 tests) | 6 **and RED** | **0, green** | explicit empty overrides — the ambient `.env` endpoint opened the not-configured gate |
| nli (2 tests) | 2 | **0** | `enable_self_hosted_llm=False` — default-on tier unrelated to the mocked-NLI verdicts |
| local_llm_service (2 tests) | 2 | **0** | client construction raises ConnectError — same except path, zero requests built |
| router (2 tests) | 3 | **0** | `LocalLLMService.is_available` patched — the localhost probe is direct httpx, outside the AsyncOpenAI seam |

Notes:
- camembert: those 3 tests were **red on any machine with `SELF_HOSTED_LLM_ENDPOINT` configured** (their "not configured" verdict is unreachable when ambient env opens the gate) — this PR repairs 3 local failures, not just leaks.
- A 4th unified test surfaced once the first 3 stopped firing (shared state/cache warm) — hermetized with the same seam.
- **MockTransport ≠ 0 egress**: the counter observes at send-entry (that's why its own controls work), so hermetic means "no request built", not "request mocked". The construction-raising pattern documents this.

## Global re-measure (full gate command, full local env)

- Before (run A): **28 llm requests** (25 leaks + 3 controls), wall **591s**.
- After (this branch): **7 llm requests** = **4 non-vacuity controls** + **3 residual**, wall **475s** (−116s).
- The 3 residual: attributed to the two `pl_2pass` tests, NOT reproducible in any sub-set (isolated file = 0; `orchestration + pl_2pass` = 0; either half of the subtree = 0), i.e. cross-test pollution from an earlier test — a **separate test bug**, not fixed here (out of #1591's per-test scope; the polluting test is still unidentified). Three instrumented full-gate runs (CI-shaped env, `.env` parked) pinned the envelope: (a) the POSTs fire from the tests' own coroutines with a **truthy provider-key read inside the `patch.dict("")` window**; (b) an `os.putenv` tracer logged **zero truthy env writes during that window** (397 writes elsewhere, all properly-scoped `patch.dict` enter/exits); (c) in a clean process the same `patch.dict` reads `''` correctly — so the read inside the gate bypasses the patched object by a mechanism still to be named (next probe: `id(os.environ)` at POST). Related, proven: `invoke_callables.py:101` runs `load_dotenv()` **at module import** — at pytest COLLECTION time (via any test-module import) this loads the *nested* `argumentation_analysis/.env` (stale, June 2025, contains a real 73-char OpenRouter key) into the process env on dev machines, defeating the ambient cleanliness every test assumes. Follow-up ticket proposed (see #1591 comment).
- Tally delta 0: no test removed, deselected, or re-marked (anti-pendule respected — no `requires_api`/`slow` marking of leaks, no ci.yml change).

## CI reading on this PR (run 32067689715, measured)

**`llm: 6` = the 4 non-vacuity controls + 2 residual `pl_2pass` requests**, `transports_patched: ["httpx", "httpx2"]`. What this settles:

- The httpx2 patch is **live in CI and catches default-client SDK sends**: the 2 residual requests themselves went through the openai-3.1/httpx2 transport and were counted — exactly the class the old counter was blind to.
- The residual contamination **reproduces in CI's clean environment** (no `.env`, no OPENROUTER) — it is not a local-env artifact. These 2 requests are **real api.openai.com calls with the provisioned key**, meaning **main's CI fires 2 real LLM calls per push, invisible to the httpx-only counter** — the coordinator's "0 real leaks in CI (3 = controls)" was a blind-transport undercount. (On main the other 10 openrouter-class leaks fire too, per run B; on this branch they are hermetized.)
- The `unknown` bucket read 142 = 141 `testserver` (ASGI/starlette TestClient, in-process loopback — test infra, not egress) + 1 `example.com` (the specificity control). `testserver` is now classified `nonllm` so `unknown` stays a signal instead of the default.

Refs #1591 · instrument #1787 · follow-up candidates (out of scope here): (a) the polluting test behind the `pl_2pass` residual (see below); (b) pin openai in environment.yml so CI stops testing an SDK no local env has.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
