### PR TITLE
fix(tests): logic_puzzles hermetic + modal requires_api (#1817)

### DIFF
--- a/tests/agents/core/logic/test_modal_logic_agent_authentic.py
+++ b/tests/agents/core/logic/test_modal_logic_agent_authentic.py
@@ -153,6 +153,7 @@ def test_initialization_and_setup_authentic(authentic_agent):
 
 @pytest.mark.asyncio
 @pytest.mark.llm_integration
+@pytest.mark.requires_api
 async def test_text_to_belief_set_authentic_modal(authentic_agent):
     """Test authentique de conversion texte -> belief set modal avec vrai LLM."""
     agent = authentic_agent["agent"]
@@ -189,6 +190,7 @@ async def test_text_to_belief_set_authentic_modal(authentic_agent):
 
 @pytest.mark.asyncio
 @pytest.mark.llm_integration
+@pytest.mark.requires_api
 async def test_generate_queries_authentic_modal(authentic_agent):
     """Test authentique de génération de requêtes modales avec vrai LLM."""
     agent = authentic_agent["agent"]
@@ -254,6 +256,7 @@ def test_tweety_bridge_modal_integration_authentic(authentic_agent):
 
 @pytest.mark.asyncio
 @pytest.mark.integration
+@pytest.mark.requires_api
 async def test_full_workflow_modal_authentic(authentic_agent):
     """Test d'intégration complète authentique - workflow modal complet sans mocks."""
     agent = authentic_agent["agent"]

--- a/tests/integration/logical_agents/test_logic_puzzles.py
+++ b/tests/integration/logical_agents/test_logic_puzzles.py
@@ -1,33 +1,26 @@
 # tests/integration/logical_agents/test_logic_puzzles.py
 
-import os
 import pytest
 import json
 from pathlib import Path
 import asyncio
+from unittest.mock import AsyncMock
 
 import semantic_kernel as sk
 from argumentation_analysis.agents.sherlock_jtms_agent import SherlockJTMSAgent
-from argumentation_analysis.config.settings import AppSettings
-
-pytestmark = pytest.mark.skipif(
-    not os.getenv("OPENAI_API_KEY"),
-    reason="Tests require OPENAI_API_KEY for agent logic puzzle solving",
-)
 
 
-# Fixture to create a kernel with LLM service for the agent
+# Hermetic kernel (#1817): every value the assertions read (confidence_score,
+# alternative_hypotheses, primary_hypothesis) is computed by the JTMS locally;
+# the LLM only writes `detailed_solution`, which no assert reads. Stubbing
+# invoke_prompt removes the key requirement and the POST without changing
+# any verdict.
 @pytest.fixture
-def kernel():
-    k = sk.Kernel()
-    from semantic_kernel.connectors.ai.open_ai import OpenAIChatCompletion
-
-    api_key = os.getenv("OPENAI_API_KEY")
-    chat_service = OpenAIChatCompletion(
-        service_id="default", ai_model_id="gpt-5-mini", api_key=api_key
+def kernel(monkeypatch):
+    monkeypatch.setattr(
+        sk.Kernel, "invoke_prompt", AsyncMock(return_value="deduction stub")
     )
-    k.add_service(chat_service)
-    return k
+    return sk.Kernel()
 
 
 # Fixture to load scenarios from JSON files
@@ -54,7 +47,6 @@ class TestLogicalAgentHardening:
         # This test is synchronous as it does not await any coroutines.
         # The `async def` was likely a leftover.
         # 1. Initialize the agent
-        settings = AppSettings()
         agent = SherlockJTMSAgent(kernel, agent_name="test_contradiction_agent")
 
         # 2. Add a single fact and declare it as true in JTMS

--- a/tests/integration/logical_agents/test_logic_puzzles_hardening.py
+++ b/tests/integration/logical_agents/test_logic_puzzles_hardening.py
@@ -2,20 +2,23 @@ import pytest
 import json
 from pathlib import Path
 import asyncio
+from unittest.mock import AsyncMock
 
 import semantic_kernel as sk
-from semantic_kernel.connectors.ai.open_ai import OpenAIChatCompletion
 from argumentation_analysis.agents.sherlock_jtms_agent import SherlockJTMSAgent
-from argumentation_analysis.config.settings import AppSettings
 
 
-# Fixture to create a kernel with LLM service for the agent
+# Hermetic kernel (#1817): every value the assertions read (confidence_score,
+# alternative_hypotheses, primary_hypothesis) is computed by the JTMS locally;
+# the LLM only writes `detailed_solution`, which no assert reads. Stubbing
+# invoke_prompt removes the key requirement and the POST without changing
+# any verdict.
 @pytest.fixture
-def kernel():
-    k = sk.Kernel()
-    chat_service = OpenAIChatCompletion(service_id="default", ai_model_id="gpt-5-mini")
-    k.add_service(chat_service)
-    return k
+def kernel(monkeypatch):
+    monkeypatch.setattr(
+        sk.Kernel, "invoke_prompt", AsyncMock(return_value="deduction stub")
+    )
+    return sk.Kernel()
 
 
 # Fixture to load scenarios from JSON files


### PR DESCRIPTION
## Summary

Closes #1817. The coordinator's rule — *does the verdict read the LLM output?* — applied file by file, which splits the "family of 4" into **2 leaks, 1 purchase, 1 ghost**:

| File | Verdict reads LLM output? | Action |
|---|---|---|
| `tests/integration/logical_agents/test_logic_puzzles.py` | **No** — every asserted value is JTMS-local | Hermetic stub (below) |
| `tests/integration/logical_agents/test_logic_puzzles_hardening.py` | **No** — same | Hermetic stub (below) |
| `tests/agents/core/logic/test_modal_logic_agent_authentic.py` | **Yes** — asserts on `belief_set.content`, generated queries | `requires_api` on the 3 LLM tests only (the 5 Tweety/JVM tests stay unmarked) |
| `tests/integration/test_authenticite_finale_gpt4o.py` | — | **Collects 0 tests** (class `AuthenticAPITester` lacks the `Test*` prefix, no module-level `test_*`): a script wearing a test filename. Its LLM calls only fire under direct execution. No marker applicable; not renamed here (cleanup-gate territory, separate decision) |

## Why the 2 logic_puzzles tests are a leak, not a purchase

In `deduce_solution` ([sherlock_jtms_agent.py:400-420](argumentation_analysis/agents/sherlock_jtms_agent.py#L400-L420)), the LLM produces only `detailed_solution` — **no assertion reads it**. Every asserted value is computed locally: `confidence_score` = `strength_score` from the hypothesis tracker (line 410), `alternative_hypotheses` = the local sort (line 415), `primary_hypothesis` = local evaluation (line 408). The LLM's only footprint on the verdicts is indirect: on failure the `except` returns `{"error": ...}` which trips `"error" not in solution` — the exact CI red (`Deduction should not fail/error`). Marking these `requires_api` would have masked a leak: real POSTs for output nobody reads.

**Fix**: the `kernel` fixture now stubs `Kernel.invoke_prompt` via class-level `monkeypatch` (instance assignment is rejected — `sk.Kernel` is a Pydantic model that raises `no_such_attribute` on unknown attrs; class-level setattr works and auto-reverts per test). The `skipif(OPENAI_API_KEY)` is removed: the tests are keyless and POSTless with **unchanged verdicts**.

## Duplication tranche (coordinator's question)

**Not a byte-duplicate — keep both.** Same class/test names, but distinct JTMS topologies per test:
- Contradiction: `test_logic_puzzles` builds a self-negation justification (`in=[f], out=[same f]`) through `_evidence_manager.add_evidence`; `_hardening` builds an inter-belief rule (`in=[f1], out=[f2]`) through `agent.add_belief` with named atoms. Different conflict shapes through different construction APIs.
- Ambiguity: `test_logic_puzzles` links evidence positive/negative across two hypotheses and asserts threshold `< 0.8` + alt-membership + primary≠alt; `_hardening` uses bare unlinked hypotheses, threshold `< 0.6`, alt-count only. Different paths through `evaluate_hypothesis_strength`.

The only true overlap was the LLM transit in `[ambiguous_scenario]` — which this PR removes from both.

## Controls (all on this branch, projet-is)

| Control | Before | After |
|---|---|---|
| Ticket repro `logical_agents + api -m "not slow and not requires_api"` | 10 passed, **2 POSTs** | **10 passed, 0 POST** |
| Per-test breakdown in that session | 2 requests on the logic_puzzles params | all 3 requests belong to the counter's own liveness tests — counter certified live in-session |
| Keyless run (`OPENAI_API_KEY=` cleared), whole dir | skip (skipif) / red (hardening) | **4/4 passed in 2.8s** |
| Gate selector on modal file | 8/8 collected (LLM tests in-band) | **5/8 collected, 3 deselected** |
| black | — | clean (3 files) |

CI impact: none expected — neither dir is in the gate argv today; this removes the blocker that vetoed `tests/integration/logical_agents` in #1814 (its 2 CI reds + 2 POSTs). Re-admission is a separate lane per the ci.yml precedent ("the next candidate directory needs its own measurement").

## Test plan

- [ ] CI green (delta 0 vs main expected)
- [ ] Reviewer confirms the leak-vs-purchase split on the 3 code files
