### PR TITLE
fix(e2e): parents[3] not parent³ — sys.path, interface_web cwd, playwright cwd, demos import

### DIFF
--- a/tests/e2e/demos/demo_service_manager_validated.py
+++ b/tests/e2e/demos/demo_service_manager_validated.py
@@ -9,7 +9,10 @@ import logging
 from pathlib import Path
 
 # Ajouter project_core au path (depuis la racine du projet)
-project_root = Path(__file__).parent.parent.parent
+# parents[3] = repo root (demos -> e2e -> tests -> root). parent³ resolves to
+# <root>/tests, where a tests/project_core package exists but does NOT contain
+# service_manager — the import only survived via the caller's cwd.
+project_root = Path(__file__).resolve().parents[3]
 sys.path.insert(0, str(project_root / "project_core"))
 
 from service_manager import ServiceManager, ServiceConfig, create_default_configs

--- a/tests/e2e/python/test_interface_web_complete.py
+++ b/tests/e2e/python/test_interface_web_complete.py
@@ -30,8 +30,12 @@ else:
     print("Configuration UTF-8 chargee automatiquement")
 
 # Tentative d'import de l'orchestrateur unifié
-project_root = Path(__file__).parent.parent.parent
-sys.path.insert(0, str(project_root))
+# parents[3] = repo root (python -> e2e -> tests -> root). A wrong depth here
+# puts <root>/tests on sys.path[0], shadowing the real `scripts` package with
+# `tests/scripts/` and poisoning sys.modules for the whole session.
+project_root = Path(__file__).resolve().parents[3]
+if str(project_root) not in sys.path:
+    sys.path.insert(0, str(project_root))
 
 try:
     from scripts.apps.webapp.unified_web_orchestrator import UnifiedWebOrchestrator
@@ -48,7 +52,7 @@ def start_flask_server():
     print("Demarrage du serveur Flask sur localhost:3000...")
 
     # Changer vers le répertoire interface_web (à la racine du projet)
