### PR TITLE
fix(e2e): web_api sys.path depth — parents[3] pinned on the 3 remaining sites (#1812)

### DIFF
--- a/tests/e2e/web_api/test_interface_simple_playwright.py
+++ b/tests/e2e/web_api/test_interface_simple_playwright.py
@@ -26,7 +26,9 @@ from pathlib import Path
 import logging
 
 # Configuration des chemins
-PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+# parents[3] = repo root (web_api -> e2e -> tests -> root). parent³ resolves to
+# <root>/tests, which would put tests/ at sys.path[0] and shadow the real packages.
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
 INTERFACE_URL = "http://localhost:3000"
 
 # Sélecteurs adaptés de l'interface React vers l'interface simple

--- a/tests/e2e/web_api/test_interfaces_integration.py
+++ b/tests/e2e/web_api/test_interfaces_integration.py
@@ -23,7 +23,9 @@ from pathlib import Path
 from unittest.mock import patch, MagicMock
 
 # Configuration des chemins
-PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+# parents[3] = repo root (web_api -> e2e -> tests -> root). parent³ resolves to
+# <root>/tests, which would put tests/ at sys.path[0] and shadow the real packages.
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
 sys.path.insert(0, str(PROJECT_ROOT))
 
 

--- a/tests/e2e/web_api/test_management_scripts.py
+++ b/tests/e2e/web_api/test_management_scripts.py
@@ -25,7 +25,9 @@ from pathlib import Path
 from unittest.mock import patch, MagicMock
 
 # Configuration des chemins
-PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+# parents[3] = repo root (web_api -> e2e -> tests -> root). parent³ resolves to
+# <root>/tests, which would put tests/ at sys.path[0] and shadow the real packages.
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
 sys.path.insert(0, str(PROJECT_ROOT))
 
 

--- a/tests/unit/test_e2e_syspath_depth_guard.py
+++ b/tests/unit/test_e2e_syspath_depth_guard.py
@@ -1,8 +1,8 @@
 """Garde — la profondeur ``sys.path`` de ``tests/e2e`` ne doit pas retomber sur ``tests/``.
 
-Le fichier ``tests/e2e/python/test_interface_web_complete.py`` fait un
-``sys.path.insert`` au niveau module pour importer l'orchestrateur.
-``Path(__file__).parent.parent.parent`` depuis ``tests/e2e/python/``
+Les fichiers sous ``tests/e2e/`` font un ``sys.path.insert`` au niveau module
+pour importer l'orchestrateur ou les scripts de service.
+``Path(__file__).parent.parent.parent`` depuis ``tests/e2e/<sub>/``
 résout **``<root>/tests``**, pas la racine : ``tests/`` se retrouvait en
 ``sys.path[0]``, ombrageant le vrai package ``scripts`` par ``tests/scripts/``
 et empoisonnant ``sys.modules`` pour toute la session (le même motif
@@ -12,9 +12,9 @@ survivait que par le cwd de l'appelant — ``tests/project_core`` n'a
 jamais contenu ``service_manager``).
 
 Le correctif épingle ``parents[3]`` (= racine du dépôt). Ce garde
-exécute le module réel dans un process vierge et vérifie la géométrie :
-la racine dans le path, ``tests/`` absent de la position 0, et le
-``project_root`` du module égal à la racine.
+exécute chaque module réel dans un process vierge et vérifie la
+géométrie : la racine dans le path, ``tests/`` absent de la position 0,
+et le ``project_root`` du module égal à la racine.
 """
 
 import json
@@ -22,9 +22,18 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
-E2E_MODULE = REPO_ROOT / "tests/e2e/python/test_interface_web_complete.py"
+# (module relatif, attribut portant la racine calculée)
+GUARDED_MODULES = [
+    ("tests/e2e/python/test_interface_web_complete.py", "project_root"),
+    ("tests/e2e/demos/demo_service_manager_validated.py", "project_root"),
+    ("tests/e2e/web_api/test_interfaces_integration.py", "PROJECT_ROOT"),
+    ("tests/e2e/web_api/test_management_scripts.py", "PROJECT_ROOT"),
+    ("tests/e2e/web_api/test_interface_simple_playwright.py", "PROJECT_ROOT"),
+]
 
 PROBE = """
 import importlib.util, json, sys
@@ -33,20 +42,26 @@ spec = importlib.util.spec_from_file_location("e2e_syspath_probe", {module!r})
 mod = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(mod)
 print("RESULT:" + json.dumps({{
-    "project_root": str(mod.project_root),
+    "project_root": str(getattr(mod, {attr!r})),
     "path0": sys.path[0],
 }}))
 """
 
 
-def test_e2e_module_puts_repo_root_on_sys_path_not_tests():
-    assert E2E_MODULE.exists(), f"module under guard missing: {E2E_MODULE}"
+@pytest.mark.parametrize(
+    "module_rel, attr",
+    GUARDED_MODULES,
+    ids=lambda value: Path(value).name if isinstance(value, str) else value,
+)
+def test_e2e_module_puts_repo_root_on_sys_path_not_tests(module_rel, attr):
+    module_path = REPO_ROOT / module_rel
+    assert module_path.exists(), f"module under guard missing: {module_path}"
 
     result = subprocess.run(
         [
             sys.executable,
             "-c",
-            PROBE.format(module=str(E2E_MODULE)),
+            PROBE.format(module=str(module_path), attr=attr),
         ],
         capture_output=True,
         text=True,
@@ -65,10 +80,10 @@ def test_e2e_module_puts_repo_root_on_sys_path_not_tests():
 
     root = str(REPO_ROOT)
     assert data["project_root"] == root, (
-        f"project_root resolves to {data['project_root']!r}, expected repo "
+        f"{module_rel}: {attr} resolves to {data['project_root']!r}, expected repo "
         f"root {root!r} — the parents[N] depth regressed (cf. stash #3147)"
     )
     assert data["path0"] != str(REPO_ROOT / "tests"), (
-        "sys.path[0] is <root>/tests — the insert shadows the real `scripts` "
-        "package with tests/scripts/ and poisons sys.modules for the session"
+        f"{module_rel}: sys.path[0] is <root>/tests — the insert shadows the real "
+        "`scripts` package with tests/scripts/ and poisons sys.modules for the session"
     )


### PR DESCRIPTION
## Summary

#1812 — les 3 derniers sites `parents[N]` cassés de `tests/e2e/web_api/` épinglés sur `parents[3]`, garde étendue, preuve par substitution dégénérée par site.

Le bug est le même que #1810 (stash #3147) : depuis `tests/e2e/web_api/`, `Path(__file__).parent.parent.parent` résout `<root>/tests`, pas la racine — `tests/` en `sys.path[0]` ombrage le vrai package `scripts` par `tests/scripts/` et empoisonne `sys.modules` pour la session.

## Files changed and why

| File | Role | Change |
|---|---|---|
| `tests/e2e/web_api/test_interfaces_integration.py` | test | `PROJECT_ROOT` épinglé `parents[3]` (+insert idem) |
| `tests/e2e/web_api/test_management_scripts.py` | test | `PROJECT_ROOT` épinglé `parents[3]` |
| `tests/e2e/web_api/test_interface_simple_playwright.py` | test | `PROJECT_ROOT` épinglé `parents[3]` |
| `tests/unit/test_e2e_syspath_depth_guard.py` | test (guard) | paramétré sur 5 modules : les 2 de #1810 (`python/`, `demos/`) + les 3 du lot |

**Non touchés (depths corrects, anti-uniformisation)** : `playwright_js_runner.py:48` (parent×4) et `util_start_servers.py:9` (depth 2) — diff vide vérifié.

## Proof — substitution dégénérée par site

Ancienne ligne remise (checkout `origin/main` du fichier), garde relancée ciblée :

```
FAILED ...[test_interfaces_integration.py-PROJECT_ROOT]
FAILED ...[test_management_scripts.py-PROJECT_ROOT]
FAILED ...[test_interface_simple_playwright.py-PROJECT_ROOT]
```

Correctif réappliqué : `5 passed, 5 warnings in 9.07s` (les 2 modules #1810 restent verts dans les deux états — la garde est bien par-site).

## Controls

- **Collection intacte** : `pytest tests/e2e/web_api/ --collect-only -q` → `31 tests collected in 0.30s` (aucun import cassé par le changement de racine).
- **Inertie module-level vérifiée** avant d'exécuter les modules dans la garde : `setUpClass` ne court pas à l'import ; les dépendances module-level (`playwright.async_api`, `aiohttp`, `psutil`) sont importables dans l'env.
- **black** : 4 fichiers touchés only — `All done! 4 files would be left unchanged` (leçon R831 : jamais un dir entier).
- **DoD #1812** : 3 sites épinglés ✅ · 2 corrects intacts ✅ · garde étendue au lot + `demos/` ✅ · rouge-sans/vert-avec mesuré et cité par site ✅

Closes #1812
