### PR TITLE
fix(gate): close the 6 POSTs the widened argv bought — purchase vs leak, decided per file (#1809)

### DIFF
--- a/tests/config/test_config_real_gpt.py
+++ b/tests/config/test_config_real_gpt.py
@@ -5,6 +5,11 @@ Tests couvrant:
 - Validation configuration OpenAI correcte
 - Test connexion GPT-4o-mini fonctionnelle
 - Test modèles supportés et limites
+
+#1809: the three tests below emit real POSTs and their verdicts read the
+call's output (response content, response time, model accessibility) — the
+call is a purchase, so they are marked ``requires_api`` and run on the
+requires_api lane, not on every gate push.
 """
 
 import pytest
@@ -166,6 +171,7 @@ class TestGPTConfigValidation:
 
     @pytest.mark.asyncio
     @pytest.mark.real_llm
+    @pytest.mark.requires_api
     async def test_gpt4o_mini_connectivity(self, gpt_config_validator):
         """Test la connectivité GPT-4o-mini."""
         connectivity = await gpt_config_validator.test_api_connectivity(OPENAI_API_KEY)
@@ -254,6 +260,7 @@ class TestKernelConfiguration:
 
     @pytest.mark.asyncio
     @pytest.mark.real_llm
+    @pytest.mark.requires_api
     async def test_kernel_settings_optimization(self):
         """Test l'optimisation des settings du kernel."""
         kernel = Kernel()
@@ -366,6 +373,7 @@ class TestConfigurationIntegration:
 
     @pytest.mark.asyncio
     @pytest.mark.real_llm
+    @pytest.mark.requires_api
     async def test_end_to_end_configuration(self):
         """Test configuration end-to-end."""
         # Configuration complète

--- a/tests/orchestration/hierarchical/test_delegation_decides_firsthand_1471_R648.py
+++ b/tests/orchestration/hierarchical/test_delegation_decides_firsthand_1471_R648.py
@@ -19,6 +19,7 @@ test is the regression guard.
 import pytest
 
 from typing import Any, Dict
+from unittest.mock import patch
 
 from argumentation_analysis.orchestration.hierarchical.orchestrator import (
     run_hierarchical_analysis,
@@ -142,31 +143,56 @@ class TestDelegationModeDecidesFirsthand:
         executor = make_registry_operational_executor(registry)
         import asyncio
 
-        result = asyncio.get_event_loop().run_until_complete(
-            executor(
-                {
-                    "tactical_task_id": "t-test-legacy",
-                    "objective_id": "obj-legacy-test",
-                    "description": "Extraire segments pertinents",
-                    "required_capabilities": ["text_extraction"],
-                    "context": {},
-                    # CC #1531: le corpus voyage par ``text_extracts`` ; sans
-                    # lui l'exécuteur échoue en ``insufficient_input`` AVANT
-                    # d'invoquer. Le routage legacy→registry testé ici est
-                    # décidé en amont de cette garde : l'assertion est intacte.
-                    "text_extracts": [
-                        {
-                            "id": "x1",
-                            "content": (
-                                "Tous les experts le disent, donc c'est vrai. "
-                                "Et si vous n'êtes pas d'accord, c'est que vous "
-                                "ne comprenez rien au sujet."
-                            ),
-                        }
-                    ],
-                }
+        # #1809: the verdict below asserts routing only (status/capability) —
+        # it does NOT read the LLM output, and ``status == "completed"`` is
+        # reachable without any call: the executor marks a task completed as
+        # soon as the provider returns non-None, and the provider's no-client
+        # branch IS the heuristic fallback. Marking this test requires_api
+        # would mask that the POST bought nothing the verdict uses. The
+        # qualified windows pin the producer's own ``os`` copy (invoke_callables
+        # holds a second copy in full sessions — same mechanism as #1807), so
+        # the provider takes its no-openai-client branch and the bridge is
+        # still exercised end-to-end: legacy name → mapping → real provider →
+        # heuristic result → completed.
+        _no_key = {
+            "OPENAI_API_KEY": "",
+            "OPENROUTER_API_KEY": "",
+            "OPENROUTER_BASE_URL": "",
+        }
+        with patch.dict(
+            "argumentation_analysis.orchestration.invoke_callables.os.environ",
+            _no_key,
+            clear=True,
+        ), patch.dict(
+            "os.environ",
+            _no_key,
+            clear=True,
+        ):
+            result = asyncio.get_event_loop().run_until_complete(
+                executor(
+                    {
+                        "tactical_task_id": "t-test-legacy",
+                        "objective_id": "obj-legacy-test",
+                        "description": "Extraire segments pertinents",
+                        "required_capabilities": ["text_extraction"],
+                        "context": {},
+                        # CC #1531: le corpus voyage par ``text_extracts`` ; sans
+                        # lui l'exécuteur échoue en ``insufficient_input`` AVANT
+                        # d'invoquer. Le routage legacy→registry testé ici est
+                        # décidé en amont de cette garde : l'assertion est intacte.
+                        "text_extracts": [
+                            {
+                                "id": "x1",
+                                "content": (
+                                    "Tous les experts le disent, donc c'est vrai. "
+                                    "Et si vous n'êtes pas d'accord, c'est que vous "
+                                    "ne comprenez rien au sujet."
+                                ),
+                            }
+                        ],
+                    }
+                )
             )
-        )
         assert result["status"] == "completed", (
             f"legacy text_extraction should route via fact_extraction, " f"got {result}"
         )


### PR DESCRIPTION
## Summary

#1805 widened the gate argv (+226 tests that really execute) and brought in **6 real `api.openai.com` POSTs per push** from two files not marked `requires_api`. Per the dispatch, the decision rule is not "mark or not" but **does the verdict read the call's output?** — established below on the assertions, per file.

## File 1 — `tests/config/test_config_real_gpt.py`: the call is a **purchase** → `requires_api`

All three emitting tests assert on the response itself:

| test | verdict reads |
|---|---|
| `test_gpt4o_mini_connectivity` | `connectivity["connection_successful"]`, `response_time < 30.0`, `model_accessible` |
| `test_kernel_settings_optimization` | `len(response) > 0`, `response[0].content is not None`, `len(response[0].content) > 10` |
| `test_end_to_end_configuration` | `colonel_mentioned` (terms in `content.lower()`), `len(content) > 30` |

The POST buys exactly what the verdict asserts. → each gains `@pytest.mark.requires_api` (they already carry `real_llm`); they move to the requires_api lane instead of firing on every push — including doc-only pushes.

## File 2 — `tests/orchestration/hierarchical/test_delegation_decides_firsthand_1471_R648.py`: **pure leak** → the call is removed, not marked

The bridging test's entire verdict:

```python
assert result["status"] == "completed", ...
assert result["capability"] == "fact_extraction"
```

- `capability` is pure routing, decided **before** invocation (`LEGACY_TO_REGISTRY_CAPABILITY`).
- `status == "completed"` is reachable **without any call**: the executor marks a task completed as soon as the provider returns non-None (delegation_orchestrator.py: "``status`` stays ``completed`` on purpose — the call DID return"), and the provider's no-client branch IS the heuristic fallback (`_invoke_fact_extraction` → `last_reason="no-openai-client"` → heuristic dict → completed).

Irony measured in the CI artifact: the 3 POSTs are the `_EXTRACTION_MAX_ATTEMPTS = 3` retry loop, which in CI fails to parse all three times and ends in the heuristic fallback anyway — the gate paid 3 calls to land exactly where it would have landed with no key.

Marking it `requires_api` would have masked that. Instead the test gets the qualified no-key windows (producer's own `os` copy in `invoke_callables` + the global copy — the form proven in #1807), so the provider takes its `no-openai-client` branch while the bridge stays exercised end-to-end: legacy name → mapping → real provider → heuristic result → completed. Note the sibling test in the same file (`test_delegation_mode_decides_end_to_end_with_real_agents`) already carries `requires_api` with a docstring saying its verdict reads graded conclusions — the file's own precedent drew the same line.

## Measurements

- **Current main attribution** (run 32245311716, `02893a8b`): `llm 10 | nonllm 142 | unknown 1` — the 10 = 4 non-vacuity controls + 3 (this file 1) + 3 (this file 2). `pl_2pass` is silent (#1807 holds).
- **Local CI-shape repro** (fake ambient key `sk-fake-*`, gate marker filter, both files): **0 watched-LLM requests**, 12 passed / 4 deselected (the 3 newly-marked + the pre-existing `requires_api` sibling).
- **Expected on this PR's CI**: `llm 4` (controls only) — never 0 — with `nonllm 142` / `unknown 1` unchanged.

## Anti-pendule

No directory leaves the argv — the fix is at the two files, as dispatched.

## Test plan

- [x] Local CI-shape repro: 0 LLM requests across both files, all non-marked tests green
- [x] black clean on both files
- [ ] PR CI: `llm 4`, `nonllm`/`unknown` unchanged

Refs #1809 · #1805 · #1794 · #1787