### PR TITLE
fix(gate): kill the ambient env loaders — identity swaps, import-time loads, the POST seeder (#1794)

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -4,6 +4,17 @@ import glob
 import logging
 import os
 from pathlib import Path
+
+# #1794: this entry point used to inherit its .env from the module-level
+# load_dotenv() in orchestration.invoke_callables — env loading belongs to
+# process entry points, not to library imports (collection-time pollution).
+try:
+    from dotenv import load_dotenv
+
+    load_dotenv()
+except ImportError:
+    pass
+
 from .factory import create_app
 from .endpoints import router as api_router, framework_router, informal_router
 from .proposal_endpoints import proposal_router

--- a/argumentation_analysis/evaluation/multi_model_benchmark.py
+++ b/argumentation_analysis/evaluation/multi_model_benchmark.py
@@ -313,10 +313,6 @@ async def run_multi_model_benchmark(
     Returns:
         ComparisonReport with aggregated scores and rankings.
     """
-    from dotenv import load_dotenv
-
-    load_dotenv()
-
     workflows = workflows or ["light", "standard"]
     registry = ModelRegistry.from_env()
     available_models = list(registry.list_models().keys())
@@ -487,6 +483,14 @@ def main():
         format="%(asctime)s [%(name)s] %(message)s",
     )
 
+    # #1794: env loading belongs to the CLI entry point — run_multi_model_benchmark
+    # is a library function and must not mutate the process environment (it leaked
+    # the nested .env key into the test suite). load_dotenv() here covers the
+    # list-models branch and the benchmark run below.
+    from dotenv import load_dotenv
+
+    load_dotenv()
+
     if args.list_workflows:
         print("Available workflows:")
         for wf in list_available_workflows():
@@ -494,9 +498,6 @@ def main():
         return
 
     if args.list_models:
-        from dotenv import load_dotenv
-
-        load_dotenv()
         registry = ModelRegistry.from_env()
         print("Available models:")
         for name, config in registry.list_models().items():

--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -94,13 +94,12 @@ def _get_strategic_directives(context: Dict[str, Any]) -> Tuple[str, List[str]]:
     return f"{header}\n" + "\n".join(lines), obj_ids
 
 
-# Ensure .env is loaded so OPENAI_API_KEY is available for all invoke callables
-try:
-    from dotenv import load_dotenv
-
-    load_dotenv()
-except ImportError:
-    pass
+# #1794: the module-level load_dotenv() that used to live here ran at pytest
+# COLLECTION time (any test-module import reached this line) and loaded the
+# nearest .env into the process env before the first test ran — deciding
+# "no api key" premises by machine topology instead of by the test. Env
+# loading now belongs to process entry points only (api/main.py,
+# run_orchestration.py; interface_web is a pure proxy).
 
 # Export all underscore-prefixed functions for star-import in unified_pipeline facade
 __all__ = [

--- a/argumentation_analysis/run_orchestration.py
+++ b/argumentation_analysis/run_orchestration.py
@@ -53,13 +53,14 @@ import argparse
 import logging
 from typing import Any, Dict, Optional
 
-# Ensure .env is loaded BEFORE any other import that might need API keys
-try:
-    from dotenv import load_dotenv
-
-    load_dotenv()
-except ImportError:
-    pass
+# #1794: .env loading moved into main() — this module lives inside
+# argumentation_analysis/, so a module-level load_dotenv() resolves the NESTED
+# argumentation_analysis/.env (not the repo root one) on import, seeding the
+# real provider key into any process that merely imports this module (tests
+# included). The CLI still loads before any LLM use; the import no longer
+# mutates the process env. The import itself is kept module-level (no call) so
+# tests that drive main() can patch it.
+from dotenv import load_dotenv  # noqa: E402 — imported only, called in main()
 
 
 def setup_logging(verbose: bool = False) -> None:
@@ -296,6 +297,12 @@ async def run_modern_analysis(
 
 async def main():
     """Fonction principale du script."""
+    # #1794: env loading belongs to the CLI entry point (see module header).
+    try:
+        load_dotenv()
+    except Exception:
+        pass
+
     parser = argparse.ArgumentParser(
         description="Orchestration des agents d'analyse argumentative",
         formatter_class=argparse.RawDescriptionHelpFormatter,

--- a/tests/unit/argumentation_analysis/orchestration/test_parent_harness_578.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_parent_harness_578.py
@@ -7,6 +7,7 @@ Verifies that _invoke_hierarchical_fallacy_per_argument correctly:
 - Falls back to single-text when no arguments available
 - Handles timeouts and errors per-argument
 """
+
 import asyncio
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -30,8 +31,14 @@ class TestExtractArgumentsForParallel:
         context = {"_state_object": state}
         result = _extract_arguments_for_parallel("any text", context)
         assert len(result) == 2
-        assert result[0] == ("arg_1", "First argument with sufficient length to pass threshold")
-        assert result[1] == ("arg_2", "Second argument also long enough for extraction test")
+        assert result[0] == (
+            "arg_1",
+            "First argument with sufficient length to pass threshold",
+        )
+        assert result[1] == (
+            "arg_2",
+            "Second argument also long enough for extraction test",
+        )
 
     def test_extracts_from_extraction_output(self):
         from argumentation_analysis.orchestration.invoke_callables import (
@@ -41,7 +48,9 @@ class TestExtractArgumentsForParallel:
         context = {
             "phase_extract_output": {
                 "arguments": [
-                    {"text": "Argument one is a substantial text for testing purposes here"},
+                    {
+                        "text": "Argument one is a substantial text for testing purposes here"
+                    },
                     {"text": "Argument two is another substantial text for testing"},
                 ]
             }
@@ -177,18 +186,20 @@ class TestInvokeHierarchicalFallacyPerArgument:
 
         # Each arg returns 1 fallacy — must be async coroutines
         def make_async_plugin_result(arg_id):
-            result_json = json.dumps({
-                "fallacies": [
-                    {
-                        "fallacy_type": f"fallacy_for_{arg_id}",
-                        "taxonomy_pk": f"pk_{arg_id}",
-                        "confidence": 0.8,
-                        "explanation": f"Fallacy in {arg_id}",
-                    }
-                ],
-                "exploration_method": "wide_net",
-                "total_iterations": 3,
-            })
+            result_json = json.dumps(
+                {
+                    "fallacies": [
+                        {
+                            "fallacy_type": f"fallacy_for_{arg_id}",
+                            "taxonomy_pk": f"pk_{arg_id}",
+                            "confidence": 0.8,
+                            "explanation": f"Fallacy in {arg_id}",
+                        }
+                    ],
+                    "exploration_method": "wide_net",
+                    "total_iterations": 3,
+                }
+            )
 
             async def _mock_run(*args, **kwargs):
                 return result_json
@@ -225,9 +236,16 @@ class TestInvokeHierarchicalFallacyPerArgument:
         ), patch(
             "argumentation_analysis.orchestration.invoke_callables._extract_arguments_for_parallel",
             return_value=arguments,
-        ), patch.dict("sys.modules", modules), patch(
-            "argumentation_analysis.orchestration.invoke_callables.os.environ",
-            {"OPENAI_API_KEY": "test-key", "OPENAI_BASE_URL": "https://api.test.com/v1", "OPENAI_CHAT_MODEL_ID": "test-model"},
+        ), patch.dict(
+            "sys.modules", modules
+        ), patch.dict(
+            "os.environ",
+            {
+                "OPENAI_API_KEY": "test-key",
+                "OPENAI_BASE_URL": "https://api.test.com/v1",
+                "OPENAI_CHAT_MODEL_ID": "test-model",
+            },
+            clear=True,
         ):
             result = await _invoke_hierarchical_fallacy_per_argument("full text", {})
 
@@ -250,18 +268,20 @@ class TestInvokeHierarchicalFallacyPerArgument:
 
         # Both return same taxonomy_pk but different source_arg_id
         def make_async_plugin_result(arg_id):
-            result_json = json.dumps({
-                "fallacies": [
-                    {
-                        "fallacy_type": "ad_hominem",
-                        "taxonomy_pk": "pk_ad_hominem",
-                        "confidence": 0.7,
-                        "explanation": f"Same fallacy in {arg_id}",
-                    }
-                ],
-                "exploration_method": "wide_net",
-                "total_iterations": 2,
-            })
+            result_json = json.dumps(
+                {
+                    "fallacies": [
+                        {
+                            "fallacy_type": "ad_hominem",
+                            "taxonomy_pk": "pk_ad_hominem",
+                            "confidence": 0.7,
+                            "explanation": f"Same fallacy in {arg_id}",
+                        }
+                    ],
+                    "exploration_method": "wide_net",
+                    "total_iterations": 2,
+                }
+            )
 
             async def _mock_run(*args, **kwargs):
                 return result_json
@@ -296,9 +316,16 @@ class TestInvokeHierarchicalFallacyPerArgument:
         ), patch(
             "argumentation_analysis.orchestration.invoke_callables._extract_arguments_for_parallel",
             return_value=arguments,
-        ), patch.dict("sys.modules", modules), patch(
-            "argumentation_analysis.orchestration.invoke_callables.os.environ",
-            {"OPENAI_API_KEY": "test-key", "OPENAI_BASE_URL": "https://api.test.com/v1", "OPENAI_CHAT_MODEL_ID": "test-model"},
+        ), patch.dict(
+            "sys.modules", modules
+        ), patch.dict(
+            "os.environ",
+            {
+                "OPENAI_API_KEY": "test-key",
+                "OPENAI_BASE_URL": "https://api.test.com/v1",
+                "OPENAI_CHAT_MODEL_ID": "test-model",
+            },
+            clear=True,
         ):
             result = await _invoke_hierarchical_fallacy_per_argument("full text", {})
 
@@ -318,11 +345,19 @@ class TestInvokeHierarchicalFallacyPerArgument:
         ]
 
         # arg_1 succeeds quickly
-        fast_result = json.dumps({
-            "fallacies": [{"fallacy_type": "ad_hominem", "taxonomy_pk": "pk_1", "confidence": 0.8}],
-            "exploration_method": "wide_net",
-            "total_iterations": 2,
-        })
+        fast_result = json.dumps(
+            {
+                "fallacies": [
+                    {
+                        "fallacy_type": "ad_hominem",
+                        "taxonomy_pk": "pk_1",
+                        "confidence": 0.8,
+                    }
+                ],
+                "exploration_method": "wide_net",
+                "total_iterations": 2,
+            }
+        )
 
         async def fast_run(*args, **kwargs):
             return fast_result
@@ -359,9 +394,16 @@ class TestInvokeHierarchicalFallacyPerArgument:
         ), patch(
             "argumentation_analysis.orchestration.invoke_callables._extract_arguments_for_parallel",
             return_value=arguments,
-        ), patch.dict("sys.modules", modules), patch(
-            "argumentation_analysis.orchestration.invoke_callables.os.environ",
-            {"OPENAI_API_KEY": "test-key", "OPENAI_BASE_URL": "https://api.test.com/v1", "OPENAI_CHAT_MODEL_ID": "test-model"},
+        ), patch.dict(
+            "sys.modules", modules
+        ), patch.dict(
+            "os.environ",
+            {
+                "OPENAI_API_KEY": "test-key",
+                "OPENAI_BASE_URL": "https://api.test.com/v1",
+                "OPENAI_CHAT_MODEL_ID": "test-model",
+            },
+            clear=True,
         ):
             # Use a very short timeout for arg_2 to trigger timeout quickly
             original_wait_for = asyncio.wait_for
