### PR TITLE
test(ci): name the 10 green out-of-argv dirs in the gate (#1783)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           TEXT_CONFIG_PASSPHRASE: ${{ secrets.TEXT_CONFIG_PASSPHRASE }}
         run: |
-          conda run -n projet-is --no-capture-output pytest tests/unit/ tests/scripts/ -m "not slow and not requires_api" --junitxml=pytest_report.xml -v --timeout=900 --timeout-method=thread
+          conda run -n projet-is --no-capture-output pytest tests/unit/ tests/scripts/ tests/orchestration/ tests/ui/ tests/utils/ tests/golden/ tests/core/ tests/config/ tests/property/ tests/argumentation_analysis/ tests/project_core/ tests/functional/ -m "not slow and not requires_api" --junitxml=pytest_report.xml -v --timeout=900 --timeout-method=thread
 
       - name: Generate test summary
         if: always()


### PR DESCRIPTION
## What

Widen the CI pytest argv (`ci.yml:140`) from `tests/unit/ tests/scripts/` to also name the **10 top-level test directories that measure green** on the current head, closing the first slice of the #1783 coverage gap (the "entrants" half of the R830 split — isolation inside `tests/integration/` stays with #1804).

Directories added (counts measured on `b0804a4b`, selection identical to CI `-m "not slow and not requires_api"`):

| Dir | Passed | Wall |
|---|---|---|
| `tests/orchestration/` | 59 | 26 s |
| `tests/ui/` | 45 | 1 s |
| `tests/utils/` | 30 | 2 s |
| `tests/golden/` | 29 | 0.4 s |
| `tests/core/` | 23 | 0.4 s |
| `tests/config/` | 12 | 11 s |
| `tests/property/` | 11 | 14 s |
| `tests/argumentation_analysis/` | 8 | 2 s |
| `tests/project_core/` | 8 | 2 s |
| `tests/functional/` | 1 | 2 s |
| **Total** | **226** | **60 s combined, 0 failed** |

## The control that decides — collection delta

Per the R830 dispatch, the deliverable's proof is the **delta of collection**, not a green run (a green CI on an argv that names nothing new is indistinguishable from the old one):

```
pytest tests/unit/ tests/scripts/                        -m "..." --collect-only → 14601 collected
pytest tests/unit/ tests/scripts/ + <10 dirs>            -m "..." --collect-only → 14827 collected
```

**Δ = +226** — exactly the 226 tests measured passing above, no more, no less. (+10 additionally deselected by the `slow` marker filter, matching the 10 `deselected` seen in the execution run.)

## Why 10 dirs and not the "7" announced

The R832 dashboard report said "7 dirs, ~134 tests" — that count was wrong (it also claimed `orchestration` was "59 skipped / 0 run" while the sweep log says **59 passed**). The sweep logs are the authority: 10 top-level directories measured 0-failed with tests actually executing. All 10 enter; nothing red enters, so the "silent hole → broken gate" conversion the anti-pendule warned about cannot happen from this diff.

## What deliberately does NOT enter

- `tests/integration/` (any subdir, including the green `workers/`, 17 passed): subject of #1804 — one of its tests is green standalone and red in-sweep; widening into it now would make the gate intermittent, strictly worse than incomplete.
- `tests/e2e/` (playwright/services deps), `tests/performance/`, `tests/soutenance/`, `tests/agents/`: measured red on this head (#1783 re-measure, issuecomment-5337700384).
- 13 directories collecting 0 tests under the CI selection — nothing to enter.
- The ~10 hanging root-level `tests/test_*.py` files (unbounded runtimes, #1783 comment).

## Risk

+226 tests at ~60 s combined wall on a local run; CI impact bounded well under the existing `timeout-minutes: 240` / per-test `--timeout=900`. The one-line diff touches no other step.

Closes the "entrants" deliverable of #1783's R830 dispatch. #1783 stays open (isolation triage, red-cluster fixes, axe C/D).

Refs #1783, #1804.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
