### PR TITLE
fix(ci): make the requires_api destination real — selectors as argv arrays, gate-parity widening, collect-only firing (#1592)

### DIFF
--- a/.github/workflows/extended-tests.yml
+++ b/.github/workflows/extended-tests.yml
@@ -4,10 +4,12 @@
 #
 # Rationale : ci.yml exécute tests/unit -m "not slow and not requires_api" pour
 # rester sous quelques minutes sans facturer d'appels LLM à chaque push. Les 640
-# tests écartés (integration 434, e2e 74, bench 11, unit slow/requires_api 121)
-# ne sont PAS exemptés de passer — ils sont différés vers cette lane, qu'on
-# déclenche à la demande (avant une release, après un gros merge) avec les vraies
-# clés. C'est aussi le seul foyer du test non-hermétique quarantiné en #1343.
+# tests écartés (integration 434, e2e 74, bench 11, unit slow/requires_api 121 —
+# ce dernier nombre est périmé : 329 mesurés le 2026-08-19 sur le sélecteur
+# élargi, voir #1592) ne sont PAS exemptés de passer — ils sont différés vers
+# cette lane, qu'on déclenche à la demande (avant une release, après un gros
+# merge) avec les vraies clés. C'est aussi le seul foyer du test non-hermétique
+# quarantiné en #1343.
 #
 # Déclenchement : onglet Actions → "Extended Test Lanes" → Run workflow →
 # choisir la lane (all ou une seule). Ou : gh workflow run extended-tests.yml -f lane=bench
@@ -22,6 +24,10 @@ on:
         type: choice
         default: all
         options: [all, integration-jvm, integration-rest, e2e, bench, unit-api]
+      collect_only:
+        description: "Collecter sans exécuter — prouve le sélecteur (nombre collecté) à coût d'appels nul (#1592)"
+        type: boolean
+        default: false
 
 # Un seul run étendu par ref ; un nouveau supersède l'en-vol.
 concurrency:
@@ -91,21 +97,43 @@ jobs:
           TEXT_CONFIG_PASSPHRASE: ${{ secrets.TEXT_CONFIG_PASSPHRASE }}
         run: |
           $lane = "${{ matrix.lane }}"
-          $common = "--junitxml=pytest_report_$lane.xml -v --timeout=900 --timeout-method=thread"
-          switch ($lane) {
-            "integration-jvm"  { $sel = "tests/integration/jpype_tweety tests/integration/logical_agents" }
-            "integration-rest" { $sel = "tests/integration --ignore=tests/integration/jpype_tweety --ignore=tests/integration/logical_agents" }
-            "e2e"              { $sel = "tests/e2e" }
-            "bench"            { $sel = "tests/bench" }
-            "unit-api"         { $sel = "tests/unit -m `"slow or requires_api`"" }
+          # #1592: selectors are argv ARRAYS, not space-split strings. The old
+          # string form shattered `-m "slow or requires_api"` into four tokens
+          # the moment .Split(" ") ran (`-m`, `"slow`, `or`, `requires_api"`) —
+          # unit-api could never pass its marker expression intact. Arrays
+          # splat as single argv entries, quotes included where needed.
+          $common = @("--junitxml=pytest_report_$lane.xml", "-v", "--timeout=900", "--timeout-method=thread")
+          if ("${{ github.event.inputs.collect_only }}" -eq "true") {
+            # #1592: fire the selector machinery (collection on the real
+            # runner) without executing a single test — zero LLM calls, and
+            # the collected count is the decisive readout proving the lane
+            # addresses something.
+            $common = @("--collect-only", "-q")
           }
-          Write-Host "Lane $lane -> pytest $sel"
-          conda run -n projet-is --no-capture-output pytest $sel.Split(" ") $common.Split(" ")
+          switch ($lane) {
+            "integration-jvm"  { $sel = @("tests/integration/jpype_tweety", "tests/integration/logical_agents") }
+            "integration-rest" { $sel = @("tests/integration", "--ignore=tests/integration/jpype_tweety", "--ignore=tests/integration/logical_agents") }
+            "e2e"              { $sel = @("tests/e2e") }
+            "bench"            { $sel = @("tests/bench") }
+            # #1592: the deferred destination must cover every location the
+            # gate's marker filter excludes. #1805 grew the gate argv to 12
+            # directories; this selector stayed at tests/unit — the two lists
+            # were meant to stay twins and diverged in silence. Exact
+            # gate-parity directories plus the marked root file; never
+            # `tests/` wholesale: block selection would swallow the two
+            # tests/integration sessionstart blockers (#1813) that no marker
+            # filter can exclude.
+            "unit-api"         { $sel = @("tests/unit", "tests/scripts", "tests/orchestration", "tests/ui", "tests/utils", "tests/golden", "tests/core", "tests/config", "tests/property", "tests/argumentation_analysis", "tests/project_core", "tests/functional", "tests/test_regression_golden.py", "-m", "slow or requires_api") }
+          }
+          Write-Host "Lane $lane -> pytest $($sel -join ' ')"
+          conda run -n projet-is --no-capture-output pytest @sel @common
 
       - name: Upload lane results
         if: always() && env.RUN == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: extended-results-${{ matrix.lane }}
-          path: pytest_report_*.xml
+          path: |
+            pytest_report_*.xml
+            llm_egress_report.json
           if-no-files-found: warn


### PR DESCRIPTION
## Summary

#1811 deferred three purchased tests to a lane that could not receive them. This PR makes the destination real — and finds the lane was broken in a second, independent way.

## The census (DoD item 1 — per test, marker-level)

Method: `pytest --collect-only -m "slow or requires_api"` over the gate's directories + the marked root file (safe to collect — gate-proven imports), grep-based enumeration for `tests/integration` / `tests/e2e` / `tests/bench` (whole-directory lanes take every test unconditionally, marker irrelevant to membership; a pytest collection there risks the #1813 sessionstart hang).

**35 files carry `slow` or `requires_api`:**

| selector | files | tests | note |
|---|---|---|---|
| `unit-api` (`tests/unit -m`) | 14 | **300** | incl. `test_workflow_robustness.py` = 258 |
| `integration-rest` (whole dir) | 11 | n/a (no marker filter) | incl. **one of the two #1813 sessionstart blockers** (`test_growth_hook_corpus_a_597.py`) |
| `integration-jvm` (whole dir) | 0 | — | no marked file under jpype_tweety/logical_agents |
| `e2e` (whole dir) | 1 | n/a | |
| `bench` (whole dir) | 1 | n/a | |
| **AUCUN** | **7** | **29** | the orphans |

**The 29 orphans** (marked, excluded from the gate by its marker filter, addressed by no extended selector):
- `tests/config/test_config_real_gpt.py` — 3 `requires_api` (the #1811 deferrals)
- `tests/orchestration/hierarchical/` — 4 files / 10 tests (9 `slow`, 1 `requires_api`)
- `tests/scripts/test_proof_bo2b_dashboard_1493.py` — 2 (`slow`, `requires_api+slow`)
- `tests/test_regression_golden.py` (root) — 14 `requires_api`

Out of every collection, deliberately: `tests/_archived/` (`norecursedirs = _*` in pytest.ini). Side-finding, out of scope: the other root-level test files (`tests/test_*.py` except the golden) are in NO lane and NO gate — the gate argv names directories only.

**Cause structurelle confirmée** : #1805 grew the gate argv to 12 directories; `extended-tests.yml` never followed. Twin lists, silent divergence.

## The second bug: the selector string was already broken

The old run step built selectors as space-split strings:

```powershell
"unit-api" { $sel = "tests/unit -m `"slow or requires_api`"" }
... pytest $sel.Split(" ") ...
```

`.Split(" ")` shatters `-m "slow or requires_api"` into four tokens (`-m`, `"slow`, `or`, `requires_api"`) — the marker expression could never arrive intact. Selectors are now argv **arrays** splatted as single entries (validated locally: `arg[4] = <slow or requires_api>`).

## The fix (DoD item 2)

`unit-api` widens to **exact gate-parity directories** + the marked root file — the two lists are structural twins again, and `-m` keeps the collected set identical to the census:

```
tests/unit tests/scripts tests/orchestration tests/ui tests/utils tests/golden
tests/core tests/config tests/property tests/argumentation_analysis
tests/project_core tests/functional tests/test_regression_golden.py
-m "slow or requires_api"
```

Verified locally: **329 collected** (14880 deselected) — matches the census sum 300 + 29. Never `tests/` wholesale: block selection would swallow the two `tests/integration` sessionstart blockers (#1813) that no marker filter can exclude (they hang before collection).

## The firing (DoD item 3) — collect-only, and why

A full `unit-api` pass is **~2600 LLM calls** (measured locally with the egress counter under a fake ambient key — the counter counts attempts, which equal calls under a valid key; per-file mass from the R831 lateral discovery, dominated by `test_workflow_robustness.py` ≈ 2300). That is exactly the "gros chiffre" the dispatch says to bring back rather than burn — **arming a schedule and the full-pass cadence is a user decision**, reported with numbers on #1592, not taken here.

So the lane is fired for real through the new `collect_only` dispatch input: same selector machinery, same runner, zero LLM calls, and the decisive readout is literally what the dispatch asks for — *un nombre de tests collectés non nul et nommé*. Firing happens on this PR branch after merge-eligibility; results are posted on #1592.

`llm_egress_report.json` joins the lane-results upload so any future real firing self-reports its call cost.

## Anti-pendule honored

- The 3 #1811 tests stay out of the gate (they were purchases).
- No directory leaves the gate argv.
- No `tests/` wholesale selector.

## Test plan

- [x] Census: 329 = 300 + 29, per-file breakdown in issue comment
- [x] Selector parity: exact new argv collects 329 locally
- [x] pwsh splatting validated (marker expression arrives as ONE argv entry)
- [x] Local cost measurement: egress counter under fake key (number on #1592)
- [ ] `collect_only` firing on the PR branch: collected count non-zero and named

Refs #1592 · #1811 · #1805 · #1813 · #1759 · #1787