### PR TITLE
test(timeouts): arm the per-test bound globally, parity for replay lane, and a bounded signature for the modal-consistency park (#1759)

### DIFF
--- a/.github/workflows/replay-llm-lane.yml
+++ b/.github/workflows/replay-llm-lane.yml
@@ -80,7 +80,12 @@ jobs:
           REPLAY_GATE: '1'
           REPLAY_STATS_OUT: replay_stats.json
         run: |
-          conda run -n projet-is --no-capture-output pytest ${{ inputs.lane_args }} --ignore=tests/unit/services/test_mcp_server_v2 -p scripts.cassettes.replay_stats_plugin -v --junitxml=pytest_report.xml
+          conda run -n projet-is --no-capture-output pytest ${{ inputs.lane_args }} --ignore=tests/unit/services/test_mcp_server_v2 -p scripts.cassettes.replay_stats_plugin -v --junitxml=pytest_report.xml --timeout=900 --timeout-method=thread
+          # #1759: this was the only pytest surface in CI without a per-test
+          # bound (step timeout-minutes: 30 kills the JOB, losing the report);
+          # --timeout=900 brings it to parity with the gate and every other
+          # lane. Same caveat as those: thread is the only method on Windows
+          # and aborts the run on fire — the dump in the log is the artifact.
 
       - name: Anti-vacuité gate (live==0, hit>=1, miss_replay==0)
         shell: pwsh

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,7 +2,17 @@
 testpaths = tests
 pythonpath = . src
 asyncio_mode = auto
-addopts = --ignore=tests/unit/api/test_analysis_service_mock.py
+# #1759: per-test bound armed globally (was CI-argv-only). Value = the CI
+# gate's own --timeout=900 (ci.yml), 9.5x above the measured unit-band max
+# (94.65s, test_communication_integration.py::test_request_response_communication,
+# 2026-08-20) — no legitimate test reddens. thread is the only method on
+# Windows: on fire it ABORTS the run with a full thread dump (the log, not the
+# junitxml, is the artifact). A test that legitimately needs longer gets
+# @pytest.mark.timeout(n); a CLI --timeout overrides this default. Bounds TEST
+# execution only — sessionstart hangs are #1813/#1820, and a NAMED red that
+# keeps the report alive is what the bounded-signature harness delivers
+# (tests/.../test_modal_consistency_bounded_signature.py).
+addopts = --ignore=tests/unit/api/test_analysis_service_mock.py --timeout=900 --timeout-method=thread
 markers =
     # Test categories
     unit: Tests unitaires isoles

--- a/tests/integration/argumentation_analysis/agents/core/logic/test_modal_consistency_bounded_signature.py
+++ b/tests/integration/argumentation_analysis/agents/core/logic/test_modal_consistency_bounded_signature.py
@@ -1,0 +1,135 @@
+"""#1759 — real arm of the bounded signature for modal consistency.
+
+The degenerate controls (blocking ⇒ named red fast, slow-but-correct ⇒ green)
+live in ``tests/unit/argumentation_analysis/agents/core/logic/
+test_modal_consistency_bounded_signature.py`` and prove the WRAPPER mechanism.
+This file points the same wrapper at the REAL end-to-end decision path —
+the one measured parking in #1783:
+
+    ModalLogicAgent._construct_modal_kb_from_json  (genuine builder, fp11 trick)
+    -> TweetyBridge.check_consistency
+    -> ModalHandler.is_modal_kb_consistent
+    -> SimpleMlReasoner.query  (TWEETY, pure-Java — runs on CI everywhere)
+
+Normally the query decides in well under a second: the test is GREEN and its
+assertions on the verdict hold. If the #1783 park (thread parked in GC inside
+``reasoner.query``) manifests, ``run_bounded`` raises ``QueryParked``: ONE named
+red in ≤ ``BOUNDED_S``, with the parked thread's stack — and, unlike
+``--timeout-method=thread``, the run and its junitxml survive. That is the
+bounded, reproducible signature the dispatch asked for: observing the blockage
+costs this single test, not a 20-min run killed by hand.
+
+Privacy HARD: synthetic propositions only (``rain``/``wet``). 0 corpus content.
+"""
+
+import logging
+import sys
+import threading
+import time
+import traceback
+
+import pytest
+
+from argumentation_analysis.core.config import settings, ModalSolverChoice
+from argumentation_analysis.core.jvm_setup import initialize_jvm
+from argumentation_analysis.agents.core.logic.modal_logic_agent import ModalLogicAgent
+from argumentation_analysis.agents.core.logic.tweety_bridge import TweetyBridge
+
+# Discriminating bound: a legitimate 2-formula decision is sub-second (even on
+# a cold JVM); anything holding longer than this is the parked shape, and the
+# bound is far below the lane's own --timeout=900 so the REPORT survives.
+BOUNDED_S = 120
+
+CONSISTENT_KB_JSON = {
+    "propositions": ["rain", "wet"],
+    "modal_formulas": ["[](rain => wet)", "rain"],
+}
+
+
+class QueryParked(AssertionError):
+    """Named red: the wrapped call did not return within its bound."""
+
+
+def run_bounded(fn, *, timeout_s, label):
+    """Same harness as the unit degenerate controls (kept self-contained —
+    cross-test-tree imports are fragile under differing rootdir configs)."""
+    outcome = {}
+
+    def _target():
+        try:
+            outcome["value"] = fn()
+        except BaseException as exc:  # diagnostic harness: capture everything
+            outcome["exc"] = exc
+
+    worker = threading.Thread(target=_target, daemon=True, name=f"bounded:{label}")
+    worker.start()
+    worker.join(timeout_s)
+    if worker.is_alive():
+        frame = sys._current_frames()[worker.ident]
+        stack = "".join(traceback.format_stack(frame))
+        raise QueryParked(
+            f"{label} did not return within {timeout_s}s (parked) — bounded "
+            f"signature #1759. Parked thread stack:\n{stack}"
+        )
+    if "exc" in outcome:
+        raise outcome["exc"]
+    return outcome["value"]
+
+
+@pytest.fixture(scope="module")
+def modal_bridge():
+    """Start the JVM (idempotent) once and build a real ``TweetyBridge``."""
+    initialize_jvm()
+    return TweetyBridge()
+
+
+@pytest.fixture(scope="module")
+def modal_kb_builder():
+    """``ModalLogicAgent`` stub running the genuine ``_construct_modal_kb_from_json``
+    code (``__new__`` bypasses the LLM-backed ``__init__`` the builder never
+    uses — the fp11 trick, see that file's docstring)."""
+    builder = ModalLogicAgent.__new__(ModalLogicAgent)
+    builder._agent_logger = logging.getLogger("BoundedSignatureKBBuilder")
+    return builder
+
+
+@pytest.fixture
+def tweety_solver():
+    """Force the pure-Java default — the always-available, always-deciding
+    modal path (no external binary). Pinning ``modal_solver`` alone is NOT
+    enough (#1339): when ``modal_prefer_spass_when_available`` is on and a
+    vendored SPASS binary is detected (local dev machines), the resolver
+    upgrades TWEETY to SPASS and the verdict message names "spass"."""
+    previous_solver = settings.modal_solver
+    previous_prefer = settings.modal_prefer_spass_when_available
+    settings.modal_solver = ModalSolverChoice.TWEETY
+    settings.modal_prefer_spass_when_available = False
+    try:
+        yield
+    finally:
+        settings.modal_solver = previous_solver
+        settings.modal_prefer_spass_when_available = previous_prefer
+
+
+class TestBoundedSignatureRealArm:
+    def test_consistent_kb_decides_within_bound(
+        self, modal_bridge, modal_kb_builder, tweety_solver
+    ):
+        """Lent-mais-correct ⇒ vert : le chemin réel décide sous la borne et le
+        verdict authentique (True, tweety) passe au travers du wrapper."""
+        kb = modal_kb_builder._construct_modal_kb_from_json(CONSISTENT_KB_JSON)
+        start = time.monotonic()
+        is_consistent, msg = run_bounded(
+            lambda: modal_bridge.check_consistency(kb, "K"),
+            timeout_s=BOUNDED_S,
+            label="check_consistency(K) -> is_modal_kb_consistent",
+        )
+        elapsed = time.monotonic() - start
+        assert is_consistent is True, (
+            f"Consistent modal KB must report consistent; "
+            f"got ({is_consistent!r}, {msg!r})."
+        )
+        assert "tweety" in msg.lower()
+        # The bound discriminates: green here means the decision returned on
+        # its own — never that the bound "passed" a parked call.
+        assert elapsed < BOUNDED_S

--- a/tests/unit/argumentation_analysis/agents/core/logic/test_modal_consistency_bounded_signature.py
+++ b/tests/unit/argumentation_analysis/agents/core/logic/test_modal_consistency_bounded_signature.py
@@ -1,0 +1,158 @@
+"""#1759 — bounded signature for ``ModalHandler.is_modal_kb_consistent``.
+
+Dispatch R835 volet 2. #1783 measured a whole-tree ``tests/integration`` run
+dying at ~48% with a thread parked in GC inside
+``modal_handler.py`` ``reasoner.query`` — and observing it costs a ~20 min run
+killed by hand. The probe posted on #1759 (issuecomment-5354806466) showed why
+``--timeout-method=thread`` (the only pytest-timeout method on Windows) is not
+the answer for a *named* red: it aborts the whole run, the junitxml is lost and
+subsequent tests never execute.
+
+This file carries the DEGENERATE CONTROLS for the bounded wrapper
+(``run_bounded``) used by the real-arm harness in
+``tests/integration/argumentation_analysis/agents/core/logic/
+test_modal_consistency_bounded_signature.py``:
+
+* a BLOCKING reasoner must convert into a NAMED failure in bounded time,
+  carrying the parked thread's stack (which names ``modal_handler.py``'s
+  ``reasoner.query`` frame — the measured park site), and
+* a SLOW-BUT-CORRECT reasoner must stay GREEN and return its real verdict.
+
+Both must hold, or the bound does not discriminate blocked from slow (#1759
+anti-pendule: 3 states, not 2). The wrapper OBSERVES the blockage — it does not
+repair it (the dispatch forbids "fixing" ``is_modal_kb_consistent`` here).
+"""
+
+import sys
+import threading
+import time
+import traceback
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+from argumentation_analysis.agents.core.logic import modal_handler as mh_module
+from argumentation_analysis.agents.core.logic.modal_handler import ModalHandler
+
+
+class QueryParked(AssertionError):
+    """Named red: the wrapped call did not return within its bound."""
+
+
+def run_bounded(fn, *, timeout_s, label):
+    """Run ``fn`` in a daemon thread; named-red if it outlives ``timeout_s``.
+
+    Returns ``fn``'s result, or re-raises its exception. If the worker is still
+    alive after ``timeout_s`` seconds, raises ``QueryParked`` carrying the
+    thread's CURRENT stack — the parked frame is the diagnostic. Unlike
+    pytest-timeout's thread method this fails ONE test by name and leaves the
+    run (and its report) alive: that is the point of the harness.
+    """
+    outcome = {}
+
+    def _target():
+        try:
+            outcome["value"] = fn()
+        except BaseException as exc:  # diagnostic harness: capture everything
+            outcome["exc"] = exc
+
+    worker = threading.Thread(target=_target, daemon=True, name=f"bounded:{label}")
+    worker.start()
+    worker.join(timeout_s)
+    if worker.is_alive():
+        frame = sys._current_frames()[worker.ident]
+        stack = "".join(traceback.format_stack(frame))
+        raise QueryParked(
+            f"{label} did not return within {timeout_s}s (parked) — bounded "
+            f"signature #1759. Parked thread stack:\n{stack}"
+        )
+    if "exc" in outcome:
+        raise outcome["exc"]
+    return outcome["value"]
+
+
+def _make_handler(monkeypatch, reasoner):
+    """Real ``ModalHandler`` over a stub initializer — no JVM needed.
+
+    The production path stays genuine up to the reasoner call: solver
+    resolution, normalization, StringReader/parseBeliefBase, contradiction
+    probe, then ``reasoner.query`` — the frame the wrapper's named red must
+    show when a reasoner blocks.
+    """
+    initializer = mock.MagicMock()
+    initializer.get_modal_parser.return_value = mock.MagicMock()
+    initializer.get_modal_reasoner.return_value = reasoner
+    handler = ModalHandler(initializer_instance=initializer)
+    monkeypatch.setattr(handler, "_get_active_reasoner", lambda: reasoner)
+    monkeypatch.setattr(
+        handler, "_build_contradiction_probe", lambda belief_set: object()
+    )
+    # modal_handler touches jpype.JClass for StringReader and catches
+    # jpype.JException; both are stubbed at the MODULE's reference (scoped to
+    # modal_handler, restored by monkeypatch — never a global-module patch).
+    monkeypatch.setattr(
+        mh_module,
+        "jpype",
+        SimpleNamespace(
+            JClass=lambda name: lambda payload: (name, payload),
+            JException=type("JException", (Exception,), {}),
+        ),
+    )
+    return handler
+
+
+class TestBoundedWrapperDegenerateControls:
+    """Substitution dégénérée, the two cases the DoD demands."""
+
+    def test_blocking_query_converts_to_named_red_in_bounded_time(self, monkeypatch):
+        """Blocked ⇒ rouge NOMMÉ en temps court (pas un run tué à la main)."""
+
+        class BlockingReasoner:
+            def query(self, belief_set, formula):
+                time.sleep(600)  # degenerate blocker: never returns, never raises
+
+        handler = _make_handler(monkeypatch, BlockingReasoner())
+        start = time.monotonic()
+        with pytest.raises(QueryParked) as excinfo:
+            run_bounded(
+                lambda: handler.is_modal_kb_consistent("[](p => q) & p"),
+                timeout_s=3,
+                label="is_modal_kb_consistent",
+            )
+        elapsed = time.monotonic() - start
+        message = str(excinfo.value)
+        assert "is_modal_kb_consistent" in message
+        assert "did not return within 3s" in message
+        # Bounded: the red arrives in seconds, not after the blocker's 600s.
+        assert elapsed < 15
+        # The named red carries the parked stack, which names the production
+        # park site measured in #1783: modal_handler's reasoner.query call.
+        assert "modal_handler" in message
+        assert "reasoner.query" in message
+
+    def test_slow_but_correct_query_stays_green_and_decides(self, monkeypatch):
+        """Lent-mais-correct ⇒ VERT : la borne rend le verdict réel, pas un rouge."""
+
+        class SlowReasoner:
+            def query(self, belief_set, formula):
+                time.sleep(2.0)  # slow but terminates with a decision
+                return False  # does not entail contradiction -> consistent
+
+        handler = _make_handler(monkeypatch, SlowReasoner())
+        is_consistent, message = run_bounded(
+            lambda: handler.is_modal_kb_consistent("[](p => q) & p"),
+            timeout_s=30,
+            label="is_modal_kb_consistent",
+        )
+        assert is_consistent is True  # tri-state #1636: decided True, not None
+        assert "consistent" in message
+
+    def test_wrapper_propagates_the_real_exception(self):
+        """The harness re-raises fn's exception — it never swallows failures."""
+
+        def _boom():
+            raise ZeroDivisionError("boom")
+
+        with pytest.raises(ZeroDivisionError, match="boom"):
+            run_bounded(_boom, timeout_s=5, label="boom")


### PR DESCRIPTION
## Summary

Closes #1759 (dispatch R835). Three layers, each grounded in a measurement:

1. **`pytest.ini` — the per-test bound is now armed globally** (`--timeout=900 --timeout-method=thread` in `addopts`). It was CI-argv-only: every local run was unbounded — the ticket's firsthand pain (pend ≥ 12 min, no indication of which test).
2. **`replay-llm-lane.yml` — parity**: the only pytest surface in CI without a per-test bound (its 30-min `timeout-minutes` killed the JOB and lost the report) now carries the same flags as the gate and every other lane.
3. **Bounded signature for the #1783 park** — `run_bounded` wraps the real modal-consistency decision path in a daemon thread with `join(timeout)`. A parked `reasoner.query` fails ONE test by name, in bounded time, with the parked thread's stack, while the run and its junitxml survive — the named red that `pytest-timeout`'s thread method (run-abort on fire, probe on the issue) cannot produce.

## Why 900s (the measurement line)

`tests/unit/ -m "not slow and not requires_api" --durations=40`, 2026-08-20, 664.86s wall, 14227 P / 263 S / 18 known local-only failures (llm_service_extended ×3, profile_spectacular ×10, compare ×5 — CI-green families; CI is the authority):

| # | Durée | Test |
|---|---|---|
| 1 | **94.65s** | `test_communication_integration.py::test_request_response_communication` |
| 2 | 28.52s | `test_api_direct_simple.py::test_api_startup_and_basic_functionality` |
| 3 | 26.49s | `test_1804_config_reload_isolation_guard.py::test_pair_fol_config_then_invoke_modal_green` |
| 4 | 23.49s | `test_proposal_api.py::TestDeliberation::test_start_deliberation` |
| 5 | 14.52s | `test_jtms_fastapi_mount.py::TestJTMSRouterMount::test_sessions_get_route` |
| 6 | 13.97s | `test_bipolar_jvm_guard_1677.py::test_honest_absent_reachable_without_jpype` |
| 7 | 13.10s | `test_no_naked_middleware_in_production_1574.py::...::test_no_bare_messagemiddleware_ctor_in_package` |
| 8 | 12.06s | `test_backend_manager.py::test_start_all_ports_occupied` |
| 9 | 11.67s | `test_run_orchestration.py::TestRunOrchestrationCLI::test_list_workflows_no_import_error` |
| 10 | 10.72s | `test_communication_integration.py::test_async_request_response` |
| 11 | 10.42s | `test_e2e_syspath_depth_guard.py::test_e2e_module_puts_repo_root_on_sys_path_not_tests[...]` |
| 12 | 10.06s | `test_mcp_server_jvm_guard_1677.py::test_mcp_server_boots_degraded_without_jpype` |
| 13 | 10.01s | `test_conversation_orchestrator_real.py::TestRealModeExecution::test_agent_timeout_handled` |
| 14 | 9.23s | `test_run_orchestration.py::TestRunOrchestrationCLI::test_help_flag_works` |
| 15 | 8.72s | `test_run_orchestration.py::TestRunOrchestrationCLI::test_render_restitution_flag_advertised` |
| 16 | 8.71s | `test_architecture_compliance.py::TestPluginCompliance::test_french_fallacy_plugin_has_kernel_functions` |
| 17 | 7.75s | `test_communication_integration.py::test_end_to_end_workflow` |
| 18 | 7.42s | `test_shell.py::test_run_command_with_custom_pythonpath` |
| 19 | 6.28s | `test_mcp_server_jvm_guard_1677.py::test_main_guard_binds_jpype_none_isolated` |
| 20 | 6.19s | `test_backend_manager.py::test_start_fails_if_wait_fails` |
| 21-40 | ≤ 5.2s | (spacy restored subrules, network_utils ×3, fetch tika timeout, lazy imports, semantic index, benchmarks...) |

**Anti-pendule control (DoD)**: the slowest legit test of the band — `test_request_response_communication`, **94.65s** — passes with 9.5× headroom under 900s. No legitimate test reddens. Escape hatch: `@pytest.mark.timeout(n)` per test; a CLI `--timeout` overrides the default. Sessionstart hangs (#1813) and the E2E decision (#1820) are out of scope of a test timeout — separate lanes.

## Bounded signature — executed controls

| Control | Result |
|---|---|
| Blocking reasoner stub (degenerate substitution) | **named red in ~3s** — `QueryParked` carrying the parked stack, which names `modal_handler.py`'s `reasoner.query` frame (the #1783 park site) |
| Slow-but-correct reasoner stub | **green**, real verdict (`True` + message) returned through the wrapper |
| Wrapper exception path | re-raises fn's own exception (never swallows) |
| Real arm (JVM live, genuine builder → `TweetyBridge.check_consistency` → `SimpleMlReasoner.query`) | **green in 4.8s**, decided `True`/`tweety` under the 120s bound |
| Surrounding band (`tests/unit/.../logic/` full subtree) | 408 passed / 0 failed |
| `pytest.ini` addopts sanity | small band green with injected bound; CLI `--timeout=60` override parses |
| Egress during all runs | `llm 4` — the counter's own liveness self-tests, the post-#1807 reference |

Side-finding (NOT fixed here — fp11's lane): `tests/.../test_fp11_modal_kb_roundtrip.py`'s `tweety_solver` fixture pins `modal_solver=TWEETY` but not `modal_prefer_spass_when_available`; on a machine with the vendored SPASS binary, #1339's resolver upgrades to SPASS and fp11's `"tweety" in msg` assert fails while the verdict stays authentic. My fixture pins both (comment explains why).

## Files removed and why

None — no deletions (Cleanup Gate N/A).

## Test plan

- [x] Degenerate controls executed (blocking/lent/exception) — 3 passed
- [x] Real arm executed — 1 passed (4.8s)
- [x] `tests/unit/argumentation_analysis/agents/core/logic/` subtree — 408 P / 0 F
- [x] `black --check` + `flake8` clean on both new files
- [x] pytest.ini addopts validated (injected bound + CLI override)
- [ ] CI gate (expect: same counts as main + 3 unit tests; integration arm runs in the extended integration-rest lane, not the gate argv)

🤖 Worker po-2025 — dispatch R835 (#1759)
