### PR TITLE
fix(tests): gpt4o script stops seeding env at import — load_dotenv moves to main() (#1817)

### DIFF
--- a/tests/integration/test_authenticite_finale_gpt4o.py
+++ b/tests/integration/test_authenticite_finale_gpt4o.py
@@ -18,8 +18,12 @@ from typing import Dict, List, Any, Optional
 import logging
 from dotenv import load_dotenv
 
-# Charger les variables d'environnement depuis .env
-load_dotenv()
+# #1794/#1817: pas de load_dotenv() à l'import — ce fichier matche test_*.py,
+# donc toute bande qui collecte tests/integration l'importe ; le chargement
+# d'un .env local à ce moment semait la vraie clé dans os.environ pour toute
+# la session. Le fichier est un script (pytest collecte 0 test : la classe
+# est AuthenticAPITester, pas Test*) : le chargement vit dans son point
+# d'entrée main(), ci-dessous.
 
 # Configuration logging
 logging.basicConfig(
@@ -293,6 +297,9 @@ def main():
     print("TEST D'AUTHENTICITE FINALE - GPT-4O-MINI")
     print("Preuves d'appels API réels avec données synthétiques")
     print("=" * 60)
+
+    # L'env se charge ici, au point d'entrée du script — jamais à l'import.
+    load_dotenv()
 
     tester = AuthenticAPITester()
 

--- a/tests/integration/test_import_does_not_seed_env.py
+++ b/tests/integration/test_import_does_not_seed_env.py
@@ -1,0 +1,68 @@
+"""Contrôle #1794/#1817 : l'import d'un fichier test_*.py ne doit pas semer os.environ.
+
+Toute bande qui collecte ``tests/integration`` importe chaque ``test_*.py`` ;
+un ``load_dotenv()`` au niveau module d'un de ces fichiers charge alors le
+``.env`` local dans l'environnement du process pour toute la session pytest ;
+la clé réelle devient lisible par chaque test qui suit. C'est la victime
+canonique : ``test_authenticite_finale_gpt4o.py`` (script — pytest n'y
+collecte aucun test, mais l'importe quand même).
+"""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+VICTIM = REPO_ROOT / "tests" / "integration" / "test_authenticite_finale_gpt4o.py"
+
+# La sonde vit dans un subprocess à environnement MINIMAL : le process pytest
+# a typiquement déjà chargé le .env (conftest / plugin dotenv), et un
+# subprocess héritier repartirait d'un os.environ déjà saturé — la fuite
+# serait invisible. Env réduit au strict nécessaire Windows + cwd = racine du
+# dépôt pour que l'éventuel load_dotenv() de la victime trouve le vrai .env —
+# c'est le chemin de la fuite. Seuls les NOMS de clés remontent, jamais les
+# valeurs.
+_PROBE = """
+import importlib.util, json, os
+before = dict(os.environ)
+spec = importlib.util.spec_from_file_location("authenticite_victim", {victim!r})
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+after = dict(os.environ)
+gained = sorted(k for k in after if before.get(k) != after[k])
+print("GAINED:" + json.dumps(gained))
+"""
+
+_CHILD_ENV = {
+    k: os.environ[k]
+    for k in ("SYSTEMROOT", "SYSTEMDRIVE", "TEMP", "TMP", "COMSPEC")
+    if k in os.environ
+}
+
+
+def test_import_of_test_module_does_not_seed_os_environ():
+    result = subprocess.run(
+        [sys.executable, "-c", _PROBE.format(victim=str(VICTIM))],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        env=_CHILD_ENV,
+        timeout=120,
+    )
+    marker = next(
+        (line for line in result.stdout.splitlines() if line.startswith("GAINED:")),
+        None,
+    )
+    assert marker is not None, (
+        "la sonde n'a pas rendu son bilan — "
+        f"returncode={result.returncode} "
+        f"stdout={result.stdout[-500:]!r} stderr={result.stderr[-500:]!r}"
+    )
+    gained = json.loads(marker[len("GAINED:") :])
+    assert gained == [], (
+        f"l'import a semé os.environ : {gained} — un load_dotenv() au niveau "
+        "module d'un fichier test_*.py charge le .env local pour toute la "
+        "session (#1794/#1817)"
+    )


### PR DESCRIPTION
## Summary

The one surviving piece of #1817 after #1822 (merged `5ae2fa5a`) — see #1819's closing comment for the full supersession story.

`tests/integration/test_authenticite_finale_gpt4o.py:22` still runs `load_dotenv()` at module level on main. The file matches `test_*.py`, so **any band collecting `tests/integration` imports it** — and the import seeds the real key into `os.environ` for the whole session (the #1794 pattern, same family as the invoke_callables polluter). #1822 called the file a "ghost" (0 tests collected — true) and left the env seeding as "cleanup-gate territory"; this PR fixes the seeding without renaming anything.

- `load_dotenv()` moved into `main()`, the script's actual entry point
- module-level call replaced by a comment naming the pattern
- nothing else changes; the 0-tests-collected status is untouched

## Control (this branch, projet-is-roo-new)

`.env` parked, no ambient key, `os.environ.pop("OPENAI_API_KEY")`, then `import tests.integration.test_authenticite_finale_gpt4o`:

```
IMPORT-SEED CHECK: PASS - import seeds nothing
```

Before the fix the same import seeded the key (that seeding is how the #1817 family was originally found in R835's egress tracing).

## Test plan

- [ ] CI green (file is not in the gate argv and collects 0 tests — delta 0 expected)

Refs #1817 · #1794 · #1822 · #1819