@@ -375,7 +417,9 @@ class TestInvokeHierarchicalFallacyPerArgument:
                 "argumentation_analysis.orchestration.invoke_callables.asyncio.wait_for",
                 side_effect=patched_wait_for,
             ):
-                result = await _invoke_hierarchical_fallacy_per_argument("full text", {})
+                result = await _invoke_hierarchical_fallacy_per_argument(
+                    "full text", {}
+                )
 
         # The fast arg completes, the slow one times out — result still valid
         assert "fallacies" in result
@@ -395,12 +439,18 @@ class TestInvokeHierarchicalFallacyPerArgument:
         # Primary guided path hangs (times out); one-shot returns quickly.
         async def guided(*args, **kwargs):
             if kwargs.get("use_one_shot"):
-                return json.dumps({
-                    "fallacies": [
-                        {"fallacy_type": "post_hoc", "taxonomy_pk": "pk_2", "confidence": 0.7}
-                    ],
-                    "exploration_method": "one_shot",
-                })
+                return json.dumps(
+                    {
+                        "fallacies": [
+                            {
+                                "fallacy_type": "post_hoc",
+                                "taxonomy_pk": "pk_2",
+                                "confidence": 0.7,
+                            }
+                        ],
+                        "exploration_method": "one_shot",
+                    }
+                )
             await asyncio.sleep(10)
             return json.dumps({"fallacies": [], "exploration_method": "wide_net"})
 
@@ -428,9 +478,16 @@ class TestInvokeHierarchicalFallacyPerArgument:
         ), patch(
             "argumentation_analysis.orchestration.invoke_callables._extract_arguments_for_parallel",
             return_value=arguments,
-        ), patch.dict("sys.modules", modules), patch(
-            "argumentation_analysis.orchestration.invoke_callables.os.environ",
-            {"OPENAI_API_KEY": "test-key", "OPENAI_BASE_URL": "https://api.test.com/v1", "OPENAI_CHAT_MODEL_ID": "test-model"},
+        ), patch.dict(
+            "sys.modules", modules
+        ), patch.dict(
+            "os.environ",
+            {
+                "OPENAI_API_KEY": "test-key",
+                "OPENAI_BASE_URL": "https://api.test.com/v1",
+                "OPENAI_CHAT_MODEL_ID": "test-model",
+            },
+            clear=True,
         ):
             original_wait_for = asyncio.wait_for
 
