### PR TITLE
fix(tests): stop orphaning shared settings — the #1804 polluter reloads config no more

### DIFF
--- a/tests/integration/argumentation_analysis/agents/core/logic/test_fol_handler_config.py
+++ b/tests/integration/argumentation_analysis/agents/core/logic/test_fol_handler_config.py
@@ -1,6 +1,5 @@
 import pytest
 import os
-import importlib
 from unittest.mock import patch, MagicMock
 
 # Importer le module config pour pouvoir le recharger
@@ -37,9 +36,10 @@ def test_fol_query_solver_dispatch(
     Tests that fol_query correctly dispatches to the right solver based on configuration.
     This replaces the previous separate tests.
     """
-    # Recharger la configuration au cas où
-    importlib.reload(config)
-
+    # NB: pas d'importlib.reload(config) ici — il remplaçait l'objet settings
+    # du module partagé, orphelinant les références figées des tests suivants
+    # (tripwire #1804 : test_invoke_modal_logic_reaches_solver basculait sur
+    # SPASS via les défauts du nouvel objet).
     with patch(
         "argumentation_analysis.agents.core.logic.fol_handler.run_prover9"
     ) as mock_run_prover9, patch.object(
@@ -82,8 +82,6 @@ async def test_fol_consistency_solver_dispatch(
     """
     Tests that fol_check_consistency correctly dispatches to the right solver.
     """
-    importlib.reload(config)
-
     with patch.object(
         FOLHandler, "_fol_check_consistency_with_prover9"
     ) as mock_prover9_impl, patch.object(

--- a/tests/unit/argumentation_analysis/agents/core/logic/test_1804_config_reload_isolation_guard.py
+++ b/tests/unit/argumentation_analysis/agents/core/logic/test_1804_config_reload_isolation_guard.py
@@ -1,0 +1,67 @@
+"""Garde #1804 — la paire minimale, dans l'ordre qui échouait.
+
+`tests/integration/.../test_fol_handler_config.py` exécutait
+``importlib.reload(config)`` sans restauration : le module partagé
+``argumentation_analysis.core.config`` recevait un NOUVEL objet ``settings``
+lors de chaque reload, orphelinant la référence figée que détient
+``test_invoke_modal_logic_reaches_solver`` (import top-level, l.34). La
+victime est le tripwire anti-force-SPASS : sa fixture force
+``modal_solver=TWEETY`` / ``prefer_spass=False`` sur l'objet figé, mais le
+lecteur différé ``invoke_callables.py:7597`` (``from ...config import
+settings`` dans le corps de la fonction) re-résout l'attribut de module à
+chaque appel — il voit donc le nouvel objet et ses défauts
+(``modal_prefer_spass_when_available: bool = True``, config.py:74) : SPASS
+gagne, la victime rougit *uniquement parce qu'un test antérieur a tourné*.
+
+Le garde exécute les deux fichiers réels dans cet ordre, en sous-processus
+(même pattern que ``test_1796_adf_eaf_decide``) : si un ``reload`` non
+restauré est réintroduit dans le pollueur, la paire rougit à nouveau.
+
+Sans le correctif (reload encore présent dans le pollueur) : rc=1, 6 failed.
+Avec le correctif : rc=0.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[6]
+
+POLLUTER = (
+    REPO_ROOT
+    / "tests/integration/argumentation_analysis/agents/core/logic/test_fol_handler_config.py"
+)
+VICTIM = (
+    REPO_ROOT
+    / "tests/integration/argumentation_analysis/agents/core/logic/test_invoke_modal_logic_reaches_solver.py"
+)
+
+
+def test_pair_fol_config_then_invoke_modal_green():
+    for path in (POLLUTER, VICTIM):
+        assert path.exists(), f"pair member missing: {path}"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            str(POLLUTER),
+            str(VICTIM),
+            "-m",
+            "not slow and not requires_api",
+            "-q",
+            "--no-header",
+            "--tb=no",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=300,
+        cwd=str(REPO_ROOT),
+    )
+    tail = (result.stdout + result.stderr)[-600:]
+    assert result.returncode == 0, (
+        "La paire minimale (pollueur puis victime, l'ordre qui échouait en "
+        "sweep) est rouge — un état partagé fuit à nouveau entre ces deux "
+        "fichiers (cf. #1804) :\n" + tail
+    )


