### PR TITLE
fix(tests): the env-seed guard discovers its population — the gate-band brother goes lazy

### DIFF
--- a/tests/integration/test_import_does_not_seed_env.py
+++ b/tests/integration/test_import_does_not_seed_env.py
@@ -1,33 +1,198 @@
-"""Contrôle #1794/#1817 : l'import d'un fichier test_*.py ne doit pas semer os.environ.
+"""Contrôle #1794/#1817/#1827 : aucun test_*.py ne sème os.environ à l'import.
 
-Toute bande qui collecte ``tests/integration`` importe chaque ``test_*.py`` ;
-un ``load_dotenv()`` au niveau module d'un de ces fichiers charge alors le
-``.env`` local dans l'environnement du process pour toute la session pytest ;
-la clé réelle devient lisible par chaque test qui suit. C'est la victime
-canonique : ``test_authenticite_finale_gpt4o.py`` (script — pytest n'y
-collecte aucun test, mais l'importe quand même).
+La population est DÉCOUVERTE, pas codée en dur (#1827) : un balayage AST sur
+tous les ``tests/**/test_*.py`` (hors ``_archived``) repère tout code exécutable
+au niveau module — corps du module et corps des ``if``/``try``/``with``/``for``
+de niveau module, récursivement, jamais l'intérieur d'un ``def``/``class``/``lambda``
+— qui appelle ``load_dotenv`` ou écrit dans ``os.environ``. Un futur semeur fait
+rougir ce contrôle sans édition.
+
+Trois rouges possibles :
+- parsing : un fichier illisible (BOM U+FEFF → lire en ``utf-8-sig``) serait
+  silencieusement hors population — faux zéro, le défaut même que ce contrôle
+  empêche. Le balayage compte ses échecs et rougit s'il y en a.
+- statique : un site semeur est listé (fichier:ligne) ;
+- dynamique : chaque semeur découvert est importé dans un subprocess à env
+  minimal, qui doit ne rien gagner — preuve d'exécution, pas de lecture.
+
+``conftest.py`` et les points d'entrée applicatifs ont le droit d'appeler
+``load_dotenv()`` : la population est strictement ``test_*.py`` au niveau module.
 """
 
+import ast
 import json
 import os
 import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
-VICTIM = REPO_ROOT / "tests" / "integration" / "test_authenticite_finale_gpt4o.py"
+TESTS_ROOT = REPO_ROOT / "tests"
+
+
+# --- 1. Balayage AST : la population est découverte, jamais codée en dur ---
+
+
+def _iter_test_files():
+    for path in sorted(TESTS_ROOT.rglob("test_*.py")):
+        if "_archived" in path.parts:
+            continue
+        yield path
+
+
+def _parse(path: Path) -> ast.Module:
+    # utf-8-sig : le dépôt porte des fichiers à BOM U+FEFF ; ast.parse lève
+    # « invalid non-printable character » sur une lecture en utf-8 nu — les
+    # fichiers sautés en silence faussent la population vers le bas.
+    return ast.parse(path.read_text(encoding="utf-8-sig"), filename=str(path))
+
+
+def _iter_module_level(stmts):
+    """Statements exécutés à l'import : corps du module + corps des
+    if/while/for/with/try de niveau module (else/except/finally compris),
+    récursivement — jamais l'intérieur d'un def/class (exécuté à l'appel)."""
+    for stmt in stmts:
+        if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            continue
+        if isinstance(stmt, (ast.If, ast.While)):
+            yield stmt
+            yield from _iter_module_level(stmt.body)
+            yield from _iter_module_level(stmt.orelse)
+        elif isinstance(stmt, (ast.For, ast.AsyncFor)):
+            yield stmt
+            yield from _iter_module_level(stmt.body)
+            yield from _iter_module_level(stmt.orelse)
+        elif isinstance(stmt, (ast.With, ast.AsyncWith)):
+            yield stmt
+            yield from _iter_module_level(stmt.body)
+        elif isinstance(stmt, ast.Try):
+            yield stmt
+            yield from _iter_module_level(stmt.body)
+            for handler in stmt.handlers:
+                yield from _iter_module_level(handler.body)
+            yield from _iter_module_level(stmt.orelse)
+            yield from _iter_module_level(stmt.finalbody)
+        else:
+            yield stmt
+
+
+def _is_os_environ(node: ast.AST) -> bool:
+    if isinstance(node, ast.Attribute):
+        return (
+            node.attr == "environ"
+            and isinstance(node.value, ast.Name)
+            and node.value.id == "os"
+        )
+    return isinstance(node, ast.Name) and node.id == "environ"
+
+
+def _iter_call_nodes(root: ast.AST):
+    """Appels d'une expression, sans descendre dans les lambdas — leur corps
+    s'exécute à l'appel, pas à l'import (témoin négatif du balayage)."""
+    stack = [root]
+    while stack:
+        node = stack.pop()
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, ast.Lambda):
+                continue
+            if isinstance(child, ast.Call):
+                yield child
+            stack.append(child)
+
+
+def _seed_in_stmt(stmt) -> str | None:
+    """Motif semeur dans un statement de niveau module, sinon None."""
+    # Appels : load_dotenv() simple ou qualifié, os.environ.update/setdefault
+    exprs: list[ast.AST]
+    if isinstance(stmt, (ast.If, ast.While)):
+        exprs = [stmt.test]
+    elif isinstance(stmt, (ast.For, ast.AsyncFor)):
+        exprs = [stmt.iter]
+    elif isinstance(stmt, (ast.With, ast.AsyncWith)):
+        exprs = [item.context_expr for item in stmt.items]
+    else:
+        exprs = [stmt]
+    for expr in exprs:
+        for node in _iter_call_nodes(expr):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            if isinstance(func, ast.Name) and func.id == "load_dotenv":
+                return "load_dotenv()"
+            if (
+                isinstance(func, ast.Attribute)
+                and func.attr == "load_dotenv"
+                and isinstance(func.value, ast.Name)
+                and func.value.id == "dotenv"
+            ):
+                return "dotenv.load_dotenv()"
+            if (
+                isinstance(func, ast.Attribute)
+                and func.attr in ("update", "setdefault")
+                and _is_os_environ(func.value)
+            ):
+                return f"os.environ.{func.attr}(...)"
+    # Écritures : os.environ[...] = ...
+    targets: list[ast.AST] = []
+    if isinstance(stmt, ast.Assign):
+        targets = list(stmt.targets)
+    elif isinstance(stmt, (ast.AnnAssign, ast.AugAssign)):
+        targets = [stmt.target]
+    for target in targets:
+        if isinstance(target, ast.Subscript) and _is_os_environ(target.value):
+            return "os.environ[...] = ..."
+    return None
+
+
+def _parse_failures() -> list[str]:
+    failures = []
+    for path in _iter_test_files():
+        try:
+            _parse(path)
+        except SyntaxError as exc:
+            failures.append(f"{path.relative_to(REPO_ROOT)}: {exc}")
+    return failures
+
+
+def _sowers() -> list[tuple[str, str]]:
+    sites = []
+    for path in _iter_test_files():
+        tree = _parse(path)
+        for stmt in _iter_module_level(tree.body):
+            kind = _seed_in_stmt(stmt)
+            if kind is not None:
+                rel = path.relative_to(REPO_ROOT).as_posix()
+                sites.append((f"{rel}:{stmt.lineno}", kind))
+    return sites
+
+
+def _sower_paths() -> list[str]:
+    paths = []
+    for path in _iter_test_files():
+        tree = _parse(path)
+        if any(
+            _seed_in_stmt(stmt) is not None for stmt in _iter_module_level(tree.body)
+        ):
+            paths.append(path.relative_to(REPO_ROOT).as_posix())
+    return paths
+
+
+# --- 2. La sonde dynamique : import en subprocess à env minimal ---
+
 
 # La sonde vit dans un subprocess à environnement MINIMAL : le process pytest
 # a typiquement déjà chargé le .env (conftest / plugin dotenv), et un
 # subprocess héritier repartirait d'un os.environ déjà saturé — la fuite
 # serait invisible. Env réduit au strict nécessaire Windows + cwd = racine du
-# dépôt pour que l'éventuel load_dotenv() de la victime trouve le vrai .env —
+# dépôt pour que l'éventuel load_dotenv() du semeur trouve le vrai .env —
 # c'est le chemin de la fuite. Seuls les NOMS de clés remontent, jamais les
 # valeurs.
 _PROBE = """
 import importlib.util, json, os
 before = dict(os.environ)
-spec = importlib.util.spec_from_file_location("authenticite_victim", {victim!r})
+spec = importlib.util.spec_from_file_location("seeded_victim", {victim!r})
 mod = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(mod)
 after = dict(os.environ)
@@ -42,27 +207,53 @@ _CHILD_ENV = {
 }
 
 
-def test_import_of_test_module_does_not_seed_os_environ():
+def test_ast_sweep_parses_every_test_file():
+    failures = _parse_failures()
+    assert failures == [], (
+        "des fichiers test_*.py échouent au parsing — ils seraient hors "
+        "population, et le balayage rendrait un faux zéro : "
+        f"{failures}"
+    )
+
+
+def test_no_module_level_env_seeder_in_tests():
+    sites = _sowers()
+    assert sites == [], (
+        "des test_*.py sèment os.environ au niveau module — ce code s'exécute "
+        "à l'import, chargé par toute bande qui collecte le fichier, et la "
+        "clé réelle devient lisible par chaque test qui suit : "
+        f"{sites} — déplacer le load_dotenv()/l'écriture dans une fonction "
+        "(#1794/#1817/#1827)"
+    )
+
+
+# Paramétrée sur la population découverte : tant que la population est propre,
+# la liste est vide et cette sonde ne collecte rien — le rouge visible est
+# alors le contrôle statique ci-dessus ; dès qu'un semeur apparaît, chaque
+# fichier fautif est prouvé à l'exécution.
+@pytest.mark.parametrize("seeder", _sower_paths())
+def test_seeder_import_does_not_seed_os_environ(seeder):
+    victim = REPO_ROOT / seeder
     result = subprocess.run(
-        [sys.executable, "-c", _PROBE.format(victim=str(VICTIM))],
+        [sys.executable, "-c", _PROBE.format(victim=str(victim))],
         capture_output=True,
         text=True,
         cwd=REPO_ROOT,
         env=_CHILD_ENV,
-        timeout=120,
+        timeout=180,
     )
     marker = next(
         (line for line in result.stdout.splitlines() if line.startswith("GAINED:")),
         None,
     )
     assert marker is not None, (
-        "la sonde n'a pas rendu son bilan — "
+        f"la sonde n'a pas rendu son bilan pour {seeder} — "
         f"returncode={result.returncode} "
         f"stdout={result.stdout[-500:]!r} stderr={result.stderr[-500:]!r}"
     )
     gained = json.loads(marker[len("GAINED:") :])
     assert gained == [], (
-        f"l'import a semé os.environ : {gained} — un load_dotenv() au niveau "
-        "module d'un fichier test_*.py charge le .env local pour toute la "
-        "session (#1794/#1817)"
+        f"l'import de {seeder} a semé os.environ : {gained} — un load_dotenv() "
+        "au niveau module charge le .env local pour toute la session "
+        "(#1794/#1817/#1827)"
     )

--- a/tests/unit/api/test_api_direct.py
+++ b/tests/unit/api/test_api_direct.py
@@ -18,46 +18,56 @@ from pathlib import Path
 from dotenv import load_dotenv
 import pytest
 
-# Charger l'environnement
-load_dotenv()
-
-# Vérifier disponibilité OPENAI_API_KEY et fichiers API
-API_ENVIRONMENT_AVAILABLE = True
-API_ENVIRONMENT_ERROR = None
+# Disponibilité calculée À L'EXÉCUTION (#1827) : l'import de ce fichier ne
+# doit ni charger .env ni écrire os.environ — toute bande qui collecte
+# tests/unit/ l'importe, et un load_dotenv() au niveau module semerait la clé
+# réelle pour toute la session pytest.
 API_FILES_REQUIRED = ["api/main.py", "api/endpoints.py", "api/dependencies.py"]
 
-try:
-    api_key = os.getenv("OPENAI_API_KEY")
-    if not api_key or len(api_key) < 20:
-        API_ENVIRONMENT_AVAILABLE = False
-        API_ENVIRONMENT_ERROR = "OPENAI_API_KEY non configurée ou invalide"
 
-    # Vérifier fichiers API
-    missing_files = [f for f in API_FILES_REQUIRED if not Path(f).exists()]
-    if missing_files:
-        API_ENVIRONMENT_AVAILABLE = False
-        API_ENVIRONMENT_ERROR = f"Fichiers API manquants: {', '.join(missing_files)}"
+def _api_environment_status():
+    """(disponible, raison) — évalué au moment où le test démarre."""
+    try:
+        api_key = os.getenv("OPENAI_API_KEY")
+        if not api_key or len(api_key) < 20:
+            return False, "OPENAI_API_KEY non configurée ou invalide"
 
-    # Vérifier disponibilité PyTorch (requis pour démarrage API via spacy/thinc)
-    if sys.platform == "win32":
-        try:
-            import torch
-        except (ImportError, OSError) as e:
-            API_ENVIRONMENT_AVAILABLE = False
-            API_ENVIRONMENT_ERROR = (
-                f"PyTorch indisponible sur Windows (requis pour API) - {str(e)[:100]}"
-            )
-except Exception as e:
-    API_ENVIRONMENT_AVAILABLE = False
-    API_ENVIRONMENT_ERROR = str(e)
+        # Vérifier fichiers API
+        missing_files = [f for f in API_FILES_REQUIRED if not Path(f).exists()]
+        if missing_files:
+            return False, f"Fichiers API manquants: {', '.join(missing_files)}"
+
+        # Vérifier disponibilité PyTorch (requis pour démarrage API via spacy/thinc)
+        if sys.platform == "win32":
+            try:
+                import torch
+            except (ImportError, OSError) as e:
+                return False, (
+                    f"PyTorch indisponible sur Windows (requis pour API) - {str(e)[:100]}"
+                )
+    except Exception as e:
+        return False, str(e)
+    return True, None
 
 
-@pytest.mark.skipif(
-    not API_ENVIRONMENT_AVAILABLE,
-    reason=f"API test environment not configured - {API_ENVIRONMENT_ERROR if API_ENVIRONMENT_ERROR else 'Missing OPENAI_API_KEY or API files'}",
-)
+def _ensure_api_environment():
+    """Charge .env puis vérifie la disponibilité — début de CHAQUE test.
+
+    Le load_dotenv() vit ici, pas au niveau module : la clé n'entre dans
+    os.environ que si un test de ce fichier s'exécute réellement.
+    """
+    load_dotenv()
+    available, error = _api_environment_status()
+    if not available:
+        pytest.skip(
+            f"API test environment not configured - "
+            f"{error or 'Missing OPENAI_API_KEY or API files'}"
+        )
+
+
 def test_environment_setup():
     """Test 1: Vérification environnement."""
+    _ensure_api_environment()
     print("\n=== Test 1: Vérification environnement ===")
 
     # Vérifier clé OpenAI
@@ -75,12 +85,9 @@ def test_environment_setup():
     print("✓ Test environnement RÉUSSI")
 
 
-@pytest.mark.skipif(
-    not API_ENVIRONMENT_AVAILABLE,
-    reason=f"API test environment not configured - {API_ENVIRONMENT_ERROR if API_ENVIRONMENT_ERROR else 'Missing OPENAI_API_KEY or API files'}",
-)
 def test_api_startup_and_basic_functionality():
     """Test 2: Démarrage API et fonctionnalité de base."""
+    _ensure_api_environment()
     print("\n=== Test 2: Démarrage API et fonctionnalités ===")
 
     # Find a free port to avoid conflicts with Docker or other services


### PR DESCRIPTION
## Ce que fait la PR

Deux volets, les deux exigés par la DoD de #1827 :

### 1. Le garde découvre sa population (#1824 codait une victime en dur)

`tests/integration/test_import_does_not_seed_env.py` est réécrit autour du balayage AST validé dans le commentaire coord :

- **Population** = tout code exécutable au niveau module des `tests/**/test_*.py` (hors `_archived`) : corps du module + corps des `if`/`while`/`for`/`with`/`try` de niveau module (else/except/finally compris), récursivement — **jamais** l'intérieur d'un `def`/`class` (ni `lambda`, pour le même motif).
- **Motifs** : `load_dotenv()` nom simple ou qualifié `dotenv.load_dotenv()`, `os.environ[...] = ...`, `os.environ.setdefault(...)`, `os.environ.update(...)`.
- **Lecture `utf-8-sig`** : les fichiers à BOM U+FEFF lèvent en utf-8 nu et sortiraient silencieusement de la population — faux zéro. Le garde **compte ses échecs de parsing et rougit s'il y en a** (exigence ajoutée à la DoD par le commentaire coord).
- **Trois couches de rouge** : (a) parsing non-nul, (b) statique — chaque site listé `fichier:ligne + motif`, (c) dynamique — chaque semeur découvert est importé dans un subprocess à env minimal (le pattern #1824) qui doit ne rien gagner.
- `conftest.py` et les points d'entrée applicatifs restent hors population (anti-pendule 3).

### 2. Le frère `tests/unit/api/test_api_direct.py` va paresseux

- `load_dotenv()` (:22, niveau module) descend dans `_ensure_api_environment()`, appelé **en tête de chaque test** — la clé n'entre dans `os.environ` que si un test s'exécute réellement.
- Le drapeau `API_ENVIRONMENT_AVAILABLE` figé à l'import devient `_api_environment_status()` évalué à l'exécution ; les deux `@pytest.mark.skipif` (collection) deviennent un skip runtime — **les 2 tests gardent exactement leur sort** (exécutés quand l'env est là, skippés sinon). Pas de bascule-en-skip déguisée.
- `API_FILES_REQUIRED` reste constante de module (aucune interaction env).

## Preuves

**Né-rouge sur main vierge** (branche posée sur `61aaca2b`, correctif pas encore appliqué) :

```
PASSED  test_ast_sweep_parses_every_test_file      (0 échec / 876 fichiers, utf-8-sig)
FAILED  test_no_module_level_env_seeder_in_tests
        → [('tests/unit/api/test_api_direct.py:22', 'load_dotenv()')]
FAILED  test_seeder_import_does_not_seed_os_environ[tests/unit/api/test_api_direct.py]
        → l'import a semé os.environ (subprocess env minimal)
```

**Post-correctif** : les trois verts ; le frère collecte 2 tests (pas de freeze) et les **2 PASSED** en local (uvicorn démarre, mock forcé — 29 s).

**Témoin négatif du monde réel** : `test_authenticite_finale_gpt4o.py` (fix #1824, `load_dotenv()` dans `main()`) est scanné par le balayage et **non détecté** — le garde distingue le semeur de l'appel légitime en fonction.

**Artifact pytest 8.4.1** : une paramétrisation vide collecte un placeholder `test[NOTSET]` **SKIPPED** (vérifié sur un reproducteur minimal). La sonde dynamique vit donc sous cette forme quand la population est propre — visible, pas silencieuse ; le rouge porteur de sens reste le contrôle statique.

## Prédiction de bande (posée avant le run)

- **Gate** (ci.yml:152) : **0/0/0** vs baseline `14647/265/323` — le garde vit sous `tests/integration/` (hors argv gate), et le frère garde le sort exact de ses 2 tests (dans `tests/unit/`, 1ʳᵉ entrée de l'argv).
- **Extended integration-rest** (le garde y vit) : +1 passed (garde parse) et le statique remplace l'ancien test, +1 skipped (placeholder NOTSET) vs l'ancien garde à victime unique.

## Anti-pendules respectés

- Pas de `requires_api` pour faire disparaître le fichier de la bande.
- Le drapeau de disponibilité est conservé (les 2 tests démarrent un serveur) — rendu paresseux, pas supprimé.
- Le garde n'interdit pas `load_dotenv()` partout : population strictement `test_*.py` niveau module.

Closes #1827.
