### PR TITLE
fix(logic): ADF and EAF decide again — three JAR-API layers repaired (#1796)

### DIFF
--- a/argumentation_analysis/agents/core/logic/adf_handler.py
+++ b/argumentation_analysis/agents/core/logic/adf_handler.py
@@ -45,8 +45,37 @@ class ADFHandler:
         self.NegationAcc = jpype.JClass(
             "org.tweetyproject.arg.adf.syntax.acc.NegationAcceptanceCondition"
         )
+        self.Link = jpype.JClass("org.tweetyproject.arg.adf.semantics.link.Link")
+        self.LinkType = jpype.JClass(
+            "org.tweetyproject.arg.adf.semantics.link.LinkType"
+        )
         self.KppParser = jpype.JClass("org.tweetyproject.arg.adf.io.KppADFFormatParser")
         self._reasoner_cache = {}
+        self._solver = None
+        self._solver_probed = False
+
+    def _get_solver(self) -> Any:
+        """#1796: every ADF reasoner takes an IncrementalSatSolver in its
+        constructor. The only implementations in the JARs are the JNI trio;
+        they decide when the DLL sits in a classpath *directory* (a jar URL
+        cannot be passed to System.load — that is what made #1244 conclude
+        they never decide). Probe once, honestly: if instantiation fails, the
+        axis degrades instead of crashing.
+        """
+        if not self._solver_probed:
+            self._solver_probed = True
+            try:
+                NativeMinisat = jpype.JClass(
+                    "org.tweetyproject.arg.adf.sat.solver.NativeMinisatSolver"
+                )
+                self._solver = NativeMinisat()
+            except Exception as e:
+                logger.warning(
+                    "ADF native SAT solver unavailable (%s) — axis will degrade.",
+                    str(e)[:120],
+                )
+                self._solver = None
+        return self._solver
 
     def _get_reasoner(self, semantics: str):
         if semantics not in self._reasoner_cache:
@@ -54,8 +83,11 @@ class ADFHandler:
                 raise ValueError(
                     f"Unknown ADF semantics: {semantics}. Available: {list(self.REASONERS.keys())}"
                 )
+            solver = self._get_solver()
+            if solver is None:
+                return None
             cls = jpype.JClass(self.REASONERS[semantics])
-            self._reasoner_cache[semantics] = cls()
+            self._reasoner_cache[semantics] = cls(solver)
         return self._reasoner_cache[semantics]
 
     def analyze_adf(
@@ -76,35 +108,59 @@ class ADFHandler:
             Dict with interpretations and statistics.
         """
         try:
-            builder = self.ADF.builder()
+            # #1796: default builder mode is eager with no LinkStrategy, which
+            # throws "missing links" as soon as a condition references a
+            # parent. We know each link's type (negation -> attacking), so we
+            # provide them explicitly — no SAT-based link strategy needed.
+            builder = self.ADF.builder().provided()
 
-            # Add statements
-            arg_map = {}
-            for stmt in statements:
-                arg = self.ADFArgument(stmt)
-                arg_map[stmt] = arg
-                builder.add(arg)
+            # #1796: the JAR's AbstractBuilder has no add(Argument) overload —
+            # only add(Argument, AcceptanceCondition) and add(Link). Every
+            # statement is added exactly once, with its condition.
+            arg_map = {stmt: self.ADFArgument(stmt) for stmt in statements}
 
-            # Add acceptance conditions
-            for stmt, condition in acceptance_conditions.items():
-                arg = arg_map[stmt]
-                if condition == "tautology":
-                    acc = self.TautologyAcc()
-                elif condition == "contradiction":
-                    acc = self.ContradictionAcc()
-                elif condition.startswith("negation:"):
+            def _acc_of(condition: str) -> Any:
+                if condition == "contradiction":
+                    return self.ContradictionAcc.INSTANCE
+                if condition.startswith("negation:"):
                     other = condition.split(":", 1)[1]
                     if other in arg_map:
-                        acc = self.NegationAcc(arg_map[other])
-                    else:
-                        acc = self.TautologyAcc()
-                else:
-                    acc = self.TautologyAcc()
-                builder.add(arg, acc)
+                        # Argument implements AcceptanceCondition, so the bare
+                        # argument is the literal for its own acceptance.
+                        return self.NegationAcc(arg_map[other])
+                return self.TautologyAcc.INSTANCE
+
+            for stmt, condition in acceptance_conditions.items():
+                builder.add(arg_map[stmt], _acc_of(condition))
+            for stmt in statements:
+                if stmt not in acceptance_conditions:
+                    builder.add(arg_map[stmt], self.TautologyAcc.INSTANCE)
+            for stmt, condition in acceptance_conditions.items():
+                if condition.startswith("negation:"):
+                    other = condition.split(":", 1)[1]
+                    if other in arg_map:
+                        builder.add(
+                            self.Link.of(
+                                arg_map[other], arg_map[stmt], self.LinkType.ATTACKING
+                            )
+                        )
 
             adf = builder.build()
 
             reasoner = self._get_reasoner(semantics)
+            if reasoner is None:
+                return {
+                    "semantics": semantics,
+                    "statements": sorted(statements),
+                    "interpretations": [],
+                    "degraded": True,
+                    "note": "ADF native SAT solver unavailable (see libs/native/README.md).",
+                    "statistics": {
+                        "statements_count": len(statements),
+                        "conditions_count": len(acceptance_conditions),
+                        "interpretations_count": 0,
+                    },
+                }
             interpretations = reasoner.getModels(adf)
 
             interp_list = []

--- a/argumentation_analysis/agents/core/logic/eaf_handler.py
+++ b/argumentation_analysis/agents/core/logic/eaf_handler.py
@@ -24,6 +24,30 @@ _EAF_REASONERS = {
 }
 
 
+def _trivial_constraint(handler: "EAFHandler", arg_name: str) -> Any:
+    """#1796: the JAR's no-arg constructor defaults the epistemic constraint to
+    ``Possibility(Tautology)`` — the one formula its own evaluator rejects
+    (``satisfiesClassicalFormula`` handles FolAtom/Conjunction/Disjunction/
+    Negation, not Tautology), so every EAF query dies with
+    ``IllegalArgumentException``. This builds the equivalent always-true
+    constraint the evaluator supports: the disjunction of the three labelled
+    statuses of one argument (every argument has exactly one status per
+    labeling, so the disjunction always holds).
+    """
+    from java.util import ArrayList
+
+    disjuncts = ArrayList()
+    for predicate in ("in", "out", "und"):
+        disjuncts.add(
+            handler._Possibility(
+                handler._FolAtom(
+                    handler._Predicate(predicate, 1), handler._Constant(arg_name)
+                )
+            )
+        )
+    return handler._Disjunction(disjuncts)
+
+
 class EAFHandler:
     """Epistemic Argumentation Framework analysis using Tweety.
 
@@ -47,6 +71,21 @@ class EAFHandler:
         # Dung classes shared
         self._Argument = jpype.JClass("org.tweetyproject.arg.dung.syntax.Argument")
         self._Attack = jpype.JClass("org.tweetyproject.arg.dung.syntax.Attack")
+
+        # #1796: constraint-building classes (see _trivial_constraint)
+        self._Predicate = jpype.JClass(
+            "org.tweetyproject.logics.commons.syntax.Predicate"
+        )
+        self._Constant = jpype.JClass(
+            "org.tweetyproject.logics.commons.syntax.Constant"
+        )
+        self._FolAtom = jpype.JClass("org.tweetyproject.logics.fol.syntax.FolAtom")
+        self._Possibility = jpype.JClass(
+            "org.tweetyproject.logics.ml.syntax.Possibility"
+        )
+        self._Disjunction = jpype.JClass(
+            "org.tweetyproject.logics.fol.syntax.Disjunction"
+        )
 
         # Load reasoners
         self._reasoners = {}
@@ -96,6 +135,11 @@ class EAFHandler:
                 arg = self._Argument(name)
                 arg_map[name] = arg
                 framework.add(arg)
+
+            # #1796: replace the default constraint (unsupported Tautology)
+            # with an equivalent, evaluable always-true constraint.
+            if arguments:
+                framework.setConstraint(_trivial_constraint(self, arguments[0]))
 
             # Create attacks
             for src, tgt in attacks:

--- a/tests/integration/argumentation_analysis/test_1796_adf_eaf_decide.py
+++ b/tests/integration/argumentation_analysis/test_1796_adf_eaf_decide.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+"""#1796: the ADF and EAF axes decide instead of crashing.
+
+Two distinct JAR-API mismatches kept both axes dead even with the JVM warm:
+
+- ADF: ``AbstractBuilder`` has no ``add(Argument)`` overload (only
+  ``add(Argument, AcceptanceCondition)`` and ``add(Link)``); the acceptance
+  enums are singletons (``.INSTANCE``, not callable); the default builder is
+  eager-without-strategy ("missing links") and every reasoner takes an
+  ``IncrementalSatSolver``.
+- EAF: the framework's no-arg constructor defaults the epistemic constraint
+  to ``Possibility(Tautology)`` — the one formula its own evaluator rejects.
+
+The guard runs a fresh subprocess (JVM started through the production entry
+point) and requires a real decision from each axis: non-empty interpretations
+for ADF, the grounded extension [a, c] for EAF on a->b->c.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+_SCRIPT = r"""
+import os
+os.environ.pop("PYTEST_RUNNING", None)
+
+from argumentation_analysis.core.jvm_setup import initialize_jvm
+initialize_jvm()
+
+from argumentation_analysis.agents.core.logic.tweety_initializer import TweetyInitializer
+
+init = TweetyInitializer()
+if not init.is_jvm_ready():
+    init.ensure_jvm_and_components_are_ready()
+
+from argumentation_analysis.agents.core.logic.adf_handler import ADFHandler
+from argumentation_analysis.agents.core.logic.eaf_handler import EAFHandler
+
+adf = ADFHandler(init).analyze_adf(
+    statements=["a", "b"],
+    acceptance_conditions={"a": "tautology", "b": "negation:a"},
+    semantics="grounded",
+)
+assert adf.get("interpretations"), f"ADF decided nothing: {adf}"
+assert adf.get("degraded") is not True, f"ADF degraded on this machine: {adf}"
+print("ADF_OK", adf["interpretations"])
+
+eaf = EAFHandler(init).analyze_epistemic_framework(
+    arguments=["a", "b", "c"],
+    attacks=[["a", "b"], ["b", "c"]],
+    epistemic_beliefs={"agent1": ["a", "b", "c"]},
+    semantics="grounded",
+)
+assert ["a", "c"] in eaf.get("extensions", []), f"EAF wrong extensions: {eaf}"
+print("EAF_OK", eaf["extensions"])
+"""
+
+
+@pytest.mark.integration
+@pytest.mark.no_jvm_session
+def test_adf_and_eaf_decide_in_fresh_process(tmp_path):
+    script = tmp_path / "probe_1796.py"
+    script.write_text(_SCRIPT, encoding="utf-8")
+
+    result = subprocess.run(
+        [sys.executable, str(script)],
+        capture_output=True,
+        text=True,
+        timeout=420,
+        cwd=str(REPO_ROOT),
+    )
+
+    combined = result.stdout + result.stderr
+    assert result.returncode == 0, f"probe failed:\n{combined[-2000:]}"
+    assert "ADF_OK" in result.stdout and "EAF_OK" in result.stdout


### PR DESCRIPTION
## Summary

Closes #1796. Both the ADF and EAF axes decide again — two distinct JAR-API mismatches repaired by measurement, follow-up of the #1784 sweep (PR #1795).

### ADF — three stacked API mismatches (adf_handler.py)

1. **`add(Argument)` does not exist**: the JAR's `AbstractBuilder` only exposes `add(Argument, AcceptanceCondition)` and `add(Link)`. Every statement is now added exactly once, with its condition.
2. **The acceptance enums**: `TautologyAcceptanceCondition`/`ContradictionAcceptanceCondition` are enums — `.INSTANCE`, not callable.
3. **Builder mode + solver**: the default builder is eager-without-`LinkStrategy` (`"Could not build ADF because of missing links!"`) and **every** ADF reasoner takes an `IncrementalSatSolver` in its constructor. The handler now:
   - builds in `provided()` mode with **explicit links** (`negation:x` → `Link.of(x, stmt, ATTACKING)` — the type is known without a SAT-based link strategy);
   - probes the native minisat solver once; when the DLL is unavailable it returns an **honest-degraded envelope** (`degraded: true`, `interpretations: []`) instead of crashing.

### EAF — the default constraint is the formula its evaluator rejects (eaf_handler.py)

Chain verified in the JAR's own embedded sources: the no-arg constructor sets `constraint = Possibility(Tautology)` (EpistemicArgumentationFramework.java:79-81), and `satisfiesClassicalFormula` handles `FolAtom/Conjunction/Disjunction/Negation` — **not `Tautology`** (line 595: `throw new IllegalArgumentException("Unsupported classical formula type: …")`). Every EAF query with the default constraint died. The handler now calls the public `setConstraint` after construction with the equivalent **always-true constraint the evaluator supports**: the disjunction of the three labelled statuses of the first argument (`Possibility(in(a)) ∨ Possibility(out(a)) ∨ Possibility(und(a))` — every argument has exactly one status per labeling).

## Measured

| Axis | Before | After |
|---|---|---|
| ADF (b = ¬a, grounded) | `No matching overloads … add(Argument)` | `{t(a) f(b)}` |
| ADF statement w/o condition | (same crash) | `{t(x)}` |
| EAF a→b→c grounded | `IllegalArgumentException: …Tautology` | `[[a, c]]` |
| Guard test (fresh subprocess, production JVM entry) | red 9.3 s | green 9.4 s |

`tests/integration/test_tweety_fallbacks.py`: the 2 `TestInvokeAdfFallback` tests now pass. The 9 remaining failures are the stale ranking tests (#1019 fail-loud contract) already fixed on PR #1795 — complementary, no overlap (this PR does not touch that file).

## ⚠️ Arbitration requested (not acted on): #1244 falsified

`libs/native/README.md` (FP-20, epic #1191) states the JNI SAT trio "never decide" on this machine. Falsified today:

- `System.load(<absolute path to minisat.dll>)` succeeds;
- `NativeMinisatSolver()` **instantiates and decides** when the DLL sits in a classpath **directory** (libs/native);
- the real mechanism behind the old verdict: the constructor loads `minisat.dll` via `getResource()`, and `System.load` **cannot take a jar URL** — with an empty libs/native the resource resolves inside the jar and the load fails before any binding is attempted.

Re-vendoring the (working, measured) DLLs in `libs/native` would make the ADF axis decide on every clone — but that reverses an epic decision, so it is left to the coordinator. The handler degrades honestly without it.

## Test plan

- [x] `tests/integration/argumentation_analysis/test_1796_adf_eaf_decide.py` (new): fresh-subprocess guard, red-on-unfixed verified by stash
- [x] `TestInvokeAdfFallback` (2 tests): pass
- [x] Mocked sweep (track_a_handlers + error_vocabulary + dung_attack_translator_1698): 157 passed
- [x] mypy strict: 4 errors, all pre-existing (baseline was 5 — one absorbed); 0 new
- [x] black: clean
- [x] CI (run 32099084035, success)

## Files removed and why

None removed.
