### PR TITLE
fix(tests): scope the openapi-contract sys.modules stubs — spacy leak closed, tests/integration/api readmitted (#1816)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,13 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           TEXT_CONFIG_PASSPHRASE: ${{ secrets.TEXT_CONFIG_PASSPHRASE }}
         run: |
-          conda run -n projet-is --no-capture-output pytest tests/unit/ tests/scripts/ tests/orchestration/ tests/ui/ tests/utils/ tests/golden/ tests/core/ tests/config/ tests/property/ tests/argumentation_analysis/ tests/project_core/ tests/functional/ tests/integration/orchestration/ tests/integration/services/ tests/integration/workers/ -m "not slow and not requires_api" --junitxml=pytest_report.xml -v --timeout=900 --timeout-method=thread
+          # #1816: tests/integration/api/ readmitted — its module-level spacy
+          # sys.modules mock leaked at collection and reddened 3 tests/unit
+          # victims at distance (#1814 veto). The stubs now live in an
+          # install/import/restore window, so admission is safe; the 2
+          # genuine-verdict LLM tests in that dir are requires_api-marked and
+          # stay deselected by the gate filter.
+          conda run -n projet-is --no-capture-output pytest tests/unit/ tests/scripts/ tests/orchestration/ tests/ui/ tests/utils/ tests/golden/ tests/core/ tests/config/ tests/property/ tests/argumentation_analysis/ tests/project_core/ tests/functional/ tests/integration/orchestration/ tests/integration/services/ tests/integration/workers/ tests/integration/api/ -m "not slow and not requires_api" --junitxml=pytest_report.xml -v --timeout=900 --timeout-method=thread
 
       - name: Generate test summary
         if: always()

--- a/tests/integration/api/test_openapi_contract.py
+++ b/tests/integration/api/test_openapi_contract.py
@@ -4,6 +4,7 @@ Boots the FastAPI app (with JPype mocked), fetches /openapi.json, and diffs
 against the committed snapshot. Fails on removed paths or changed required
 params. Additions are allowed (non-breaking).
 """
+
 import json
 import os
 import sys
@@ -11,22 +12,44 @@ import unittest.mock as m
 
 import pytest
 
-# Mock JPype and heavy NLP libs before any API imports
+# #1816: these stubs exist only so the app boots without a live JVM during
+# the imports below. They were bare `sys.modules.setdefault` calls at module
+# level with no restore, so the mere collection of this file leaked MagicMock
+# "spacy"/"jpype" entries into sys.modules for the whole session — any later
+# `from spacy.matcher import ...` then failed, reddening three tests in
+# tests/unit (see #1816). Two fixes:
+#   - spacy needs no stub at all: it is a real dependency (environment.yml)
+#     and nothing under api/ references it directly — the real module
+#     imports fine;
+#   - the JVM stubs stay (the app must boot JVM-less) but live in an
+#     install/import/restore window: sys.modules is snapshotted before the
+#     imports and restored after, the same pattern as
+#     test_argumentation_analyzer.py and test_flask_service_integration.py.
 _jpype_mock = m.MagicMock()
 _jpype_mock.isJVMStarted = m.MagicMock(return_value=False)
-sys.modules.setdefault("jpype", _jpype_mock)
-sys.modules.setdefault("jpype._core", m.MagicMock())
-sys.modules.setdefault("jpype.imports", m.MagicMock())
-sys.modules.setdefault("jpype.types", m.MagicMock())
-sys.modules.setdefault("argumentation_analysis.core.bootstrap", m.MagicMock())
-sys.modules.setdefault("spacy", m.MagicMock())
-sys.modules.setdefault("spacy.tokens", m.MagicMock())
-sys.modules.setdefault("spacy.language", m.MagicMock())
+_JVM_STUBS = {
+    "jpype": _jpype_mock,
+    "jpype._core": m.MagicMock(),
+    "jpype.imports": m.MagicMock(),
+    "jpype.types": m.MagicMock(),
+    "argumentation_analysis.core.bootstrap": m.MagicMock(),
+}
+
+_stubs_saved = {name: sys.modules.get(name) for name in _JVM_STUBS}
+for name, stub in _JVM_STUBS.items():
+    sys.modules.setdefault(name, stub)
 
 from fastapi.testclient import TestClient
 
 from api.factory import create_app
 from api.endpoints import router as api_router, framework_router, informal_router
+
+# Restore sys.modules — nothing this module injected leaks past its imports.
+for name, saved in _stubs_saved.items():
+    if saved is None:
+        sys.modules.pop(name, None)
+    else:
+        sys.modules[name] = saved
 
 _PROJECT_ROOT = os.path.normpath(
     os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "..")
@@ -109,21 +132,22 @@ class TestOpenAPIContract:
             for method, details in methods.items():
                 if "parameters" not in details:
                     continue
-                live_details = (
-                    live_spec.get("paths", {}).get(path, {}).get(method, {})
-                )
+                live_details = live_spec.get("paths", {}).get(path, {}).get(method, {})
                 live_params = {
-                    p.get("name"): p
-                    for p in live_details.get("parameters", [])
+                    p.get("name"): p for p in live_details.get("parameters", [])
                 }
                 for param in details["parameters"]:
                     if not param.get("required", False):
                         continue
                     name = param.get("name")
                     if name not in live_params:
-                        errors.append(f"Removed required param '{name}' in {method.upper()} {path}")
+                        errors.append(
+                            f"Removed required param '{name}' in {method.upper()} {path}"
+                        )
                     elif not live_params[name].get("required", False):
-                        errors.append(f"Required param '{name}' became optional in {method.upper()} {path}")
+                        errors.append(
+                            f"Required param '{name}' became optional in {method.upper()} {path}"
+                        )
         assert not errors, f"Breaking param changes: {errors}"
 
     def test_no_removed_request_body_fields(self, live_spec, snapshot_spec):
@@ -134,9 +158,7 @@ class TestOpenAPIContract:
                 snap_body = details.get("requestBody")
                 if not snap_body:
                     continue
-                live_details = (
-                    live_spec.get("paths", {}).get(path, {}).get(method, {})
-                )
+                live_details = live_spec.get("paths", {}).get(path, {}).get(method, {})
                 live_body = live_details.get("requestBody")
                 if not live_body:
                     errors.append(f"Removed request body in {method.upper()} {path}")


### PR DESCRIPTION
# Fix + census + readmission — #1816

## Le fix (couche propriétaire)

`tests/integration/api/test_openapi_contract.py` installait 8 `sys.modules.setdefault`
au niveau module — à la **collection** — sans jamais restaurer :

- **stubs spacy (×3) : supprimés.** spacy est une dépendance réelle (environment.yml:20)
  et rien sous `api/` ne le référence directement (grep : 0 match). Le vrai module
  s'importe ; les 3 victimes l'utilisent déjà avec succès sur main.
- **stubs JVM + bootstrap (×5) : conservés mais fenêtrés.** L'app doit booter sans JVM
  vivante — les stubs restent nécessaires — mais vivent maintenant dans une fenêtre
  snapshot/install/restore autour des imports `api.factory`/`api.endpoints` :
  `sys.modules` est restauré dès la fin des imports du module. C'est le pattern que
  deux frères unitaires appliquent déjà (`test_argumentation_analyzer.py:35-62`,
  `test_flask_service_integration.py:18-36`) — le fautif était l'exception qui y
  avait échappé.

## Preuve locale (clé ambiante factice, filtre gate)

| Étape | Commande (ordre argv préservé) | Résultat |
|---|---|---|
| Baseline | 3 fichiers victimes seuls | **77 passed, 1 skipped** — victimes vertes |
| AVANT (fautif main) | `tests/integration/api` en tête + victimes | **3 failed** — exactement les 3 victimes nommées (run CI 32290039420 reproduit à l'identique) |
| APRÈS (ce fix) | même argv | **83 passed, 0 failed** — les 3 victimes revenues à leur état baseline |

## Le contrôle qui décide : readmission en position

`tests/integration/api/` readmis dans l'argv du gate (ci.yml, après `workers/`).
La lane des 2 tests `requires_api` du subdir (`deliberation_genuine_verdict`,
`websocket_deliberation_genuine`) est déjà couverte par `integration-rest`
(`tests/integration` moins 2 ignores) — pas d'orphelin créé, pas de double-comptage
(#1592 twin-lists).

Run local pleine échelle (argv gate 15 dirs + api, clé factice, `.env` parké) :
**53 failed / 14586 passed / 270 skipped / 323 deselected** (10:35) — les 53 sont les
familles locales connues (CB-1528/1531/1560 ~34, profile_spectacular 10,
llm_service_extended 3, speech_env_url 1, delegation 1, proof_bo2b 2, compare_modes 2) ;
**aucune failure après argv-position 9** → rien dans tests/integration/api ni dans les
integration/* du gate.

**Contrôle d'attribution (le différentiel qui décide)** — même argv, avec vs sans api :

| Run | Résultat |
|---|---|
| `tests/integration/api` + arbre `tests/unit/argumentation_analysis` + délégation | **16 failed / 12967 passed** |
| arbre + délégation seuls (sans api) | **16 failed / 12961 passed** |
| `comm -13` des listes FAILED triées | **vide — zéro rouge imputable au diff** |

api en session ajoute exactement **+6 passés** (les 6 tests openapi), 0 nouveau rouge ;
les **3 victimes spacy sont vertes dans le run où api est présent**.

Egress : l'api subtree contribue **0 requête LLM** (run restreint avec contre-témoin vivant :
l'unique requête observée vient du lecteur ambient connu, 0 des tests api ; run pleine
échelle : 0 watched-LLM). Le critère `llm 4` du gate se mesure sur le run CI de cette PR
(référence main : run 32291458743, 14598 passed / 268 skipped).

## Census — tous les sites `sys.modules.setdefault(` / `sys.modules[...] =` dans tests/

### Le fautif (seul site actif non restauré polluant des modules réels)

| Site | Niveau | Restauré | Verdict |
|---|---|---|---|
| `tests/integration/api/test_openapi_contract.py:17-24` (8 setdefault : jpype ×4, bootstrap, spacy ×3) | module (= collection) | NON | **La fuite #1816** — 3 victimes prouvées CI (run 32290039420) |

### Frères au pattern correct (le précédent que le fix adopte)

| Site | Niveau | Restauré |
|---|---|---|
| `tests/unit/argumentation_analysis/core/test_argumentation_analyzer.py:35-38` | module (fenêtre d'import) | OUI (restore/pop l.48-62) |
| `tests/unit/argumentation_analysis/services/test_flask_service_integration.py:18-19` | module (fenêtre d'import) | OUI (restore/pop l.29-36) |

### Frères actifs mais by-design (aucune fuite)

| Site | Niveau | Restauré | Raison d'inoffensivité |
|---|---|---|---|
| `tests/conftest.py:101-102` (jpype) | module | NON | Conditionnel `--disable-jvm-session` (E2E opt-in) — le gate ne passe jamais le flag |
| `tests/unit/.../execution/test_execution_strategies.py:47` (torch) | module via `_ensure_importable()` | NON | Ne s'arme QUE si `import torch` échoue (DLL crash) — fallback en env déjà dégradé |
| `tests/unit/.../test_fallacy_comparison_3way_569.py:24` (`compare`) | fonction | NON | Clé synthétique — aucun autre importeur du nom |
| `tests/scripts/test_extract_belief_trajectories_1489.py:46`, `_1491.py:47,60`, `test_proof_bo2b_dashboard_1493.py:55` | helper/fixture | pop si échec | Clés synthétiques (scripts chargés par file path) — aucune victime plausible |
| `tests/unit/.../test_mcp_server_jvm_guard_1677.py:112-113,180,194-195` | sonde embarquée | N/A | Faux positifs du grep : code exécuté en subprocess isolé (« teardown is exit ») |
| `tests/unit/mocks/test_numpy_mock.py:74-138` | méthodes de test | OUI (l.114-138) | Test DU mock — install + restore explicites |
| `tests/unit/.../quality/test_quality_virtue_detectors.py:276` | teardown | c'est le restore | Écriture de `_torch_before` |

### Frères latents — infra `tests/mocks/`, aucun importeur collecté aujourd'hui

| Site | Niveau | Situation |
|---|---|---|
| `tests/mocks/jpype_setup.py:134-168` | hook sessionstart | INFRA session-wide by design (`USE_REAL_JPYPE`) — sujet #1813 (po-2023) |
| `tests/mocks/bootstrap.py:42-56` | fonction | INFRA obsolète (integration_fixtures.py:47) — plus importée |
| `tests/mocks/networkx_mock.py:422-435` | module (self-install `sys.modules["networkx"] = lui-même`) | **Latent** : remplacerait networkx process-wide si un test collecté l'importait — grep : aucun importeur aujourd'hui |
| `tests/mocks/pytest_mock.py:41` (`sys.modules["pytest"] = MockPytest()`) | module (self-install) | **Latent** : remplacerait pytest lui-même — aucun importeur collecté |
| `tests/mocks/numpy_setup.py` | fixture/marqueur | INFRA avec restore (l.92,162) |
| `tests/mocks/pandas_setup.py:69-77` | fonction | INFRA — swap seulement si pandas absent/3.12+ |
| `tests/mocks/jpype_components/imports.py:50` | fonction | INFRA composant du mock jpype |

**Conclusion census** : 1 seul site fautif actif. Les 2 frères unitaires prouvent que le
pattern correct existait déjà — le fautif y a échappé. Les 2 latents (`networkx_mock`,
`pytest_mock`, self-install au niveau module) mériteraient une garde ou un archivage —
hors scope #1816, signalés pour arbitrage.

## Anti-pendule (conforme au dispatch)

- Pas de retrait d'`api` de l'argv : il y est **readmis**, pas retiré.
- Pas de `skipif spacy` sur les victimes : elles sont légitimement vertes, la source est soignée.
- Pas de remplacement de `setdefault` par affectation directe : la fenêtre restore les deux.
- spacy réel vérifié présent (environment.yml) → les stubs spacy sont **supprimés**, pas fenêtrés.

Refs #1816 · #1814 · #1785 · #1592. Opaque IDs only — aucune donnée dataset.
