### PR TITLE
test(ci): admit the 6 clean integration subdirs, measured in position (#1783)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           TEXT_CONFIG_PASSPHRASE: ${{ secrets.TEXT_CONFIG_PASSPHRASE }}
         run: |
-          conda run -n projet-is --no-capture-output pytest tests/unit/ tests/scripts/ tests/orchestration/ tests/ui/ tests/utils/ tests/golden/ tests/core/ tests/config/ tests/property/ tests/argumentation_analysis/ tests/project_core/ tests/functional/ -m "not slow and not requires_api" --junitxml=pytest_report.xml -v --timeout=900 --timeout-method=thread
+          conda run -n projet-is --no-capture-output pytest tests/unit/ tests/scripts/ tests/orchestration/ tests/ui/ tests/utils/ tests/golden/ tests/core/ tests/config/ tests/property/ tests/argumentation_analysis/ tests/project_core/ tests/functional/ tests/integration/api/ tests/integration/jpype_tweety/ tests/integration/logical_agents/ tests/integration/orchestration/ tests/integration/services/ tests/integration/workers/ -m "not slow and not requires_api" --junitxml=pytest_report.xml -v --timeout=900 --timeout-method=thread
 
       - name: Generate test summary
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           TEXT_CONFIG_PASSPHRASE: ${{ secrets.TEXT_CONFIG_PASSPHRASE }}
         run: |
-          conda run -n projet-is --no-capture-output pytest tests/unit/ tests/scripts/ tests/orchestration/ tests/ui/ tests/utils/ tests/golden/ tests/core/ tests/config/ tests/property/ tests/argumentation_analysis/ tests/project_core/ tests/functional/ tests/integration/api/ tests/integration/jpype_tweety/ tests/integration/logical_agents/ tests/integration/orchestration/ tests/integration/services/ tests/integration/workers/ -m "not slow and not requires_api" --junitxml=pytest_report.xml -v --timeout=900 --timeout-method=thread
+          conda run -n projet-is --no-capture-output pytest tests/unit/ tests/scripts/ tests/orchestration/ tests/ui/ tests/utils/ tests/golden/ tests/core/ tests/config/ tests/property/ tests/argumentation_analysis/ tests/project_core/ tests/functional/ tests/integration/orchestration/ tests/integration/services/ tests/integration/workers/ -m "not slow and not requires_api" --junitxml=pytest_report.xml -v --timeout=900 --timeout-method=thread
 
       - name: Generate test summary
         if: always()


### PR DESCRIPTION
## What

Admit the 6 clean `tests/integration/` subdirectories into the gate argv (`ci.yml:146`): `api`, `jpype_tweety`, `logical_agents`, `orchestration`, `services`, `workers`.

Measured green with clean process exit on `02893a8b` (issuecomment-5344123316): 53 passed / 2 skipped / ~64 s combined, deterministic, DLL-independent.

## The control — measured IN POSITION, not in isolation

Isolated green is not admission green (#1804: `tests/integration` was green-alone-red-in-sweep; `tests/orchestration` flipped 59-passed → 59-skipped). The deciding measure is this PR's own CI run — the full gate argv, in the order it names the directories — compared to main's last run.

**Before (main `f45b1656`, run 32278831018, completed/success):**

```
14598 passed, 264 skipped, 315 deselected, 4 xfailed — 508.62s
```

**Expected if admission works:** `passed` **+53** (→ 14651) AND `skipped` **+2** (→ 266).

**Flip-to-skip signature (fails the DoD):** `passed` ~flat with `skipped` +55 — that would be green bought without coverage; the lot shrinks, no skipif is added.

- [x] `passed` and `skipped` both cited, before and after (after filled below once CI completes)
- [ ] CI verdict read from the pytest summary line, not the rollup (#1799 control)

## #1813 blockers verified unreachable (not assumed)

`pytest tests/integration/{api,jpype_tweety,logical_agents,orchestration,services,workers} --collect-only` under the gate selector: **55/63 collected (8 deselected), 0 matches for `enrichment|growth_hook`**. The two #1813 hang files live at `tests/integration/` root, not in any admitted subdir.

## Egress reference

Since #1811 the reference is `llm 4` (controls only). Verified on this PR's run below — any number > 4 names a test that calls; it gets reported per-test, not blanket-marked.

## What stays out, one line each

| Excluded | Reason |
|---|---|
| `tests/integration/argumentation_analysis/` | 6 deterministic reds — SPASS name-pinning ("solver decides via SPASS, test pins 'tweety'"); test-side, dedicated ticket |
| `tests/integration/webapp/` | 1 red env-side (React build not in git) with **no skip guard** — red in CI too; needs honest skip or CI build |
| `tests/integration/recovered/` | collects 0 tests but process exit hangs ~15 min after summary — would burn the CI job measuring nothing (#1813 family) |
| `tests/integration/test_*.py` (root files) | the 8 conversational reds (mock target `OpenAIChatCompletion` gone from the module — test-side) and both #1813 hang files live here |

## Non-goals (anti-pendule)

- No fix to any of the 15 reds in this PR — this is a perimeter widening, not a fix campaign. Each of the 3 red families gets its own ticket.
- No `skipif` to force a directory in.

## #1783