-    interface_web_dir = Path(__file__).parent.parent.parent / "interface_web"
+    interface_web_dir = Path(__file__).resolve().parents[3] / "interface_web"
 
     # Lancer le serveur Flask
     process = subprocess.Popen(
@@ -81,7 +85,7 @@ def run_playwright_tests():
     print("Lancement des tests Playwright...")
 
     # Répertoire racine du projet pour exécuter les tests
-    project_root = Path(__file__).parent.parent.parent
+    project_root = Path(__file__).resolve().parents[3]
 
     try:
         result = subprocess.run(

--- a/tests/unit/test_e2e_syspath_depth_guard.py
+++ b/tests/unit/test_e2e_syspath_depth_guard.py
@@ -1,0 +1,74 @@
+"""Garde — la profondeur ``sys.path`` de ``tests/e2e`` ne doit pas retomber sur ``tests/``.
+
+Le fichier ``tests/e2e/python/test_interface_web_complete.py`` fait un
+``sys.path.insert`` au niveau module pour importer l'orchestrateur.
+``Path(__file__).parent.parent.parent`` depuis ``tests/e2e/python/``
+résout **``<root>/tests``**, pas la racine : ``tests/`` se retrouvait en
+``sys.path[0]``, ombrageant le vrai package ``scripts`` par ``tests/scripts/``
+et empoisonnant ``sys.modules`` pour toute la session (le même motif
+cassait ``interface_web_dir`` et le ``cwd`` Playwright, plus
+``tests/e2e/demos/demo_service_manager_validated.py`` où l'import ne
+survivait que par le cwd de l'appelant — ``tests/project_core`` n'a
+jamais contenu ``service_manager``).
+
+Le correctif épingle ``parents[3]`` (= racine du dépôt). Ce garde
+exécute le module réel dans un process vierge et vérifie la géométrie :
+la racine dans le path, ``tests/`` absent de la position 0, et le
+``project_root`` du module égal à la racine.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+E2E_MODULE = REPO_ROOT / "tests/e2e/python/test_interface_web_complete.py"
+
+PROBE = """
+import importlib.util, json, sys
+from pathlib import Path
+spec = importlib.util.spec_from_file_location("e2e_syspath_probe", {module!r})
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+print("RESULT:" + json.dumps({{
+    "project_root": str(mod.project_root),
+    "path0": sys.path[0],
+}}))
+"""
+
+
+def test_e2e_module_puts_repo_root_on_sys_path_not_tests():
+    assert E2E_MODULE.exists(), f"module under guard missing: {E2E_MODULE}"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            PROBE.format(module=str(E2E_MODULE)),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        cwd=str(REPO_ROOT),
+    )
+    payload = next(
+        (line for line in result.stdout.splitlines() if line.startswith("RESULT:")),
+        None,
+    )
+    assert payload is not None, (
+        "probe did not report — module exec failed:\n"
+        + (result.stdout + result.stderr)[-600:]
+    )
+    data = json.loads(payload[len("RESULT:") :])
+
+    root = str(REPO_ROOT)
+    assert data["project_root"] == root, (
+        f"project_root resolves to {data['project_root']!r}, expected repo "
+        f"root {root!r} — the parents[N] depth regressed (cf. stash #3147)"
+    )
+    assert data["path0"] != str(REPO_ROOT / "tests"), (
+        "sys.path[0] is <root>/tests — the insert shadows the real `scripts` "
+        "package with tests/scripts/ and poisons sys.modules for the session"
+    )


### PR DESCRIPTION
## What

Applies the sys.path depth fix recovered from the ai-01 stash (campaign #3147, [TASK] on the workspace dashboard 2026-08-19): `Path(__file__).parent.parent.parent` from `tests/e2e/**` resolves to **`<root>/tests`**, not the repo root. Four sites carried the wrong depth.

| File | Site | What parent³ broke |
|---|---|---|
| `tests/e2e/python/test_interface_web_complete.py` | `:33` | `sys.path.insert` put `tests/` in `sys.path[0]` — shadows the real `scripts` package with `tests/scripts/`, poisons `sys.modules` for the session |
| same | `:51` | `interface_web_dir` = `tests/interface_web` (**absent**) — Flask subprocess started in a dead dir instead of `<root>/interface_web` |
| same | `:84` | Playwright pytest subprocess `cwd=tests/` — relative `tests/functional/...` paths break |
| `tests/e2e/demos/demo_service_manager_validated.py` | `:12` | added `tests/project_core` to sys.path, which has **never** contained `service_manager` — the import only survived via the caller's cwd |

## Fix

`parents[3]` + `.resolve()` — verbatim from the stash (the idempotence guard on the insert included). Intent for sites 51/84 proven by their own comments ("à la racine du projet") + the `cwd=` parameters + filesystem targets that exist only at the root.

## Guard (CI band — tests/unit/)

`tests/unit/test_e2e_syspath_depth_guard.py` executes the **real module** in a fresh subprocess and asserts:
1. `mod.project_root == repo root`
2. `sys.path[0] != <root>/tests`

Proof measured this round:
- guard with the old line stashed back → **1 failed** (`project_root resolves to '...\tests' — the parents[N] depth regressed`) in 6.25 s
- guard with the fix → **1 passed** in 6.5 s (re-verified post-black)

## Out of scope, documented for a separate intent review

Same `parent³` pattern, different usage — NOT touched here (the stash didn't either):
- `tests/e2e/python/test_react_interface_complete.py` ×3 (subprocess `-c` with inherited cwd; `parent³/services/...` — needs the react build path checked against #322 consolidation)
- `tests/e2e/python/test_phase3_web_api_authentic.py:35` (`PROJECT_ROOT/logs`, `PROJECT_ROOT/reports` — output dirs, currently written under `tests/`)
- `tests/e2e/python/validate_no_mocks_phase3.py:23`

Per the stash instructions, `docs/soutenance/slides.md` from the same stash was **not** taken (in-progress edit, not a fix).

## Test plan

- [x] Guard red without fix / green with fix (measured above)
- [x] Module probe: `project_root` = repo root, orchestrateur importé depuis le vrai package `scripts` (`ORCHESTRATOR_AVAILABLE: True`)
- [x] Demos probe: `service_manager` now resolves from `<root>/project_core`
- [x] black on the 3 touched files

