### PR TITLE
fix(logic): canonical traced warmup for every bare TweetyInitializer() (#1784)

### DIFF
--- a/argumentation_analysis/agents/core/logic/tweety_initializer.py
+++ b/argumentation_analysis/agents/core/logic/tweety_initializer.py
@@ -363,3 +363,25 @@ class TweetyInitializer:
 
     def is_jvm_started(self) -> bool:
         return self.__class__._jvm_started
+
+
+def ready_initializer() -> "TweetyInitializer":
+    """#1784: canonical traced warmup for every ``TweetyInitializer`` construction.
+
+    A bare ``TweetyInitializer()`` never loads the Tweety classes, so handler
+    guards reject a booted JVM and axis availability depends on which tools
+    happened to run first in the process (#1775, #1219, #1784). This helper
+    warms the initializer explicitly before handler construction: traced (a
+    real load failure stays loud — no silent lazy-init), idempotent after the
+    first call. It replaces the 11 bare constructions #1784 measured in
+    ``invoke_callables`` and the #1778 private copy in ``tweety_logic_plugin``.
+    """
+    initializer = TweetyInitializer()  # type: ignore[no-untyped-call]
+    if not initializer.is_jvm_ready():
+        logger.info(
+            "#1784: Tweety classes not loaded on this path — warming the "
+            "initializer before handler construction so axis availability "
+            "does not depend on call order."
+        )
+        initializer.ensure_jvm_and_components_are_ready()  # type: ignore[no-untyped-call]
+    return initializer

--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -4517,10 +4517,10 @@ async def _invoke_dl(input_text: str, context: Dict[str, Any]) -> Dict[str, Any]
     try:
         from argumentation_analysis.agents.core.logic.dl_handler import DLHandler
         from argumentation_analysis.agents.core.logic.tweety_initializer import (
-            TweetyInitializer,
+            ready_initializer,
         )
 
-        initializer = TweetyInitializer()  # type: ignore[no-untyped-call]
+        initializer = ready_initializer()
         handler = DLHandler(initializer)
         kb = await asyncio.to_thread(
             handler.create_knowledge_base, tbox, abox_concepts, abox_roles
@@ -4561,10 +4561,10 @@ async def _invoke_cl(input_text: str, context: Dict[str, Any]) -> Dict[str, Any]
     try:
         from argumentation_analysis.agents.core.logic.cl_handler import CLHandler
         from argumentation_analysis.agents.core.logic.tweety_initializer import (
-            TweetyInitializer,
+            ready_initializer,
         )
 
-        initializer = TweetyInitializer()  # type: ignore[no-untyped-call]
+        initializer = ready_initializer()
         handler = CLHandler(initializer)
         kb = await asyncio.to_thread(handler.create_knowledge_base, conditionals)
         if query_conclusion:
@@ -4735,10 +4735,10 @@ async def _invoke_setaf(input_text: str, context: Dict[str, Any]) -> Dict[str, A
     try:
         from argumentation_analysis.agents.core.logic.setaf_handler import SetAFHandler
         from argumentation_analysis.agents.core.logic.tweety_initializer import (
-            TweetyInitializer,
+            ready_initializer,
         )
 
-        initializer = TweetyInitializer()  # type: ignore[no-untyped-call]
+        initializer = ready_initializer()
         handler = SetAFHandler(initializer)
         output = await asyncio.to_thread(
             handler.analyze_setaf, args, attacks, semantics
@@ -4822,10 +4822,10 @@ async def _invoke_weighted(input_text: str, context: Dict[str, Any]) -> Dict[str
             WeightedHandler,
         )
         from argumentation_analysis.agents.core.logic.tweety_initializer import (
-            TweetyInitializer,
+            ready_initializer,
         )
 
-        initializer = TweetyInitializer()  # type: ignore[no-untyped-call]
+        initializer = ready_initializer()
         handler = WeightedHandler(initializer)
         output = await asyncio.to_thread(
             handler.analyze_weighted_framework, args, attacks, semantics
@@ -4863,10 +4863,10 @@ async def _invoke_social(input_text: str, context: Dict[str, Any]) -> Dict[str, 
             SocialHandler,
         )
         from argumentation_analysis.agents.core.logic.tweety_initializer import (
-            TweetyInitializer,
+            ready_initializer,
         )
 
-        initializer = TweetyInitializer()  # type: ignore[no-untyped-call]
+        initializer = ready_initializer()
         handler = SocialHandler(initializer)
         output = await asyncio.to_thread(
             handler.analyze_social_framework, args, attacks, votes
@@ -4939,10 +4939,10 @@ async def _invoke_eaf(input_text: str, context: Dict[str, Any]) -> Dict[str, Any
     try:
         from argumentation_analysis.agents.core.logic.eaf_handler import EAFHandler
         from argumentation_analysis.agents.core.logic.tweety_initializer import (
-            TweetyInitializer,
+            ready_initializer,
         )
 
-        initializer = TweetyInitializer()  # type: ignore[no-untyped-call]
+        initializer = ready_initializer()
         handler = EAFHandler(initializer)
         return await asyncio.to_thread(
             handler.analyze_epistemic_framework, args, attacks, beliefs, semantics
@@ -4979,10 +4979,10 @@ async def _invoke_delp(input_text: str, context: Dict[str, Any]) -> Dict[str, An
     try:
         from argumentation_analysis.agents.core.logic.delp_handler import DeLPHandler
         from argumentation_analysis.agents.core.logic.tweety_initializer import (
-            TweetyInitializer,
+            ready_initializer,
         )
 
-        initializer = TweetyInitializer()  # type: ignore[no-untyped-call]
+        initializer = ready_initializer()
         handler = DeLPHandler(initializer)
         return await asyncio.to_thread(
             handler.analyze_delp, program_text, queries, criterion
@@ -5002,10 +5002,10 @@ async def _invoke_qbf(input_text: str, context: Dict[str, Any]) -> Dict[str, Any
     try:
         from argumentation_analysis.agents.core.logic.qbf_handler import QBFHandler
         from argumentation_analysis.agents.core.logic.tweety_initializer import (
-            TweetyInitializer,
+            ready_initializer,
         )
 
-        initializer = TweetyInitializer()  # type: ignore[no-untyped-call]
+        initializer = ready_initializer()
         handler = QBFHandler(initializer)
         return await asyncio.to_thread(handler.analyze_qbf, quantifiers, formula)
     except Exception as e:
@@ -7824,10 +7824,10 @@ async def _invoke_dung_extensions(
             SEMANTICS_REASONERS,
         )
         from argumentation_analysis.agents.core.logic.tweety_initializer import (
-            TweetyInitializer,
+            ready_initializer,
         )
 
-        initializer = TweetyInitializer()  # type: ignore[no-untyped-call]
+        initializer = ready_initializer()
         handler = AFHandler(initializer)
 
         # Compute all 11 semantics in one pass (framework built once).
@@ -8052,10 +8052,10 @@ async def _default_tweety_dung_backend(
             SEMANTICS_REASONERS,
         )
         from argumentation_analysis.agents.core.logic.tweety_initializer import (
-            TweetyInitializer,
+            ready_initializer,
         )
 
-        initializer = TweetyInitializer()  # type: ignore[no-untyped-call]
+        initializer = ready_initializer()
         handler = AFHandler(initializer)
         sem_list = [s for s in _COMPARE_DUNG_SEMANTICS if s in SEMANTICS_REASONERS]
         result = await asyncio.to_thread(
@@ -9901,12 +9901,12 @@ async def _invoke_external_modal_solver(
                 ModalHandler,
             )
             from argumentation_analysis.agents.core.logic.tweety_initializer import (
-                TweetyInitializer,
+                ready_initializer,
             )
 
             if not settings.modal_solver == ModalSolverChoice.SPASS:
                 object.__setattr__(settings, "modal_solver", ModalSolverChoice.SPASS)
-            initializer = TweetyInitializer()  # type: ignore[no-untyped-call]
+            initializer = ready_initializer()
             handler = ModalHandler(initializer_instance=initializer)
             belief_set_str = "\n".join(str(f) for f in formulas)
             is_consistent, msg = await asyncio.to_thread(

--- a/argumentation_analysis/orchestration/unified_pipeline.py
+++ b/argumentation_analysis/orchestration/unified_pipeline.py
@@ -260,11 +260,10 @@ async def run_unified_analysis(
     ):
         try:
             from argumentation_analysis.agents.core.logic.tweety_initializer import (
-                TweetyInitializer,
+                ready_initializer,
             )
 
-            init = TweetyInitializer()
-            init.ensure_jvm_and_components_are_ready()
+            ready_initializer()
             logger.info("JPype/Tweety warmup complete before DAG execution")
         except Exception as e:
             logger.warning(f"JPype warmup failed (will retry in-phase): {e}")

--- a/argumentation_analysis/plugins/tweety_logic_plugin.py
+++ b/argumentation_analysis/plugins/tweety_logic_plugin.py
@@ -69,24 +69,14 @@ def _jvm_required(func):
 
 
 def _ready_initializer():
-    """#1775: a bare ``TweetyInitializer()`` never loads the Tweety classes,
-    so the handler guards rejected a booted JVM and axis availability depended
-    on which tools happened to run first in the process. Warm the initializer
-    explicitly (idempotent after the first call, traced) before constructing
-    handlers."""
+    """#1775/#1784: delegates to the canonical traced warmup
+    (``tweety_initializer.ready_initializer``). Kept as a thin alias so the
+    plugin's call sites and the #1775 tripwire keep one stable name."""
     from argumentation_analysis.agents.core.logic.tweety_initializer import (
-        TweetyInitializer,
+        ready_initializer,
     )
 
-    initializer = TweetyInitializer()  # type: ignore[no-untyped-call]
-    if not initializer.is_jvm_ready():
-        logger.info(
-            "#1775: Tweety classes not loaded on this path — warming the "
-            "initializer before handler construction so axis availability "
-            "does not depend on call order."
-        )
-        initializer.ensure_jvm_and_components_are_ready()
-    return initializer
+    return ready_initializer()
 
 
 class TweetyLogicPlugin:

--- a/tests/integration/argumentation_analysis/test_1784_invoke_callables_cold_boot.py
+++ b/tests/integration/argumentation_analysis/test_1784_invoke_callables_cold_boot.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+"""#1784 — les axes formels d'``invoke_callables`` ne dépendent plus de l'ordre d'appel.
+
+Même contrat que le tripwire #1775 (``test_1775_axis_order_independence.py``)
+pour ``tweety_logic_plugin``, transplanté aux 11 sites ``TweetyInitializer()``
+nus d'``invoke_callables.py`` : processus frais, JVM démarrée par l'entrée de
+production, AUCUN TweetyBridge construit (c'est lui qui pose
+``_classes_loaded`` en effet de bord), puis appel direct d'un axe formel de
+l'orchestration. La précondition « démarre froid » est assertée à
+l'intérieur du sous-processus : si un import réchauffe le drapeau, le test
+échoue sur sa précondition au lieu de passer à tort (#1019).
+
+Avant le fix #1784, ce test échouait sur ``RuntimeError('...
+unavailable: JVM/Tweety required')`` — le premier axe appelé sur un système
+démarré se déclarait indisponible alors que la JVM tournait, parce que les
+classes Tweety n'étaient pas chargées sur ce chemin.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+
+# Processus frais : JVM démarrée par l'entrée de production, zéro
+# TweetyBridge au préalable, puis appel direct d'un axe de l'orchestration.
+# _invoke_dl : site 1 du sweep #1784 — verdict à froid mesuré RUNTIME_JVM
+# (« DLHandler » exige is_jvm_ready(), rejeté alors que la JVM tourne). Les
+# axes à dégradation silencieuse (qbf : fallback dict ; dung_extensions :
+# degraded=True) n'étaient pas de bons candidats : ils ne lèvent pas à froid.
+_FRESH_INVOKE_SCRIPT = r"""
+import json
+
+import argumentation_analysis.core.dll_guard  # noqa: F401 — doit précéder jpype
+
+from argumentation_analysis.core.jvm_setup import initialize_jvm
+from argumentation_analysis.agents.core.logic.tweety_initializer import TweetyInitializer
+
+assert initialize_jvm(), "initialize_jvm() a echoue"
+assert not TweetyInitializer._classes_loaded, (
+    "precondition violee : le processus frais demarre chaud — le test ne "
+    "prouverait plus l'independance d'ordre"
+)
+
+import asyncio
+
+from argumentation_analysis.orchestration.invoke_callables import _invoke_dl
+
+out = asyncio.run(
+    _invoke_dl(
+        "test",
+        {
+            "tbox": [("Human", "Person")],
+            "abox_concepts": [("alice", "Human")],
+            "abox_roles": [],
+        },
+    )
+)
+assert isinstance(out, dict), f"reponse non-dict : {out}"
+assert "error" not in out or not str(out.get("error", "")).startswith("JVM"), (
+    f"axe rend une erreur JVM : {out}"
+)
+consistent = out.get("consistent")
+assert consistent is not None, f"axe ne decide pas : {out}"
+print("AXIS_OK:", json.dumps(out, default=str)[:300])
+"""
+
+
+@pytest.mark.integration
+@pytest.mark.no_jvm_session
+def test_orchestration_formal_axis_survives_cold_boot():
+    """#1784 DoD : processus frais, JVM démarrée, zéro TweetyBridge au
+    préalable — ``_invoke_dl`` doit décider. Avant le fix, la construction
+    du ``DLHandler`` sur un ``TweetyInitializer()`` nu levait
+    ``RuntimeError('... unavailable: JVM/Tweety required')`` alors que la JVM
+    tournait (verdict RUNTIME_JVM mesuré, site 1 de la table #1784)."""
+    env = os.environ.copy()
+    # Le sous-processus simule un processus de production, pas un contexte
+    # pytest (sinon ``ensure_jvm_and_components_are_ready`` exigirait une
+    # fixture pour démarrer la JVM).
+    env.pop("PYTEST_RUNNING", None)
+    proc = subprocess.run(
+        [sys.executable, "-c", _FRESH_INVOKE_SCRIPT],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        cwd=PROJECT_ROOT,
+        env=env,
+        timeout=420,
+    )
+    print("--- STDOUT (fresh-invoke subprocess) ---")
+    print(proc.stdout[-3000:])
+    print("--- STDERR (fresh-invoke subprocess) ---")
+    print(proc.stderr[-3000:])
+    assert proc.returncode == 0, (
+        "l'axe DL de l'orchestration a echoue en cold boot — "
+        f"voir sortie ci-dessus (rc={proc.returncode})"
+    )
+    assert "AXIS_OK:" in proc.stdout

--- a/tests/integration/test_tweety_fallbacks.py
+++ b/tests/integration/test_tweety_fallbacks.py
@@ -16,8 +16,9 @@ Key schema invariants verified:
   - State snapshot contains the expected top-level keys
 
 Known schema mismatches (documented, not fixed here):
-  - _python_ranking_fallback returns "ranking" key; _write_ranking_to_state
-    reads "arguments" → ranking_results entries have arguments=[]
+  - _python_ranking_fallback no longer returns anything — it is a fail-loud
+    stub (#1019, RA-8 #1053), so its old ranking/arguments writer mismatch
+    is void. The dialogue mismatch below still stands.
   - _invoke_dialogue fallback returns "trace" key; _write_dialogue_to_state
     reads "dialogue_trace" → dialogue_results entries have trace=[]
 """
@@ -194,38 +195,29 @@ class TestGenerateAttacksFromArgs:
 
 
 class TestPythonRankingFallback:
-    def test_returns_required_keys(self):
-        result = _python_ranking_fallback(SAMPLE_ARGS, SAMPLE_ATTACKS, "categorizer")
-        assert "method" in result
-        assert "ranking" in result
-        assert "scores" in result
-        assert "comparisons" in result
-        assert result["fallback"] == "python"
+    """Fail-loud contract (#1019, RA-8 #1053, re-mesuré #1784).
 
-    def test_method_preserved(self):
-        result = _python_ranking_fallback(SAMPLE_ARGS, SAMPLE_ATTACKS, "burden")
-        assert result["method"] == "burden"
+    The pre-#1053 tests asserted the synthetic-score dict (method/ranking/
+    scores/comparisons). That fallback entered state as authentic formal
+    results — an anti-theater violation — and was deliberately replaced by
+    this raising stub. The stale assertions were silently red outside CI
+    (#1783) and were read as a #1775-class signature in #1784; the re-measure
+    showed they are the fail-loud contract working as merged.
+    """
 
-    def test_ranking_contains_all_args(self):
-        result = _python_ranking_fallback(SAMPLE_ARGS, SAMPLE_ATTACKS, "categorizer")
-        assert set(result["ranking"]) == set(SAMPLE_ARGS)
+    @pytest.mark.parametrize("method", ["categorizer", "burden", "discussion"])
+    def test_every_method_raises_fail_loud(self, method):
+        with pytest.raises(
+            RuntimeError, match=rf"Ranking semantics \({method}\) unavailable"
+        ):
+            _python_ranking_fallback(SAMPLE_ARGS, SAMPLE_ATTACKS, method)
 
-    def test_scores_between_zero_and_one(self):
-        result = _python_ranking_fallback(SAMPLE_ARGS, SAMPLE_ATTACKS, "categorizer")
-        for arg, score in result["scores"].items():
-            assert 0.0 <= score <= 1.0
-
-    def test_attacked_arg_has_lower_score(self):
-        args = ["a", "b"]
-        attacks = [["a", "b"]]  # a attacks b → b should have score < a
-        result = _python_ranking_fallback(args, attacks, "categorizer")
-        assert result["scores"]["b"] < result["scores"]["a"]
-
-    def test_empty_args_returns_empty_ranking(self):
-        result = _python_ranking_fallback([], [], "categorizer")
-        assert result["ranking"] == []
-        assert result["scores"] == {}
-        assert result["comparisons"] == []
+    def test_empty_inputs_raise_too(self):
+        """No degenerate input silently succeeds — empty graphs raise the same
+        unavailability rather than returning an empty-but-authentic-looking
+        ranking."""
+        with pytest.raises(RuntimeError, match="JVM/Tweety required"):
+            _python_ranking_fallback([], [], "categorizer")
 
 
 # ---------------------------------------------------------------------------
@@ -257,12 +249,11 @@ class TestInvokeRankingFallback:
         assert isinstance(result, dict)
 
     async def test_schema_mismatch_ranking_vs_arguments(self):
-        """KNOWN MISMATCH: fallback returns 'ranking', writer reads 'arguments'.
-
-        When JVM is unavailable, state.add_ranking_result() will receive
-        arguments=[] because _write_ranking_to_state looks for 'arguments' key
-        which is absent from the Python fallback output.
-        """
+        """Historical mismatch, now void (#1019/#1784): the dict-shaped Python
+        ranking fallback — whose 'ranking' key the writer never read — was
+        replaced by a fail-loud stub, so no synthetic ranking output exists to
+        mismatch. With the JVM up the handler path returns a real result with
+        no 'fallback' key; the guard below keeps documenting that."""
         result = await _invoke_ranking(SAMPLE_TEXT, {})
         if result.get("fallback") == "python":
             # Fallback has 'ranking' key but NOT 'arguments'
@@ -410,24 +401,14 @@ class TestInvokeProbabilisticFallback:
 class TestStateWritersWithFallbackOutput:
     """State writers must be robust to fallback output schemas."""
 
-    def test_write_ranking_fallback_does_not_raise(self, fresh_state):
-        output = _python_ranking_fallback(SAMPLE_ARGS, SAMPLE_ATTACKS, "categorizer")
-        ctx = {"current_arg_id": "test_arg"}
-        _write_ranking_to_state(output, fresh_state, ctx)  # Must not raise
-
-    def test_write_ranking_fallback_creates_entry(self, fresh_state):
-        output = _python_ranking_fallback(SAMPLE_ARGS, SAMPLE_ATTACKS, "categorizer")
-        _write_ranking_to_state(output, fresh_state, {})
-        assert len(fresh_state.ranking_results) == 1
-
-    def test_write_ranking_fallback_arguments_preserved(self, fresh_state):
-        """Verify ranking fallback correctly passes arguments to state writer."""
-        output = _python_ranking_fallback(SAMPLE_ARGS, SAMPLE_ATTACKS, "categorizer")
-        _write_ranking_to_state(output, fresh_state, {})
-        entry = fresh_state.ranking_results[0]
-        # Fixed: fallback now includes 'arguments' key
-        assert entry["arguments"] == SAMPLE_ARGS
-        assert entry["method"] == "categorizer"
+    def test_write_ranking_fallback_stub_raises_before_writer(self):
+        """#1019/#1784: the ranking stub raises upstream, so the writer is
+        never fed a synthetic ranking payload. If a dict-shaped fallback ever
+        reappears, the stub call stops raising and this test fails loudly."""
+        with pytest.raises(RuntimeError, match="Ranking semantics"):
+            output = _python_ranking_fallback(
+                SAMPLE_ARGS, SAMPLE_ATTACKS, "categorizer"
+            )
 
     def test_write_aspic_fallback_does_not_raise(self, fresh_state):
         output = {

--- a/tests/unit/argumentation_analysis/orchestration/test_attack_retention_accounting_1698.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_attack_retention_accounting_1698.py
@@ -351,7 +351,7 @@ class TestSoustractionNoGenuineRelations1629:
             self._stub_handler_module(sink),
         ), patch(
             "argumentation_analysis.agents.core.logic.tweety_initializer."
-            "TweetyInitializer",
+            "ready_initializer",
             return_value=None,
         ):
             output = await _invoke_setaf("text", {"arguments": ["a", "b"]})
@@ -386,7 +386,7 @@ class TestSoustractionNoGenuineRelations1629:
             self._stub_handler_module(sink),
         ), patch(
             "argumentation_analysis.agents.core.logic.tweety_initializer."
-            "TweetyInitializer",
+            "ready_initializer",
             return_value=None,
         ):
             output = await _invoke_setaf("text", {"arguments": ["a", "b", "c"]})
@@ -420,7 +420,7 @@ class TestSoustractionNoGenuineRelations1629:
             self._stub_handler_module(sink),
         ), patch(
             "argumentation_analysis.agents.core.logic.tweety_initializer."
-            "TweetyInitializer",
+            "ready_initializer",
             return_value=None,
         ):
             output = await _invoke_setaf("text", {"arguments": ["arg1", "arg2"]})
@@ -452,7 +452,7 @@ class TestSoustractionNoGenuineRelations1629:
             self._stub_handler_module(sink),
         ), patch(
             "argumentation_analysis.agents.core.logic.tweety_initializer."
-            "TweetyInitializer",
+            "ready_initializer",
             return_value=None,
         ):
             output = await _invoke_weighted("text", {"arguments": ["a", "b"]})

--- a/tests/unit/argumentation_analysis/orchestration/test_dung_attack_translator_1698.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_dung_attack_translator_1698.py
@@ -121,6 +121,9 @@ def _inject_fake_handlers(monkeypatch) -> List[Dict[str, Any]]:
         _fake_module(
             "argumentation_analysis.agents.core.logic.tweety_initializer",
             TweetyInitializer=_FakeTweetyInitializer,
+            # #1784: production now constructs the initializer via
+            # ready_initializer() before building handlers.
+            ready_initializer=lambda: _FakeTweetyInitializer(),
         ),
     )
 

--- a/tests/unit/argumentation_analysis/orchestration/test_jpype_warmup_529.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_jpype_warmup_529.py
@@ -38,9 +38,9 @@ class TestJpypeWarmup:
         from argumentation_analysis.orchestration import unified_pipeline
 
         source = inspect.getsource(unified_pipeline.run_unified_analysis)
-        assert 'workflow_name == "spectacular"' in source, (
-            "Warmup should be guarded by workflow_name == 'spectacular' check"
-        )
+        assert (
+            'workflow_name == "spectacular"' in source
+        ), "Warmup should be guarded by workflow_name == 'spectacular' check"
 
     def test_warmup_failure_is_non_fatal(self):
         """Warmup failure should log warning, not crash."""
@@ -48,14 +48,16 @@ class TestJpypeWarmup:
 
         source = inspect.getsource(unified_pipeline.run_unified_analysis)
         # Find the try/except around warmup
-        assert "JPype warmup failed" in source, (
-            "Warmup should catch exceptions and log a warning, not propagate"
-        )
+        assert (
+            "JPype warmup failed" in source
+        ), "Warmup should catch exceptions and log a warning, not propagate"
 
     @pytest.mark.asyncio
     async def test_warmup_called_before_executor(self):
         """Warmup must execute before WorkflowExecutor.execute()."""
-        from argumentation_analysis.orchestration.unified_pipeline import run_unified_analysis
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            run_unified_analysis,
+        )
 
         # Parse the function source to verify ordering
         source = inspect.getsource(run_unified_analysis)
@@ -63,7 +65,10 @@ class TestJpypeWarmup:
 
         func_def = None
         for node in ast.walk(tree):
-            if isinstance(node, ast.AsyncFunctionDef) and node.name == "run_unified_analysis":
+            if (
+                isinstance(node, ast.AsyncFunctionDef)
+                and node.name == "run_unified_analysis"
+            ):
                 func_def = node
                 break
 
@@ -102,9 +107,9 @@ class TestJpypeWarmup:
         executor_pos = source.find("executor.execute")
         assert warmup_pos > 0, "TweetyInitializer not found in source"
         assert executor_pos > 0, "executor.execute not found in source"
-        assert warmup_pos < executor_pos, (
-            "JPype warmup (TweetyInitializer) must appear before executor.execute()"
-        )
+        assert (
+            warmup_pos < executor_pos
+        ), "JPype warmup (TweetyInitializer) must appear before executor.execute()"
 
     def test_jpype_phase_set_covers_all_required_phases(self):
         """The _jpype_phases set should include all phases that use JPype."""
@@ -112,10 +117,13 @@ class TestJpypeWarmup:
 
         source = inspect.getsource(unified_pipeline.run_unified_analysis)
         required_phases = [
-            "pl", "fol", "modal", "dung_extensions",
-            "aspic_analysis", "fol_solver", "modal_solver",
+            "pl",
+            "fol",
+            "modal",
+            "dung_extensions",
+            "aspic_analysis",
+            "fol_solver",
+            "modal_solver",
         ]
         for phase in required_phases:
-            assert f'"{phase}"' in source, (
-                f"_jpype_phases should include '{phase}'"
-            )
+            assert f'"{phase}"' in source, f"_jpype_phases should include '{phase}'"

--- a/tests/unit/argumentation_analysis/orchestration/test_jpype_warmup_529.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_jpype_warmup_529.py
@@ -16,16 +16,21 @@ class TestJpypeWarmup:
     """Verify synchronous JPype warmup in unified_pipeline.py."""
 
     def test_warmup_code_exists_in_run_unified_analysis(self):
-        """run_unified_analysis must contain JPype warmup block."""
+        """run_unified_analysis must warm up Tweety through the canonical helper.
+
+        #1784: the warmup now goes through ``ready_initializer()`` — the
+        canonical traced warmup in tweety_initializer (construct, then
+        ``ensure_jvm_and_components_are_ready`` when cold). The inline
+        ``TweetyInitializer`` / ``ensure_jvm_and_components_are_ready`` pair
+        this test used to grep for was moved into that helper; asserting the
+        old strings here would force callers to inline the warmup again.
+        """
         from argumentation_analysis.orchestration import unified_pipeline
 
         source = inspect.getsource(unified_pipeline.run_unified_analysis)
-        assert "TweetyInitializer" in source, (
-            "run_unified_analysis should reference TweetyInitializer for warmup"
-        )
-        assert "ensure_jvm_and_components_are_ready" in source, (
-            "run_unified_analysis should call ensure_jvm_and_components_are_ready() "
-            "for synchronous JPype warmup"
+        assert "ready_initializer" in source, (
+            "run_unified_analysis should warm up Tweety via ready_initializer() "
+            "(canonical traced warmup, #1784)"
         )
 
     def test_warmup_guarded_by_spectacular_check(self):

--- a/tests/unit/argumentation_analysis/orchestration/test_structured_arg_translator.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_structured_arg_translator.py
@@ -848,6 +848,12 @@ def _inject_fake_setaf_module(monkeypatch, payload):
         pass
 
     fake_init.TweetyInitializer = _FakeTweetyInitializer  # type: ignore[attr-defined]
+
+    # #1784: production now constructs the initializer via ready_initializer()
+    # before building handlers — the fake module must carry the symbol.
+    fake_init.ready_initializer = (  # type: ignore[attr-defined]
+        lambda: _FakeTweetyInitializer()
+    )
     monkeypatch.setitem(
         sys.modules,
         "argumentation_analysis.agents.core.logic.tweety_initializer",
@@ -1084,6 +1090,12 @@ def _inject_fake_weighted_module(monkeypatch, payload):
         pass
 
     fake_init.TweetyInitializer = _FakeTweetyInitializer  # type: ignore[attr-defined]
+
+    # #1784: production now constructs the initializer via ready_initializer()
+    # before building handlers — the fake module must carry the symbol.
+    fake_init.ready_initializer = (  # type: ignore[attr-defined]
+        lambda: _FakeTweetyInitializer()
+    )
     monkeypatch.setitem(
         sys.modules,
         "argumentation_analysis.agents.core.logic.tweety_initializer",


### PR DESCRIPTION
fix(logic): canonical traced warmup for every bare TweetyInitializer() (#1784)

## What

`TweetyInitializer()` alone never loads the Tweety classes — on a process
where the JVM runs, the handler guards (`is_jvm_ready()`) then reject every
formal axis whose call path didn't construct a TweetyBridge first. #1778
fixed 10 sites in `tweety_logic_plugin`; the sweep stopped at the file
boundary. #1784 measured the remaining 13 sites and fixes the 11 that lack
readiness.

- **Measured table (the deliverable)** — fresh process, cold-start
  precondition asserted before every axis, `_classes_loaded` recorded after
  each call: all 11 no-readiness sites are dead cold, but only **7 raise**
  the `JVM/Tweety required` signature (dl, cl, setaf, weighted, social, eaf,
  delp); **3 degrade silently** (`_invoke_qbf` → `valid:null,
  fallback:"error"`; `_invoke_dung_extensions` → `degraded:true` honest-absent;
  `_default_tweety_dung_backend` → `available:false`); **1 sits behind the
  SPASS gate** (`_invoke_external_modal_solver` — and its TweetyBridge
  fallback *warms* the flag, measured: last axis only). Full table in the
  issue comment.
- **Fix — canonical helper** `ready_initializer()` in `tweety_initializer.py`
  (#1778 form: construct → if `not is_jvm_ready()` → logged INFO →
  `ensure_jvm_and_components_are_ready()`, idempotent, never silent
  lazy-init). Consumers: the 11 `invoke_callables` sites;
  `tweety_logic_plugin._ready_initializer` delegates (single source of
  truth); `unified_pipeline.py` spectacular warmup adopts it (body was
  identical). The #1219 modal site (7630) is deliberately untouched — its
  `initialize_modal_components()`-only semantics are correct and documented.
- **Order-independence guard** (#1778 pattern):
  `test_1784_invoke_callables_cold_boot.py` — fresh subprocess, JVM started
  by the production entry, cold precondition asserted inside, direct
  `_invoke_dl` call. Red on unfixed code (verified), green after.
- **Downstream signal demystified**: the 9 `test_tweety_fallbacks.py`
  failures the issue read as a #1775-class signature are stale tests of the
  synthetic Python ranking fallback that #1019/RA-8 #1053 deliberately made
  fail-loud; updated to pin the real contract (`pytest.raises`). The 2 ADF
  failures are the `AbstractBuilder.add` overload incompatibility (separate
  ticket, excluded by the issue's anti-pendule) and remain red.

## Files removed and why

None removed. `tests/integration/test_tweety_fallbacks.py`: 6 dict-shape
tests of `TestPythonRankingFallback` collapsed into 2 fail-loud contract
tests (parametrized), 3 ranking writer-robustness tests replaced by 1
stub-raises-before-writer test — they asserted a fallback payload that no
longer exists (#1019); behavior identical to what the stub contract requires.

## Test plan

- [x] Fresh-process measurement table (11 axes) — before/after
- [x] Guard test red on unfixed code / green after fix
- [x] `test_tweety_fallbacks.py`: 11 failed → 2 failed (ADF overloads,
      separate ticket), 54 → 63 passed
- [x] Plugin delegation sweep (`test_tweety_logic_plugin_error_vocabulary.py`,
      #1775 tripwire)
- [x] Consumer sweep (external solvers, state writers, sanitize provenance)
- [x] mypy strict: 0 new errors (26 pre-existing on tweety_initializer)
- [x] black clean

Closes #1784