### PR DESCRIPTION
## What

Closes the isolation leak of #1804: a test in `tests/integration` was green alone and red mid-sweep, and the leaking state is now named, fixed at the owning layer, and guarded by the ordered minimal pair.

## The minimal pair (DoD 1) — reproduced on demand

```
pytest tests/integration/argumentation_analysis/agents/core/logic/test_fol_handler_config.py \
       tests/integration/argumentation_analysis/agents/core/logic/test_invoke_modal_logic_reaches_solver.py \
       -m "not slow and not requires_api"
→ 6 failed, 4 passed        (polluter first, victim second)
victim file alone           → 6 passed
victim test alone           → 1 passed
```

Bisected from the full chunk (`tests/integration/argumentation_analysis` = 13 failed) down through dir-level and file-level runs; the only predecessor that flips the victim is `test_fol_handler_config.py` (`fp11`, `fp12`, `eprover_real`, `external_provers_wired` all leave it green).

## The leaking state, named (DoD 2)

`importlib.reload(config)` at `test_fol_handler_config.py:41` and `:85` re-executes the shared module `argumentation_analysis.core.config`, which **replaces the `settings` object**. The victim holds a *frozen* reference (`from …config import settings`, module top-level import) and its fixture sets `modal_solver=TWEETY` / `modal_prefer_spass_when_available=False` **on the old object**. The pipeline reads settings through a *deferred* import re-resolved at each call (`invoke_callables.py:7597`), so it sees the **new** object with library defaults — `modal_prefer_spass_when_available: bool = True` (`config.py:74`) — and SPASS wins. The victim is literally the anti-force-SPASS tripwire (its docstring pins that history), so it red-denies for position only.

Same mechanism family as the #1800 identity swaps: a test replaces a shared object instead of writing through it, and every tracer watching "writes" sees nothing.

## Fix at the owning layer (DoD 3)

The reloads are removed from the polluter — they were vestigial (comment: "au cas où"): both tests already patch `fol_handler.settings` directly via `mock_settings`, so reloading the config module bought nothing while orphaning every frozen reference in the process. Not hardened at the victim: making the tripwire robust to a replaced settings object would green it while leaving the leak intact for its neighbors.

## The guard is the ordered pair (DoD 4)

New `tests/unit/argumentation_analysis/agents/core/logic/test_1804_config_reload_isolation_guard.py` runs both real files in the failing order in a subprocess (same pattern as `test_1796_adf_eaf_decide`) and asserts returncode 0. It lives in `tests/unit/` so the **CI band executes it from the merge on** — a reintroduced unrestored `reload(config)` anywhere before the victim reddens this guard.

Proof, measured this round:
- guard on the unmodified tree → **1 failed (13.4 s)** — the pair reddens inside the subprocess
- guard with the fix → **1 passed (13.5 s)**, re-verified after black reformatting (11.9 s)

## Position-dependent population in tests/integration (DoD 5) — measured, not assumed

On `b0804a4b` with this fix:

| Scope | Before fix | After fix |
|---|---|---|
| `logic/` dir alone | 13 failed / 39 passed | **6 failed / 46 passed** |
| full `argumentation_analysis` chunk | 13 failed / 46 passed | **6 failed / 53 passed** |

The 7 recovered tests (6 `invoke_modal` + `mace4_real`) were **all** position-dependent on this single polluter. The 6 remaining reds (`fp11` ×2, `spass_real` ×4) fail **identically alone** (measured: `6 failed` in an isolated two-file run) — deterministic name-pinning family, already triaged in #1783 (issuecomment-5337700384), out of scope here.

Also re-measured for the record: the coordination-skip half of this ticket's premise (`orchestration` 59-skipped at ~03:32) does **not reproduce** in either of this machine's two single-session sweeps on the fresh head (`59 passed` in pass-1 sweep, and again inside the 10-dir combined run for #1805's validation) — that observation sits inside the double-session window acknowledged on #1783.

## Consequence for #1783

With the polluter fixed, the `argumentation_analysis` chunk of `tests/integration` is 6-red — all deterministic, none position-dependent. The `tests/integration` widening prerequisite this ticket held is reduced to the remaining unmeasured/hanging bands catalogued in #1783, no longer to an isolation unknown.

Closes #1804.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
