### PR TITLE
fix(env): pin openai==3.3.0 — a floor is not a version (#1794)

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -74,6 +74,7 @@ dependencies:
   - pip:
     - textstat  # FB-23 #1088: readability (Flesch) for the quality-radar clarte detector
     - semantic-kernel>=1.33.0
+    - openai==3.3.0  # Pinned. semantic-kernel declares only a floor (openai>=2.0.0), so every fresh env resolved whatever PyPI served that day. Measured 2026-08-19: CI resolved openai 3.3.0 while dev envs built months earlier sat on 2.26.0 — and openai>=3.x moved its transport from httpx to httpx2. That gap is precisely why a CI-only failure like #1794 cannot be reproduced on a dev box: the two sides do not run the same client. 3.3.0 is the version the gate actually exercises (run 32195821578, green). Same drift class as python-sat below: a floor is not a version.
     - flask_socketio>=5.3.6
     - playwright
     - pytest-playwright


### PR DESCRIPTION
User-approved (R829). Refs #1794.

## The measurement

Nothing in this repo ever chose an openai version. `semantic-kernel` declares `openai>=2.0.0` — a floor with no ceiling — so every environment resolved whatever PyPI served on its creation day. CI builds a fresh env each run; dev boxes do not.

Measured 2026-08-19, CI run `32195821578` versus a dev box:

| package | dev box | CI |
|---|---|---|
| **openai** | 2.26.0 | **3.3.0** |
| semantic-kernel | 1.40.0 | 1.44.1 |
| mcp | 1.26.0 | 2.0.0 |
| pydantic | 2.11.10 | 2.13.4 |
| httpx | 0.28.1 | 0.28.1 *(identical)* |
| httpx2 | absent | 2.12.0 *(pulled by `mcp>=2.0`)* |

The openai row is the one with consequences: **3.x moved its transport from `httpx` to `httpx2`**. So a dev box cannot reproduce a CI-only failure such as #1794 — the two sides are not running the same client, and no amount of local probing closes that gap.

## Why 3.3.0 and not 2.26.0

The purpose is to let a dev box reproduce CI, not the reverse. 3.3.0 is also the version the gate actually exercises today (green on the full unit band). Pinning to the older dev version would push CI onto a client it has never run.

Caveat stated plainly: **neither version is validated against the real API by the gate**, because the tests that would exercise the client are exactly the ones the gate excludes (`-m "not slow and not requires_api"`). That is #1592/#1603's territory, not this PR's. This PR removes the drift; it does not claim the API path is covered.

Dev environments converge on their next rebuild. Until then they stay on 2.26.0 — this prevents future drift, it does not retroactively fix existing envs.

## Related findings, deliberately NOT acted on here

Reported so they are not lost, each out of this PR's scope:

1. **`environment.yml` has 57 dependencies with no version at all**, 10 floors, and exactly one exact pin (`python-sat==1.9.dev7` — added under duress after two separate CI deaths, and the comment there already names this drift class).
2. **`conda-lock.yml` is tracked but dead.** Last touched 2025-07-18; it pins openai 1.91.0, semantic-kernel 1.33.0, mcp 1.9.4 — incompatible with the current `mcp>=2.0`. And CI does not use it: `ci.yml:30` and `:70` both say `environment-file: environment.yml`. It gives the impression the repo is locked when it is not.
3. **`black>=23.0.0` drifts the same way** — dev 26.1.0 vs CI 26.5.1, and the two disagree on how to wrap `assert cond, message`. A worker can be told "black is clean" locally and have CI disagree. Same one-line fix if wanted.

## Verification

The CI run of this PR is the test: `Setup Miniconda` fails outright if the pinned set no longer solves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)