### PR TITLE
fix(gate): pin the pl_2pass no-key windows to the producer's os copy (#1794)

### DIFF
--- a/tests/unit/argumentation_analysis/test_pl_2pass_pipeline.py
+++ b/tests/unit/argumentation_analysis/test_pl_2pass_pipeline.py
@@ -219,7 +219,23 @@ class TestTwoPassPipeline:
         # bypasses it and the fallback-on-no-key premise never holds: the LLM
         # fires (measured: 1 openrouter.ai request). Clearing the toggle makes
         # the tested premise real; no mock needed.
+        # #1794: the producer (NLToLogicTranslator client build,
+        # services/nl_to_logic.py) can hold a DIFFERENT os module object than
+        # sys.modules["os"] in a full session (measured: divergent id(os.environ)
+        # — same mechanism as test_env_checks). A window on the global
+        # "os.environ" clears only the sys.modules copy; the producer's copy
+        # keeps whatever key it saw (CI: test-written; local repro: ambient) and
+        # the POST still fires. The qualified window pins the object the
+        # producer actually reads.
         with patch.dict(
+            "argumentation_analysis.services.nl_to_logic.os.environ",
+            {
+                "OPENAI_API_KEY": "",
+                "OPENROUTER_API_KEY": "",
+                "OPENROUTER_BASE_URL": "",
+            },
+            clear=True,
+        ), patch.dict(
             "os.environ",
             {
                 "OPENAI_API_KEY": "",
@@ -326,7 +342,18 @@ class TestBackwardCompat:
         # #1794: clear=True — without it the ambient key (CI secret or the nested
         # .env leaked by multi_model_benchmark) survives the window and the
         # no-key premise never holds (measured: real POSTs out of the test).
+        # #1794 (round 3): qualified window on the producer's os binding — the
+        # global window alone does not reach NLToLogicTranslator's os.environ
+        # copy in a full session (see test_fallback_when_no_api_key above).
         with patch.dict(
+            "argumentation_analysis.services.nl_to_logic.os.environ",
+            {
+                "OPENAI_API_KEY": "",
+                "OPENROUTER_API_KEY": "",
+                "OPENROUTER_BASE_URL": "",
+            },
+            clear=True,
+        ), patch.dict(
             "os.environ",
             {
                 "OPENAI_API_KEY": "",


### PR DESCRIPTION
## What

Closes the last 3 residual LLM POSTs measured on merged main (`b0804a4b`, CI run 32217624535, `llm_egress_report.json`): `llm=7` = 4 non-vacuity controls + 3 POSTs from exactly two pl_2pass tests, although their windows hold `clear=True` + empty provider keys.

| test | POSTs | call site |
|---|---|---|
| `TestTwoPassPipeline::test_fallback_when_no_api_key` | 1 | test_pl_2pass_pipeline.py:231 |
| `TestBackwardCompat::test_no_state_object_graceful` | 2 | test_pl_2pass_pipeline.py:338 |

All `POST api.openai.com/v1/chat/completions`; the 1-vs-2 asymmetry is `NLToLogicTranslator(max_retries=2)` (initial + retry).

## Producer path (code elimination, not guesswork)

- Raw-SDK path (`_get_openai_client`, invoke_callables.py:6365-6366) is **unreachable** in these tests: requires `client is not None` (false under an empty key) AND `len(input_text) > 100` (both inputs are <15 chars).
- Every surviving POST comes from the NL fallback: `_invoke_propositional_logic` → `translate_batch` (invoke_callables.py:6546) → translator client build at `services/nl_to_logic.py:361-376`, which reads `os.environ` at call time.

## Why the global window didn't hold — reproduced, then fixed

Reproduction (CI shape, local, `.env` parked, fake ambient key `sk-fake-*`):

| run | shape | pl_2pass POSTs |
|---|---|---|
| repro1 | file alone + ambient key | 0 |
| repro2 | subtree + ambient key | **2 + 2** (matches CI modulo retry variance) |
| repro3 | subtree + ambient key + **this fix** | **0** (mass 2601→2598: exactly the 3 pl_2pass POSTs gone) |

A POST firing under a window that emptied every provider key means the producer reads an `os.environ` object the window does not control — the two-os-copies mechanism already measured for `test_env_checks` in the same session family (divergent `id(os.environ)` in full sessions; a session-size cross-effect, per repro1 vs repro2).

Fix: the same qualified form that closed `test_env_checks` — both windows now ALSO pin `argumentation_analysis.services.nl_to_logic.os.environ` (`clear=True`), the object the producer actually reads. The global window stays (it still clears the C-env for other readers).

Side observation (separate lane, not fixed here): the same local repro shows 2598 more requests from 268 unwindowed ambient-key readers — calm in CI because the CI ambient slot has no valid key (the R827/R828 401s read test-written values, not a runner secret).

`unknown: 1` = `test_counter_ignores_non_llm_host` → `GET example.com/ping` — the counter's specificity control, by design.

## Test plan

- [x] File solo: 19 passed, 0 egress (pre- and post-rebase)
- [x] Subtree CI-shape repro: pl_2pass 2+2 → 0, same 17 known local-only failures before/after
- [ ] CI on this branch reports `llm=4` (controls only)

Refs #1794 · #1787 · #1591

🤖 Generated with [Claude Code](https://claude.com/claude-code)