@@ -445,7 +502,9 @@ class TestInvokeHierarchicalFallacyPerArgument:
                 "argumentation_analysis.orchestration.invoke_callables.asyncio.wait_for",
                 side_effect=patched_wait_for,
             ):
-                result = await _invoke_hierarchical_fallacy_per_argument("full text", {})
+                result = await _invoke_hierarchical_fallacy_per_argument(
+                    "full text", {}
+                )
 
         # The one-shot fallback recovered the fallacy instead of returning empty.
         assert len(result["fallacies"]) == 1

--- a/tests/unit/argumentation_analysis/service_setup/test_analysis_services.py
+++ b/tests/unit/argumentation_analysis/service_setup/test_analysis_services.py
@@ -195,7 +195,9 @@ def test_initialize_services_llm_fails_raises_exception(
     )
 
 
-def test_initialize_services_jvm_disabled(mock_settings, mock_init_jvm, caplog):
+def test_initialize_services_jvm_disabled(
+    mock_settings, mock_init_jvm, mock_load_dotenv, mock_find_dotenv, caplog
+):
     """Teste que la JVM n'est pas initialisée si elle est désactivée dans la config."""
     caplog.set_level(logging.INFO)
     mock_settings.enable_jvm = False
@@ -208,7 +210,14 @@ def test_initialize_services_jvm_disabled(mock_settings, mock_init_jvm, caplog):
     mock_init_jvm.assert_not_called()
 
 
-def test_initialize_services_libs_dir_is_none(mock_settings, mock_init_jvm, caplog):
+def test_initialize_services_libs_dir_is_none(
+    mock_settings, mock_init_jvm, mock_load_dotenv, mock_find_dotenv, caplog
+):
+    # #1794: without these mocks, initialize_analysis_services() runs a real
+    # load_dotenv(find_dotenv()) which resolves the NESTED .env (from
+    # argumentation_analysis/service_setup/ it walks up to argumentation_analysis/.env)
+    # and seeds the real provider key into the process env mid-suite — the writer
+    # behind the surviving pl_2pass POSTs (named by per-directory bisection).
     """Teste le cas où LIBS_DIR est None dans la config."""
     caplog.set_level(logging.ERROR)
     mock_settings.enable_jvm = True

--- a/tests/unit/argumentation_analysis/test_cluedo_mode_dispatch.py
+++ b/tests/unit/argumentation_analysis/test_cluedo_mode_dispatch.py
@@ -75,6 +75,10 @@ class TestCluedoModeDispatch:
             "argumentation_analysis.run_orchestration.setup_environment",
             new_callable=AsyncMock,
             return_value=MagicMock(service_id="test"),
+        ), patch(
+            # #1794: main() loads the CLI .env — in-test that call would seed
+            # the real (nested) provider key into the process env.
+            "argumentation_analysis.run_orchestration.load_dotenv",
         ):
             from argumentation_analysis.run_orchestration import main
             import sys
@@ -83,8 +87,10 @@ class TestCluedoModeDispatch:
             original_argv = sys.argv
             sys.argv = [
                 "run_orchestration.py",
-                "--mode", "cluedo",
-                "--text", "Test text for investigation",
+                "--mode",
+                "cluedo",
+                "--text",
+                "Test text for investigation",
             ]
             try:
                 await main()
@@ -109,6 +115,9 @@ class TestCluedoModeDispatch:
             "argumentation_analysis.run_orchestration.setup_environment",
             new_callable=AsyncMock,
             return_value=MagicMock(service_id="test"),
+        ), patch(
+            # #1794: same as above — main()'s CLI .env load stays out of tests.
+            "argumentation_analysis.run_orchestration.load_dotenv",
         ):
             from argumentation_analysis.run_orchestration import main
             import sys
@@ -116,8 +125,10 @@ class TestCluedoModeDispatch:
             original_argv = sys.argv
             sys.argv = [
                 "run_orchestration.py",
-                "--mode", "cluedo",
-                "--text", "Some interesting text about a mystery",
+                "--mode",
+                "cluedo",
+                "--text",
+                "Some interesting text about a mystery",
             ]
             try:
                 await main()
@@ -128,7 +139,9 @@ class TestCluedoModeDispatch:
 
             # Check initial_question was derived from text
             if mock_cluedo_fn.called:
-                call_kwargs = mock_cluedo_fn.call_args[1] if mock_cluedo_fn.call_args[1] else {}
+                call_kwargs = (
+                    mock_cluedo_fn.call_args[1] if mock_cluedo_fn.call_args[1] else {}
+                )
                 initial_q = call_kwargs.get("initial_question", "")
                 assert "text" in initial_q.lower() or "indice" in initial_q.lower()
 

--- a/tests/unit/argumentation_analysis/test_pl_2pass_pipeline.py
+++ b/tests/unit/argumentation_analysis/test_pl_2pass_pipeline.py
@@ -226,6 +226,7 @@ class TestTwoPassPipeline:
                 "OPENROUTER_API_KEY": "",
                 "OPENROUTER_BASE_URL": "",
             },
+            clear=True,
         ):
             result = asyncio.get_event_loop().run_until_complete(
                 _invoke_propositional_logic(state.raw_text, ctx)
@@ -322,6 +323,9 @@ class TestBackwardCompat:
         }
 
         # Same #1591 premise fix as TestTwoPassPipeline::test_fallback_when_no_api_key.
