### PR TITLE
fix(orchestration): the registry summary counts all three populations and moves after the last registration (#1748)

### DIFF
--- a/argumentation_analysis/orchestration/registry_setup.py
+++ b/argumentation_analysis/orchestration/registry_setup.py
@@ -89,6 +89,7 @@ def setup_registry(
     """
     registry = CapabilityRegistry()
     registered = []
+    slots_declared = []
     skipped = []
 
     # --- Core agents (always available) ---
@@ -353,7 +354,10 @@ def setup_registry(
             skipped.append(("speech_transcription_service", str(e)))
 
     # --- Declare unfilled slots for future Tweety extensions ---
-    _declare_tweety_slots(registry)
+    tweety_registered, tweety_slots, tweety_skipped = _declare_tweety_slots(registry)
+    registered.extend(tweety_registered)
+    slots_declared.extend(tweety_slots)
+    skipped.extend(tweety_skipped)
 
     # --- TweetyLogicPlugin: SK wrapper for all handlers (#91) ---
     try:
@@ -692,13 +696,6 @@ def setup_registry(
     except ImportError as e:
         skipped.append(("collaborative_debate_service", str(e)))
 
-    logger.info(
-        f"Registry setup complete: {len(registered)} registered, "
-        f"{len(skipped)} skipped"
-    )
-    if skipped:
-        logger.debug(f"Skipped components: {[s[0] for s in skipped]}")
-
     # Deep synthesis service (#532)
     try:
         registry.register_service(
@@ -758,11 +755,32 @@ def setup_registry(
     except Exception as e:
         skipped.append(("ai_shield_service", str(e)))
 
+    # Bilan en fin de fonction : il doit suivre la DERNIÈRE inscription, sinon
+    # les blocs ci-dessus s'ajoutent à un compte déjà journalisé (#1748). Trois
+    # populations, pas deux : un handler Tweety dont l'inscription échoue est
+    # déclaré absent (slot), pas silencieux — 37/0 était invariant à travers
+    # cette distinction (#1019).
+    logger.info(
+        f"Registry setup complete: {len(registered)} registered, "
+        f"{len(slots_declared)} declared-absent slots, {len(skipped)} skipped"
+    )
+    if slots_declared:
+        logger.debug(f"Declared-absent capability slots: {slots_declared}")
+    if skipped:
+        logger.debug(f"Skipped components: {[s[0] for s in skipped]}")
+
     return registry
 
 
-def _declare_tweety_slots(registry: CapabilityRegistry) -> None:
-    """Register Tweety handler capabilities (Track A #55-#62, #85-#86)."""
+def _declare_tweety_slots(
+    registry: CapabilityRegistry,
+) -> tuple[list, list, list]:
+    """Register Tweety handler capabilities (Track A #55-#62, #85-#86).
+
+    Returns its own tally to merge into the setup summary (#1748):
+    (registered handler names, declared-absent capability slots,
+    (name, reason) for handlers where even slot declaration failed).
+    """
     tweety_handlers = [
         (
             "ranking_semantics_handler",
@@ -871,6 +889,9 @@ def _declare_tweety_slots(registry: CapabilityRegistry) -> None:
             _invoke_asp_reasoning,
         ),
     ]
+    registered: list = []
+    slots_declared: list = []
+    skipped: list = []
     for name, caps, desc, invoke_fn in tweety_handlers:
         try:
             registry.register_service(
@@ -880,8 +901,18 @@ def _declare_tweety_slots(registry: CapabilityRegistry) -> None:
                 metadata={"description": desc, "requires": ["jvm"]},
                 invoke=invoke_fn,
             )
+            registered.append(name)
         except Exception as e:
             logger.debug(f"Tweety handler {name} registration deferred: {e}")
-            # Fall back to slot declaration if JVM not available
+            # Fall back to slot declaration if registration failed: the
+            # capability is known but declared absent, not silently missing.
+            slot_error = None
             for cap in caps:
-                registry.declare_slot(cap, requires=["jvm"], description=desc)
+                try:
+                    registry.declare_slot(cap, requires=["jvm"], description=desc)
+                    slots_declared.append(cap)
+                except Exception as declare_err:
+                    slot_error = declare_err
+            if slot_error is not None:
+                skipped.append((name, str(slot_error)))
+    return registered, slots_declared, skipped

--- a/argumentation_analysis/orchestration/registry_setup.py
+++ b/argumentation_analysis/orchestration/registry_setup.py
@@ -7,7 +7,7 @@ Split from unified_pipeline.py (#310).
 """
 
 import logging
-from typing import Dict, Any
+from typing import Dict, Any, List, Tuple
 
 from argumentation_analysis.core.capability_registry import (
     CapabilityRegistry,
@@ -774,7 +774,7 @@ def setup_registry(
 
 def _declare_tweety_slots(
     registry: CapabilityRegistry,
-) -> tuple[list, list, list]:
+) -> tuple[List[str], List[str], List[Tuple[str, str]]]:
     """Register Tweety handler capabilities (Track A #55-#62, #85-#86).
 
     Returns its own tally to merge into the setup summary (#1748):
@@ -889,9 +889,9 @@ def _declare_tweety_slots(
             _invoke_asp_reasoning,
         ),
     ]
-    registered: list = []
-    slots_declared: list = []
-    skipped: list = []
+    registered: List[str] = []
+    slots_declared: List[str] = []
+    skipped: List[Tuple[str, str]] = []
     for name, caps, desc, invoke_fn in tweety_handlers:
         try:
             registry.register_service(

--- a/tests/unit/argumentation_analysis/orchestration/test_registry_setup_tally_1748.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_registry_setup_tally_1748.py
@@ -1,0 +1,137 @@
+"""#1748 — le bilan de setup_registry doit être honnête et sensible au monde.
+
+Trois propriétés, chacune par substitution dégénérée (on force le mécanisme,
+pas l'environnement) :
+
+1. **égalité annoncé == réel** : le compte journalisé doit égaler les
+   inscriptions effectivement passées au registre — la propriété est
+   l'égalité, jamais la constante (57 bougera au prochain composant).
+2. **le bilan sépare les mondes** : quand l'inscription des handlers Tweety
+   échoue, ils doivent apparaître en *declared-absent slots*, et la ligne de
+   bilan doit **changer**. L'ancien format (`37 registered, 0 skipped`) était
+   invariant à travers ces deux états opposés du système (#1019).
+3. **l'échec total est visible** : un handler dont même la déclaration de
+   slot échoue doit atterrir dans `skipped`, au complet.
+"""
+
+import logging
+import re
+from unittest import mock
+
+from argumentation_analysis.core.capability_registry import CapabilityRegistry
+from argumentation_analysis.orchestration import registry_setup
+
+SUMMARY_RE = re.compile(
+    r"Registry setup complete: (\d+) registered, "
+    r"(\d+) declared-absent slots, "
+    r"(\d+) skipped"
+)
+
+
+class _CountingRegistry(CapabilityRegistry):
+    """Compte chaque inscription réussie au point de passage unique."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.made = []
+
+    def register(self, *args, **kwargs):
+        registration = super().register(*args, **kwargs)
+        self.made.append(registration.name)
+        return registration
+
+
+def _tweety_handler_names():
+    """Noms des handlers lus sur le producteur — suit les ajouts futurs."""
+    recorder = _CountingRegistry()
+    registry_setup._declare_tweety_slots(recorder)
+    return set(recorder.made)
+
+
+def _last_summary(caplog):
+    line = None
+    for record in caplog.records:
+        if record.getMessage().startswith("Registry setup complete"):
+            line = record.getMessage()
+    assert line is not None, "setup_registry n'a pas émis sa ligne de bilan"
+    match = SUMMARY_RE.fullmatch(line)
+    assert match is not None, f"bilan pas au format 3 populations : {line!r}"
+    return tuple(int(group) for group in match.groups())
+
+
+def _run_setup(caplog):
+    caplog.clear()
+    with caplog.at_level(logging.INFO, logger="UnifiedPipeline"):
+        registry = registry_setup.setup_registry()
+    return registry, _last_summary(caplog)
+
+
+def test_announced_registered_equals_actual_registrations(caplog):
+    with mock.patch.object(registry_setup, "CapabilityRegistry", _CountingRegistry):
+        registry, summary = _run_setup(caplog)
+
+    announced_registered, announced_slots, _ = summary
+    assert announced_registered == len(registry.made)
+    assert announced_registered == len(registry._registrations)
+    assert announced_slots == len(registry._slots)
+    # La garde du ticket : les handlers Tweety comptent dans le bilan annoncé.
+    tweety_names = _tweety_handler_names()
+    assert tweety_names
+    assert tweety_names <= set(registry.made)
+
+
+def test_summary_separates_tweety_registered_from_declared_absent(caplog):
+    tweety_names = _tweety_handler_names()
+
+    class SlotWorldRegistry(_CountingRegistry):
+        def register(self, *args, **kwargs):
+            name = kwargs.get("name", args[0] if args else None)
+            if name in tweety_names:
+                raise RuntimeError(f"forced register failure for {name} (#1748)")
+            return super().register(*args, **kwargs)
+
+    _, world_registered = _run_setup(caplog)
+    with mock.patch.object(registry_setup, "CapabilityRegistry", SlotWorldRegistry):
+        registry_slots, world_absent = _run_setup(caplog)
+
+    reg_a, slots_a, _ = world_registered
+    reg_b, slots_b, _ = world_absent
+    assert reg_b < reg_a, (
+        f"le bilan n'a pas bougé quand les handlers formels sont absents : "
+        f"{reg_b} registered dans les deux mondes (#1019)"
+    )
+    assert slots_b > slots_a
+    # Le compte annoncé de slots est celui réellement stocké.
+    assert slots_b == len(registry_slots._slots)
+    assert tweety_names.isdisjoint(registry_slots.made)
+
+
+def test_handler_where_slot_declaration_also_fails_lands_in_skipped(caplog):
+    tweety_names = _tweety_handler_names()
+    normal_registry, _ = _run_setup(caplog)
+    tweety_capabilities = set()
+    for name in tweety_names:
+        registration = normal_registry._registrations.get(name)
+        assert registration is not None, f"handler {name} absent du monde normal"
+        tweety_capabilities.update(registration.capabilities)
+
+    class DoomWorldRegistry(_CountingRegistry):
+        def register(self, *args, **kwargs):
+            name = kwargs.get("name", args[0] if args else None)
+            if name in tweety_names:
+                raise RuntimeError(f"forced register failure for {name} (#1748)")
+            return super().register(*args, **kwargs)
+
+        def declare_slot(self, *args, **kwargs):
+            name = kwargs.get("name", args[0] if args else None)
+            if name in tweety_capabilities:
+                raise RuntimeError(f"forced slot failure for {name} (#1748)")
+            return super().declare_slot(*args, **kwargs)
+
+    with mock.patch.object(registry_setup, "CapabilityRegistry", DoomWorldRegistry):
+        registry_doom, world_doom = _run_setup(caplog)
+
+    reg_doom, slots_doom, skipped_doom = world_doom
+    assert skipped_doom == len(tweety_names)
+    assert slots_doom == 0
+    assert reg_doom == len(registry_doom.made)


### PR DESCRIPTION
## #1748 — le bilan compte les trois populations, et il bouge quand le monde change

### Le fix (arithmétique + placement)

- `setup_registry` journalisait `37 registered, 0 skipped` à la ligne 695, **trois blocs d'inscription avant le `return`** — le bilan est déplacé juste avant le `return`.
- `_declare_tweety_slots(registry)` ne recevait pas les listes de tally → ses 17 handlers n'incrémentaient jamais le compteur. Il retourne désormais son propre bilan à fusionner : `(registered, slots_declared, skipped)`.
- Un handler dont l'inscription échoue déclare ses capacités en **slots** (déclarées absentes, visibles) ; un handler dont même la déclaration de slot échoue atterrit dans `skipped`, nommément.

### Le vrai défaut corrigé : l'invariance (#1019)

L'ancienne ligne était invariante à travers deux états opposés du système — machine où les 17 handlers formels s'inscrivent vs machine où ils basculent en slots déclarés absents : même `37 registered, 0 skipped` des deux côtés. Nouveau format :

```
Registry setup complete: 57 registered, 0 declared-absent slots, 0 skipped
```

(mesuré sur ce run : 57 annoncé = 57 réels = 57 en stockage).

### Tests — 3 propriétés par substitution dégénérée, rouge-avant-fix démontré

`test_registry_setup_tally_1748.py` (3 failed sur le producteur d'origine, 3 passed après) :

1. **égalité annoncé == réel** — spy au point de passage unique `register()` : annoncé == appels réussis == `len(_registrations)`. Jamais la constante 57 (désarmée au premier composant ajouté). Les noms des handlers sont lus sur le producteur (`_declare_tweety_slots` contre un registre enregistreur), pas une liste parallèle.
2. **le bilan sépare les mondes** — échec d'inscription forcé pour les 17 handlers : `registered` baisse, `slots` monte, annoncé slots == slots stockés. Rouge sur l'ancien code, qui loggait la même ligne dans les deux mondes.
3. **l'échec total est visible** — inscription ET slot forcés en échec : `skipped == len(handlers)`, slots == 0.

### Régression

231 passed sur le voisinage (track_a_handlers, unified_pipeline, architecture_compliance + nouveaux). Les appelants existants de `_declare_tweety_slots` ignorent la valeur de retour (import seul ou mock) — signature compatible. Black clean.

### Sonde aval (le livrable au-delà du compteur)

Postée sur l'issue #1748 : résoluble 18/18, phases réellement exécutées COMPLETED avec résultats formels, surfaces de sélection nommées, + un trou adjacent découvert (message d'erreur ranking trompeur).