+        # #1794: clear=True — without it the ambient key (CI secret or the nested
+        # .env leaked by multi_model_benchmark) survives the window and the
+        # no-key premise never holds (measured: real POSTs out of the test).
         with patch.dict(
             "os.environ",
             {
@@ -329,6 +333,7 @@ class TestBackwardCompat:
                 "OPENROUTER_API_KEY": "",
                 "OPENROUTER_BASE_URL": "",
             },
+            clear=True,
         ):
             result = asyncio.get_event_loop().run_until_complete(
                 _invoke_propositional_logic("test text", ctx)

--- a/tests/unit/argumentation_analysis/test_run_orchestration.py
+++ b/tests/unit/argumentation_analysis/test_run_orchestration.py
@@ -1,11 +1,16 @@
 """Tests for run_orchestration.py CLI entry point."""
+
 import subprocess
 import sys
 from pathlib import Path
 
 import pytest
 
-CLI_SCRIPT = Path(__file__).parent.parent.parent.parent / "argumentation_analysis" / "run_orchestration.py"
+CLI_SCRIPT = (
+    Path(__file__).parent.parent.parent.parent
+    / "argumentation_analysis"
+    / "run_orchestration.py"
+)
 
 
 class TestRunOrchestrationCLI:
@@ -19,14 +24,17 @@ class TestRunOrchestrationCLI:
         explicit PYTHONPATH.
         """
         result = subprocess.run(
-            [sys.executable, "-c",
-             f"import importlib.util; "
-             f"spec = importlib.util.spec_from_file_location('run_orch', r'{CLI_SCRIPT}'); "
-             f"mod = importlib.util.module_from_spec(spec); "
-             f"import sys; "
-             f"project_root = r'{CLI_SCRIPT.parent}'; "
-             f"script_dir = r'{CLI_SCRIPT.parent}'; "
-             f"print(str(script_dir) in sys.path or True);"],
+            [
+                sys.executable,
+                "-c",
+                f"import importlib.util; "
+                f"spec = importlib.util.spec_from_file_location('run_orch', r'{CLI_SCRIPT}'); "
+                f"mod = importlib.util.module_from_spec(spec); "
+                f"import sys; "
+                f"project_root = r'{CLI_SCRIPT.parent}'; "
+                f"script_dir = r'{CLI_SCRIPT.parent}'; "
+                f"print(str(script_dir) in sys.path or True);",
+            ],
             capture_output=True,
             text=True,
             timeout=30,
@@ -157,7 +165,15 @@ class TestCoherentThreeStateRunOrchestration:
 
         # Hypothesis with NO 'coherent' key — the arming input.
         fake_result = InvestigationResult(
-            trace=[{"step": 1, "phase": "x", "agent": "A", "findings": {}, "conclusion": "c"}],
+            trace=[
+                {
+                    "step": 1,
+                    "phase": "x",
+                    "agent": "A",
+                    "findings": {},
+                    "conclusion": "c",
+                }
+            ],
             reasoning_chain=["c"],
             agents_used=["A"],
             agent_count=1,
@@ -173,6 +189,9 @@ class TestCoherentThreeStateRunOrchestration:
         )
         # Avoid JVM / heavy env setup.
         monkeypatch.setattr(ro, "setup_environment", AsyncMock(return_value=None))
+        # #1794: main() loads the CLI .env — in-test that call would seed the
+        # real (nested) provider key into the process env.
+        monkeypatch.setattr(ro, "load_dotenv", lambda *a, **k: True)
 
         monkeypatch.setattr(
             sys,

--- a/tests/unit/argumentation_analysis/utils/dev_tools/test_env_checks.py
+++ b/tests/unit/argumentation_analysis/utils/dev_tools/test_env_checks.py
@@ -98,7 +98,7 @@ class TestRunCommand:
 class TestCheckJavaEnvironment:
     @patch("argumentation_analysis.utils.dev_tools.env_checks._run_command")
     @patch.dict(
-        "os.environ",
+        "argumentation_analysis.utils.dev_tools.env_checks.os.environ",
         {"JAVA_HOME": "/fake/java"},
         clear=True,
     )
@@ -121,7 +121,9 @@ class TestCheckJavaEnvironment:
         assert result is True
 
     @patch("argumentation_analysis.utils.dev_tools.env_checks._run_command")
-    @patch.dict("os.environ", clear=True)
+    @patch.dict(
+        "argumentation_analysis.utils.dev_tools.env_checks.os.environ", clear=True
+    )
     def test_no_java_home_java_works(self, mock_run):
         # No JAVA_HOME but java -version works
         mock_run.return_value = (0, "", "java version 11")
@@ -130,7 +132,9 @@ class TestCheckJavaEnvironment:
         assert result is False
 
     @patch("argumentation_analysis.utils.dev_tools.env_checks._run_command")
-    @patch.dict("os.environ", clear=True)
+    @patch.dict(
+        "argumentation_analysis.utils.dev_tools.env_checks.os.environ", clear=True
+    )
     def test_no_java_at_all(self, mock_run):
         mock_run.return_value = (-1, "", "FileNotFoundError: java")
         result = check_java_environment()
@@ -138,7 +142,7 @@ class TestCheckJavaEnvironment:
 
     @patch("argumentation_analysis.utils.dev_tools.env_checks._run_command")
     @patch.dict(
-        "os.environ",
+        "argumentation_analysis.utils.dev_tools.env_checks.os.environ",
         {"JAVA_HOME": "/fake"},
         clear=True,
     )
@@ -153,7 +157,7 @@ class TestCheckJavaEnvironment:
 
     @patch("argumentation_analysis.utils.dev_tools.env_checks._run_command")
     @patch.dict(
-        "os.environ",
+        "argumentation_analysis.utils.dev_tools.env_checks.os.environ",
         {"JAVA_HOME": "/fake/java"},
         clear=True,
     )

--- a/tests/unit/argumentation_analysis/utils/dev_tools/test_env_checks.py
+++ b/tests/unit/argumentation_analysis/utils/dev_tools/test_env_checks.py
@@ -97,9 +97,10 @@ class TestRunCommand:
 
 class TestCheckJavaEnvironment:
     @patch("argumentation_analysis.utils.dev_tools.env_checks._run_command")
-    @patch(
-        "argumentation_analysis.utils.dev_tools.env_checks.os.environ",
+    @patch.dict(
+        "os.environ",
         {"JAVA_HOME": "/fake/java"},
+        clear=True,
     )
     @patch("argumentation_analysis.utils.dev_tools.env_checks._PathInternal")
     def test_java_home_valid_and_java_works(self, mock_path_cls, mock_run):
@@ -120,7 +121,7 @@ class TestCheckJavaEnvironment:
         assert result is True
 
     @patch("argumentation_analysis.utils.dev_tools.env_checks._run_command")
-    @patch("argumentation_analysis.utils.dev_tools.env_checks.os.environ", {})
+    @patch.dict("os.environ", clear=True)
     def test_no_java_home_java_works(self, mock_run):
         # No JAVA_HOME but java -version works
         mock_run.return_value = (0, "", "java version 11")
@@ -129,16 +130,17 @@ class TestCheckJavaEnvironment:
         assert result is False
 
     @patch("argumentation_analysis.utils.dev_tools.env_checks._run_command")
-    @patch("argumentation_analysis.utils.dev_tools.env_checks.os.environ", {})
+    @patch.dict("os.environ", clear=True)
     def test_no_java_at_all(self, mock_run):
         mock_run.return_value = (-1, "", "FileNotFoundError: java")
         result = check_java_environment()
         assert result is False
 
     @patch("argumentation_analysis.utils.dev_tools.env_checks._run_command")
-    @patch(
-        "argumentation_analysis.utils.dev_tools.env_checks.os.environ",
+    @patch.dict(
+        "os.environ",
         {"JAVA_HOME": "/fake"},
+        clear=True,
     )
     @patch("argumentation_analysis.utils.dev_tools.env_checks._PathInternal")
     def test_java_home_not_a_dir(self, mock_path_cls, mock_run):
@@ -150,9 +152,10 @@ class TestCheckJavaEnvironment:
         assert result is False
 
     @patch("argumentation_analysis.utils.dev_tools.env_checks._run_command")
-    @patch(
-        "argumentation_analysis.utils.dev_tools.env_checks.os.environ",
+    @patch.dict(
+        "os.environ",
         {"JAVA_HOME": "/fake/java"},
+        clear=True,
     )
     @patch("argumentation_analysis.utils.dev_tools.env_checks._PathInternal")
     def test_java_version_returns_no_output(self, mock_path_cls, mock_run):

--- a/tests/unit/project_core/managers/test_dotenv_loading.py
+++ b/tests/unit/project_core/managers/test_dotenv_loading.py
@@ -5,6 +5,7 @@ Verifies:
   - divergence WARNING is emitted when a secondary .env carries a different key
   - no WARNING when secondary .env has the same key as root
 """
+
 import logging
 import os
 from pathlib import Path
@@ -40,16 +41,20 @@ class TestDotenvLoadingDeterministic:
         with patch.object(_em_mod, "_find_repo_root", return_value=tmp_path):
             EnvironmentManager()
 
-        assert os.environ.get("OPENAI_API_KEY") == "sk-root-VALID", (
-            "Root .env should have overridden the stale value via override=True"
-        )
+        assert (
+            os.environ.get("OPENAI_API_KEY") == "sk-root-VALID"
+        ), "Root .env should have overridden the stale value via override=True"
 
     def test_dotenv_path_points_to_root_env(self, tmp_path: Path) -> None:
         """dotenv_path attribute must reflect the root .env location."""
         root_env = tmp_path / ".env"
         root_env.write_text("DUMMY=1\n", encoding="utf-8")
 
-        with patch.object(_em_mod, "_find_repo_root", return_value=tmp_path):
+        # #1794: EnvironmentManager's load_dotenv(override=True) writes the real
+        # os.environ — sandbox it so the fixture key cannot leak into the session.
+        with patch.dict("os.environ", {}, clear=True), patch.object(
+            _em_mod, "_find_repo_root", return_value=tmp_path
+        ):
             mgr = EnvironmentManager()
 
         assert mgr.dotenv_path == str(root_env)
@@ -70,16 +75,18 @@ class TestDotenvDivergenceWarning:
         secondary_dir.mkdir()
         _write_env(secondary_dir / ".env", "OPENAI_API_KEY", "sk-dead-ZZZZ")
 
-        with patch.object(_em_mod, "_find_repo_root", return_value=tmp_path), \
-             patch.object(_em_mod, "_SECONDARY_ENV_RELPATHS", ["argumentation_analysis/.env"]):
+        with patch.dict("os.environ", {}, clear=True), patch.object(
+            _em_mod, "_find_repo_root", return_value=tmp_path
+        ), patch.object(
+            _em_mod, "_SECONDARY_ENV_RELPATHS", ["argumentation_analysis/.env"]
+        ):
             with caplog.at_level(
                 logging.WARNING, logger="project_core.managers.environment_manager"
             ):
                 EnvironmentManager()
 
         assert any(
-            "divergence" in record.message
-            for record in caplog.records
+            "divergence" in record.message for record in caplog.records
         ), "Expected a WARNING containing 'divergence' for mismatched keys"
 
     def test_no_warning_when_keys_identical(
@@ -93,16 +100,18 @@ class TestDotenvDivergenceWarning:
         secondary_dir.mkdir()
         _write_env(secondary_dir / ".env", "OPENAI_API_KEY", "sk-same-BBBB")
 
-        with patch.object(_em_mod, "_find_repo_root", return_value=tmp_path), \
-             patch.object(_em_mod, "_SECONDARY_ENV_RELPATHS", ["argumentation_analysis/.env"]):
+        with patch.dict("os.environ", {}, clear=True), patch.object(
+            _em_mod, "_find_repo_root", return_value=tmp_path
+        ), patch.object(
+            _em_mod, "_SECONDARY_ENV_RELPATHS", ["argumentation_analysis/.env"]
+        ):
             with caplog.at_level(
                 logging.WARNING, logger="project_core.managers.environment_manager"
             ):
                 EnvironmentManager()
 
         assert not any(
-            "divergence" in record.message
-            for record in caplog.records
+            "divergence" in record.message for record in caplog.records
         ), "No WARNING should be emitted when secondary key matches root"
 
     def test_warning_masks_key_values(
@@ -116,16 +125,23 @@ class TestDotenvDivergenceWarning:
         secondary_dir.mkdir()
         _write_env(secondary_dir / ".env", "OPENAI_API_KEY", "sk-proj-LONGSECONDARY9")
 
-        with patch.object(_em_mod, "_find_repo_root", return_value=tmp_path), \
-             patch.object(_em_mod, "_SECONDARY_ENV_RELPATHS", ["argumentation_analysis/.env"]):
+        with patch.dict("os.environ", {}, clear=True), patch.object(
+            _em_mod, "_find_repo_root", return_value=tmp_path
+        ), patch.object(
+            _em_mod, "_SECONDARY_ENV_RELPATHS", ["argumentation_analysis/.env"]
+        ):
             with caplog.at_level(
                 logging.WARNING, logger="project_core.managers.environment_manager"
             ):
                 EnvironmentManager()
 
         for record in caplog.records:
-            assert "LONGROOT12345" not in record.message, "Full root key must not appear in log"
-            assert "LONGSECONDARY9" not in record.message, "Full secondary key must not appear in log"
+            assert (
+                "LONGROOT12345" not in record.message
+            ), "Full root key must not appear in log"
+            assert (
+                "LONGSECONDARY9" not in record.message
+            ), "Full secondary key must not appear in log"
 
     def test_no_warning_when_secondary_absent(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture
@@ -134,14 +150,16 @@ class TestDotenvDivergenceWarning:
         root_env = tmp_path / ".env"
         _write_env(root_env, "OPENAI_API_KEY", "sk-root-CCCC")
 
-        with patch.object(_em_mod, "_find_repo_root", return_value=tmp_path), \
-             patch.object(_em_mod, "_SECONDARY_ENV_RELPATHS", ["argumentation_analysis/.env"]):
+        with patch.dict("os.environ", {}, clear=True), patch.object(
+            _em_mod, "_find_repo_root", return_value=tmp_path
+        ), patch.object(
+            _em_mod, "_SECONDARY_ENV_RELPATHS", ["argumentation_analysis/.env"]
+        ):
             with caplog.at_level(
                 logging.WARNING, logger="project_core.managers.environment_manager"
             ):
                 EnvironmentManager()
 
         assert not any(
-            "divergence" in record.message
-            for record in caplog.records
+            "divergence" in record.message for record in caplog.records
         ), "No WARNING when there is no secondary .env to diverge from"

--- a/tests/unit/test_1794_env_premise_guard.py
+++ b/tests/unit/test_1794_env_premise_guard.py
@@ -12,19 +12,16 @@ Measured by trap + identity probe in the same run: POST fired with
 Two guards:
 - source guard: the identity-swap motif is banned from the gate tree
   (it was red before the fix — 9 sites);
-- execution guard: after a predecessor enters AND EXITS a rebind (the
-  historical polluter, simulated here forever), the pl_2pass no-key scenario
-  emits zero watched-LLM request, observed by the #1787 counter.
+- execution guard: one deliberate swap must ENTER AND EXIT with the process
+  env object restored (identity, type, keys). The no-key-scenario variant
+  was removed: it measured the ambient mid-window writer (#1794 follow-up,
+  named by the os._Environ.__setitem__ tracer), not the swap mechanism —
+  it stayed red after the swap fix and conflated the two defects.
 """
 
-import asyncio
 import re
 from pathlib import Path
 from unittest.mock import patch
-
-import pytest
-
-import tests.llm_egress_counter as egress_module
 
 _TESTS_ROOT = Path(__file__).resolve().parents[1]
 
@@ -70,65 +67,24 @@ def test_no_os_environ_identity_swap_in_gate_tree():
     )
 
 
-def test_no_api_key_scenario_emits_nothing_after_a_rebind_roundtrip():
-    """Execution guard: a predecessor that entered and exited an os.environ
-    rebind (the historical polluter shape) must leave the no-key premise
-    enforceable — the #1787 counter must attribute zero watched-LLM request
-    to the pl_2pass no-key scenario run right after it."""
-    counter = egress_module.get_counter()
-    if counter is None:  # pragma: no cover - counter not active in this session
-        pytest.skip("LLM egress counter not active")
-
-    # The polluter's shape, kept on purpose: swap the process env, then let
-    # mock restore it. A leaking exit would leave os.environ a plain dict and
-    # the scenario below would fire (measured in the trap run of #1794).
-    sentinel = {"OPENROUTER_API_KEY": "sk-leak-should-not-survive-the-exit"}
-    with patch("os.environ", sentinel):
-        assert os_env_get("OPENROUTER_API_KEY") == "sk-leak-should-not-survive-the-exit"
-    assert (
-        os_env_get("OPENROUTER_API_KEY") != "sk-leak-should-not-survive-the-exit"
-    ), "the rebind outlived its with-block — process env is still the swapped dict"
-
-    from argumentation_analysis.core.shared_state import UnifiedAnalysisState
-    from argumentation_analysis.orchestration.invoke_callables import (
-        _invoke_propositional_logic,
-    )
-
-    state = UnifiedAnalysisState("Test argument for the guard scenario.")
-    ctx = {
-        "_state_object": state,
-        "source_metadata": {"opaque_id": "guard_1794"},
-        "arguments": ["National sovereignty requires immediate action"],
-    }
-
-    before = counter.total()
-    with patch.dict(
-        "os.environ",
-        {"OPENAI_API_KEY": "", "OPENROUTER_API_KEY": "", "OPENROUTER_BASE_URL": ""},
-    ):
-        asyncio.get_event_loop().run_until_complete(
-            _invoke_propositional_logic(state.raw_text, ctx)
-        )
-
-    attributed = [
-        r
-        for r in counter.snapshot()["requests"]
-        if r["test"].endswith(
-            "test_no_api_key_scenario_emits_nothing_after_a_rebind_roundtrip"
-        )
-        and r["class"] == "llm"
-    ]
-    assert not attributed, (
-        "the no-key scenario emitted watched-LLM request(s) after a clean "
-        "rebind roundtrip — the env premise is again decided outside the "
-        f"test: {attributed}"
-    )
-    assert (
-        counter.total() <= before + 1
-    )  # at most the counter's own control, never ours
-
-
-def os_env_get(key):
+def test_rebind_roundtrip_restores_process_environ():
+    """Execution guard: perform the historical polluter shape (one global
+    identity swap via patch) and assert the with-block EXIT restores the
+    process env object — same identity, still an _Environ, and the sentinel
+    key gone. A reintroduced leaking wrapper (swap that outlives its
+    with-block, the #1794 mechanism) fails here with no LLM call and no
+    counter dependency."""
     import os
 
-    return os.environ.get(key)
+    original = os.environ
+    sentinel = {"OPENROUTER_API_KEY": "sk-leak-should-not-survive-the-exit"}
+    with patch("os.environ", sentinel):
+        assert os.environ is sentinel, "patch('os.environ', ...) must swap the object"
+    assert os.environ is original, (
+        "the rebind outlived its with-block — process env is still the "
+        "swapped dict, so a later test's patch.dict window can resolve the "
+        "wrong object and leak provider keys (#1794)"
+    )
+    assert (
+        os.environ.get("OPENROUTER_API_KEY") != sentinel["OPENROUTER_API_KEY"]
+    ), "the sentinel key survived the exit"

--- a/tests/unit/test_1794_env_premise_guard.py
+++ b/tests/unit/test_1794_env_premise_guard.py
@@ -1,0 +1,134 @@
+"""#1794 — guards for the env-premise pollution family.
+
+The gate's two surviving real POSTs (#1591 residual) were caused by tests
+doing ``patch("<any-module>.os.environ", {...})``: mock resolves the module,
+then ``setattr(os, "environ", dict)`` — a GLOBAL identity swap, not a scoped
+one. During the swap window ``os.environ`` is a plain dict: dict writes never
+reach ``putenv`` (the C env block desynchronizes), and a later test's
+``patch.dict`` can resolve the swapped object instead of the process env.
+Measured by trap + identity probe in the same run: POST fired with
+``os.environ`` = ``builtins.dict``.
+
+Two guards:
+- source guard: the identity-swap motif is banned from the gate tree
+  (it was red before the fix — 9 sites);
+- execution guard: after a predecessor enters AND EXITS a rebind (the
+  historical polluter, simulated here forever), the pl_2pass no-key scenario
+  emits zero watched-LLM request, observed by the #1787 counter.
+"""
+
+import asyncio
+import re
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+import tests.llm_egress_counter as egress_module
+
+_TESTS_ROOT = Path(__file__).resolve().parents[1]
+
+# patch("<module>.os.environ", ...), patch("os.environ", ...) and
+# patch.object(os, "environ", ...) all setattr the environ ATTRIBUTE of the
+# os module — a global identity swap. patch.dict(...) mutates the object and
+# is the only legitimate form.
+_SWAP_MOTIF = re.compile(
+    r"patch\(\s*[\"'](?:[\w.]+\.)?os\.environ[\"']"
+    r"|patch\.object\(\s*os\s*,\s*[\"']environ[\"']"
+)
+
+
+def _gate_test_files():
+    files = []
+    for sub in ("unit", "scripts"):
+        files.extend((Path(_TESTS_ROOT) / sub).rglob("*.py"))
+    return sorted(files)
+
+
+def test_no_os_environ_identity_swap_in_gate_tree():
+    """Source guard: patch("<mod>.os.environ", {...}) rebinds the process env
+    globally (#1794) — mutation via patch.dict(..., clear=True) is the only
+    legitimate form. Fails on any reintroduction of the swap motif."""
+    offenders = []
+    for f in _gate_test_files():
+        if f.name == Path(__file__).name:
+            # this guard deliberately performs one round-trip swap (execution
+            # guard below) — it asserts the restoration itself.
+            continue
+        try:
+            src = f.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        for i, line in enumerate(src.splitlines(), start=1):
+            if _SWAP_MOTIF.search(line):
+                offenders.append(f"{f.relative_to(_TESTS_ROOT)}:{i}: {line.strip()}")
+    assert not offenders, (
+        "os.environ identity-swap patch(es) found — these rebind the process "
+        "env globally and leak provider keys into other tests' premises "
+        "(#1794). Convert to patch.dict('os.environ', {...}, clear=True):\n"
+        + "\n".join(offenders)
+    )
+
+
+def test_no_api_key_scenario_emits_nothing_after_a_rebind_roundtrip():
+    """Execution guard: a predecessor that entered and exited an os.environ
+    rebind (the historical polluter shape) must leave the no-key premise
+    enforceable — the #1787 counter must attribute zero watched-LLM request
+    to the pl_2pass no-key scenario run right after it."""
+    counter = egress_module.get_counter()
+    if counter is None:  # pragma: no cover - counter not active in this session
+        pytest.skip("LLM egress counter not active")
+
+    # The polluter's shape, kept on purpose: swap the process env, then let
+    # mock restore it. A leaking exit would leave os.environ a plain dict and
+    # the scenario below would fire (measured in the trap run of #1794).
+    sentinel = {"OPENROUTER_API_KEY": "sk-leak-should-not-survive-the-exit"}
+    with patch("os.environ", sentinel):
+        assert os_env_get("OPENROUTER_API_KEY") == "sk-leak-should-not-survive-the-exit"
+    assert (
+        os_env_get("OPENROUTER_API_KEY") != "sk-leak-should-not-survive-the-exit"
+    ), "the rebind outlived its with-block — process env is still the swapped dict"
+
+    from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+    from argumentation_analysis.orchestration.invoke_callables import (
+        _invoke_propositional_logic,
+    )
+
+    state = UnifiedAnalysisState("Test argument for the guard scenario.")
+    ctx = {
+        "_state_object": state,
+        "source_metadata": {"opaque_id": "guard_1794"},
+        "arguments": ["National sovereignty requires immediate action"],
+    }
+
+    before = counter.total()
+    with patch.dict(
+        "os.environ",
+        {"OPENAI_API_KEY": "", "OPENROUTER_API_KEY": "", "OPENROUTER_BASE_URL": ""},
+    ):
+        asyncio.get_event_loop().run_until_complete(
+            _invoke_propositional_logic(state.raw_text, ctx)
+        )
+
+    attributed = [
+        r
+        for r in counter.snapshot()["requests"]
+        if r["test"].endswith(
+            "test_no_api_key_scenario_emits_nothing_after_a_rebind_roundtrip"
+        )
+        and r["class"] == "llm"
+    ]
+    assert not attributed, (
+        "the no-key scenario emitted watched-LLM request(s) after a clean "
+        "rebind roundtrip — the env premise is again decided outside the "
+        f"test: {attributed}"
+    )
+    assert (
+        counter.total() <= before + 1
+    )  # at most the counter's own control, never ours
+
+
+def os_env_get(key):
+    import os
+
+    return os.environ.get(key)


### PR DESCRIPTION
## Update (round 2) — the loader behind the surviving POSTs is named and closed; both CI reds fixed; local subtree gate `llm=0`, probe silent

Three ambient loaders have now been named and removed, one per instrumentation round. The last one is the direct cause of the surviving pl_2pass POSTs.

### The loader chain, in discovery order

| # | loader | named by | removed by |
|---|---|---|---|
| 1 | `invoke_callables.py` module-level `load_dotenv()` (loaded at pytest COLLECTION from any test-module import) | round-1 trap/probe | round 1 (this PR's first commit) |
| 2 | `run_multi_model_benchmark` body `load_dotenv()` (`:318`) — seeded the nested key mid-suite | round-2 gate4 putenv-tracer stack | moved to `main()` |
| 3 | **`run_orchestration.py:60` module-level `load_dotenv()`** — imported by 10+ test files, the FIRST root-level test file (`test_cluedo_mode_dispatch.py:71`) runs before `test_fol/pl_2pass_pipeline.py` in collection order | round-2 gate8 `_Environ.__setitem__` tracer stack | moved into `main()` (this update) |

Why #3 is the POST loader: `run_orchestration.py` lives inside `argumentation_analysis/`, so its `load_dotenv()` (no explicit path → `find_dotenv()` walks up) resolves the **nested** `argumentation_analysis/.env` (June 2025) — seeding the real provider key mid-suite. Proof chain, all measured this round:

1. **Subtree-only gate** (probe at the premise-decision point in `_translate_with_llm`): `llm=4` — exactly 2× `test_fallback_when_no_api_key` + 2× `test_no_state_object_graceful`, every probe line reading the nested `.env` key pair.
2. **Collection alone seeds nothing** (in-process `--collect-only`, env read before/after: empty).
3. **Per-directory bisection** (one process, env printed after each dir): every subdirectory clean in isolation — the seed is a cross-effect living in the **root-level test files** that directory bisection never covers.
4. **Gate8 tracer**: first `sk-proj` write carries the stack `test_cluedo_mode_dispatch.py:71 → run_orchestration.py:60 → load_dotenv() → SET OPENAI_API_KEY=sk-proj… + SET OPENROUTER_API_KEY=sk-or…` — the exact key pair the probe saw at every POST.
5. Why the round-1 tracer missed it: `:318` seeded the same key EARLIER in the session, and `load_dotenv(override=False)` **silently skips keys already present** — loader #3's writes never existed in that trace. A tracer can only name the FIRST loader; each removal reveals the next.
6. Fix: `load_dotenv()` moved into `main()` — the CLI still loads before any LLM use; the import no longer mutates the process env. Verified: bare import leaves the env empty; `main()` contains the load; the 12 cluedo+run_orchestration tests pass.
7. **Post-fix subtree gate**: `llm=0`, probe silent — not a single key read at any premise-decision point. The 4 surviving pl_2pass POSTs are dead. (One extra trap found on the way: simply moving the load into `main()` is not enough — **3 tests drive `main()` directly** and re-seeded via the entry point; they now patch `run_orchestration.load_dotenv`. Gate9→10b proves it: same code fix, llm 4→0 once the callers were patched.)

### Other changes this round

| change | sites | why |
|---|---|---|
| `test_env_checks.py` windows qualified: `patch.dict("argumentation_analysis.utils.dev_tools.env_checks.os.environ", ..., clear=True)` | 5 | in a full session **two copies of the `os` module coexist** (measured: `id(os.environ)` read inside the test ≠ id seen by the tracer). A window opened on the test's `os` doesn't hold on the copy `check_java_environment` reads — the CI red. The qualified form pins the object the module under test imports. **Green in the full local gate.** |
| guard redesigned → `test_rebind_roundtrip_restores_process_environ` | 1 | one deliberate swap, ENTER+EXIT restoration asserted (identity, `_Environ` type, sentinel gone). 0 LLM calls, 0 counter dependency. The old no-key variant was self-poisoned (it measured the ambient writer, not the swap mechanism) — and it is what kept the ambient-writer hunt alive. |
| `test_analysis_services.py`: `test_initialize_services_jvm_disabled` + `test_initialize_services_libs_dir_is_none` now take `mock_load_dotenv`/`mock_find_dotenv` | 2 signatures | they were the only 2 of the file's 8 tests calling `initialize_analysis_services()` without the mock fixtures → real `load_dotenv(find_dotenv())` resolving the nested `.env` (`analysis_services.py:32`, a library-side writer that remains — see follow-ups). Directory re-tested alone: env stays empty. |
| `clear=True` on the two no-key windows in `test_pl_2pass_pipeline.py` | 2 | without `clear`, an ambient key (CI secret or nested-`.env` leak) survives the window and the no-key premise never holds |

### Honest egress accounting

- Gate7 (all fixes except the `run_orchestration` one): `llm=8` = 4 non-vacuity controls + the 4 pl_2pass POSTs (probe: nested key at every decision point). **Criterion `llm=4` NOT met by that state.**
- Post-fix subtree gate: `llm=0`, probe silent (gate10b, after also patching the 3 tests that drive `main()` — see the trap note above). The CI number will come from this PR's own run (in CI the same ambient slot is filled by runner secrets — the nested `.env` doesn't exist there; the loader removal plus `clear=True` windows are what the CI criterion exercises).
- Gate health: **0 new failures** across gates 5/6/7 vs the known flaky families (63 failed stable, byte-identical lists gate5 vs gate7).

### Known residuals (documented, not fixed here)

- **Two `os` module copies in a full session** (reload/duplication, trigger unidentified — measured via divergent `id(os.environ)`; the qualified patch form is robust to it). Handed to the issue.
- `analysis_services.py:32` still calls `load_dotenv(find_dotenv())` in a **library** function (caller `analysis_pipeline.py:236` is not a process entry point). Left as runtime behavior — follow-up for arbitration: the #1794 principle says env loading belongs to entry points only. `config/.env` carries the **same** key as the nested `.env` (two machine-local reservoirs).
- `evaluation/test_evaluation_module.py:88` writes `os.environ["OPENAI_API_KEY"]` directly (seeds `'my-key'` across tests — no POST, real test→test pollution). Filed for follow-up.
- `test_speech_transcription_service.py::TestServiceConfig::test_env_url`: green isolated, red subtree-only (order, `WHISPER_API_URL`) — #1794-family victim.
- The nested `argumentation_analysis/.env` itself is user-owned machine hygiene, per the issue's scope note.

---

## What (round 1 record)

Names and removes the first two defects in the env-premise family — the `os.environ` identity swaps and the import-time env load — and guards against their reintroduction.

### 1. The mechanism, printed not reasoned (per the issue's instruction)

Two instruments in the same full-gate run (CI-shaped env, root `.env` parked out of tree):

- **Identity trap** (module-class property on `os`, logging every `os.environ = X` assignment with its stack): **9 assignments, all `builtins.dict`, none from production code**. Every stack ends in `unittest/mock.py:1556 __enter__ setattr` and names a test doing:

```python
patch("<some.module>.os.environ", {...})
```

  mock resolves `<some.module>.os` → **the os module itself**, then `setattr(os, "environ", dict)` — a **global identity swap**, not a scoped patch. The 9 sites: `test_parent_harness_578.py` ×4 (lines 229/300/363/432) and `test_env_checks.py` ×5.

- **Identity probe at send-entry** (id/type of `os.environ` + the 3 provider keys read through `os.environ.get` vs `._data` vs `GetEnvironmentVariableW`, in the same run): the watched POSTs fired with **`os.environ` = `builtins.dict`** — the producer read provider keys that exist only in the swapped dict, while the C env block (`GetEnvironmentVariableW`) had **no such keys** (dict writes never reach `putenv`). This is why every prior write-tracer saw "no writes": the polluter never *wrote* keys, it *replaced the object*.

Both instruments: scratchpad only, not committed (the trap is invasive — 65 induced failures in its run; measurement claims come from its assignment log, the final gate number from a clean instrument-free run).

### 2. The fix (round 1)

| change | sites |
|---|---|
| `patch("<mod>.os.environ", {...})` → `patch.dict("os.environ", {...}, clear=True)` | 9 (4 in `test_parent_harness_578.py`, 5 in `test_env_checks.py` — the latter further qualified in round 2) |
| module-level `load_dotenv()` removed from `invoke_callables.py` | 1 |
| `api/main.py` now loads `.env` explicitly (sole entry point inheriting from the transitive load; `run_orchestration.py` already did; `interface_web/app.py` is a pure proxy) | 1 |

`patch.dict(..., clear=True)` keeps the exact original semantics while mutating the process env object — never rebinding it. `@patch(target, new)` injects no mock argument and neither does `patch.dict`, so test signatures are unchanged. Both files: **40/40 green** after conversion.

### 3. Guards (`tests/unit/test_1794_env_premise_guard.py`)

- **Source guard**: the identity-swap motif (`patch("<mod>.os.environ", ...)`, `patch("os.environ", ...)`, `patch.object(os, "environ", ...)`) is banned from `tests/unit/` + `tests/scripts/`. **Red before the fix (9 offenders), green after** — substitution control run: the regex matches all 3 historical shapes and spares `patch.dict`.
- **Execution guard** (round 2): `test_rebind_roundtrip_restores_process_environ` — one deliberate swap entered **and exited**, restoration asserted. No LLM call, no counter dependency.

### Ambient loader chain (round 1 record — extended by the table above)

`tests/conftest.py` calls `ensure_env()` → `EnvironmentManager` → root `.env` with `override=True`; **when no root `.env` exists it falls back to `find_dotenv()`** which can load the nested `argumentation_analysis/.env` — per-machine topology again. In CI the same ambient slot is filled by the runner's provisioned secrets. (With the root parked this round, `ensure_env` logged "Aucun fichier .env trouvé" — inert in this configuration.)

### Notes / follow-ups (out of scope here)

- `analysis_services.py:32` `load_dotenv(find_dotenv())` in a library function — arbitration follow-up.
- ~30 `scripts/*.py` CLI tools import invoke callables without loading `.env` themselves; they degrade via the documented heuristic fallback. Separate ticket.
- The `example.com` specificity control remains the only `unknown`-class request — by design.
- The nested `argumentation_analysis/.env` + `config/.env` (same key) are user-owned machine hygiene, per the issue's scope note.

Refs #1794 · #1591 · #1787 · PR #1793

🤖 Generated with [Claude Code](https://claude.com/claude-code)
