### PR TITLE
test(api): the second env seeder goes lazy — the import guard discovers its population (#1827)

### DIFF
--- a/tests/integration/test_import_does_not_seed_env.py
+++ b/tests/integration/test_import_does_not_seed_env.py
@@ -1,13 +1,32 @@
-"""Contrôle #1794/#1817 : l'import d'un fichier test_*.py ne doit pas semer os.environ.
+"""Contrôle #1794/#1817/#1827 : aucun module test_*.py ne sème os.environ à l'import.
 
-Toute bande qui collecte ``tests/integration`` importe chaque ``test_*.py`` ;
-un ``load_dotenv()`` au niveau module d'un de ces fichiers charge alors le
-``.env`` local dans l'environnement du process pour toute la session pytest ;
-la clé réelle devient lisible par chaque test qui suit. C'est la victime
-canonique : ``test_authenticite_finale_gpt4o.py`` (script — pytest n'y
-collecte aucun test, mais l'importe quand même).
+Toute bande qui collecte un répertoire importe chacun de ses ``test_*.py`` ;
+un ``load_dotenv()`` au niveau module (ou une écriture ``os.environ[...] =``)
+exécuté à ce moment charge le ``.env`` local dans l'environnement du process
+pour toute la session pytest — la clé réelle devient lisible par chaque test
+qui suit, et un run local cesse d'être reproductible face à la CI (#1827).
+
+La population n'est PAS codée en dur : elle est DÉCOUVERTE par un balayage
+AST de ``tests/**/test_*.py`` (hors ``_archived``). Un futur semeur fait donc
+rougir ce garde sans édition — c'était le défaut du garde #1824, qui ne
+voyait que sa victime canonique (``test_authenticite_finale_gpt4o.py``,
+corrigée en #1824).
+
+Le balayage considère « niveau module » tout ce qui s'exécute à l'import :
+le corps du module **plus** les corps des ``if`` / ``try`` / ``with`` /
+``for`` / ``while`` de niveau module, récursivement — et **jamais**
+l'intérieur d'un ``def`` / ``class`` (le point d'entrée ``main()`` d'un
+script a le droit d'appeler ``load_dotenv()`` : c'est le correctif #1824
+lui-même, le témoin négatif du garde).
+
+#1827 (leçon ai-01) : le texte est lu en ``utf-8-sig`` — 8 fichiers du dépôt
+portent un BOM UTF-8 qu'``ast.parse`` refuse après un ``read_text(utf-8)``
+nu ; ces fichiers étaient silencieusement hors population et le balayage
+rendait un faux zéro d'allure honnête. Le garde compte ses échecs de
+parsing et ROUGIT si ce compte n'est pas nul.
 """
 
+import ast
 import json
 import os
 import subprocess
@@ -15,19 +34,126 @@ import sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-VICTIM = REPO_ROOT / "tests" / "integration" / "test_authenticite_finale_gpt4o.py"
+TESTS_ROOT = REPO_ROOT / "tests"
+
+# Motifs recherchés au niveau module : appel load_dotenv (nom simple ou
+# qualifié — ``dotenv.load_dotenv()``), et mutations directes d'os.environ
+# (assignation d'item, setdefault, update). La DoD #1827 cite ces formes.
+_SEED_CALL_NAMES = {"load_dotenv"}
+_ENVIRON_MUTATING_METHODS = {"setdefault", "update"}
+_ASSIGN_TARGETS = {"environ"}
+
+
+def _is_load_dotenv_call(node: ast.AST) -> bool:
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    if isinstance(func, ast.Name):
+        return func.id in _SEED_CALL_NAMES
+    if isinstance(func, ast.Attribute):
+        return func.attr in _SEED_CALL_NAMES
+    return False
+
+
+def _is_environ_mutation(node: ast.AST) -> bool:
+    # os.environ[...] = ...  (Assign/AnnAssign/AugAssign target Subscript)
+    if isinstance(node, (ast.Assign, ast.AnnAssign, ast.AugAssign)):
+        targets = node.targets if hasattr(node, "targets") else [node.target]
+        for target in targets:
+            if (
+                isinstance(target, ast.Subscript)
+                and isinstance(target.value, ast.Attribute)
+                and target.value.attr in _ASSIGN_TARGETS
+                and isinstance(target.value.value, ast.Name)
+                and target.value.value.id == "os"
+            ):
+                return True
+        return False
+    # os.environ.setdefault(...) / os.environ.update(...)
+    if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+        if node.func.attr in _ENVIRON_MUTATING_METHODS:
+            recv = node.func.value
+            if (
+                isinstance(recv, ast.Attribute)
+                and recv.attr in _ASSIGN_TARGETS
+                and isinstance(recv.value, ast.Name)
+                and recv.value.id == "os"
+            ):
+                return True
+    return False
+
+
+def _iter_module_level_nodes(tree: ast.Module):
+    """Yield every node that EXECUTES at import time.
+
+    Walks the module body and descends into statement blocks of level-module
+    control flow (if/try/with/for/while), recursively — but never into
+    function/class bodies: those run at call time, not import time.
+    """
+    stack = list(ast.iter_child_nodes(tree))
+    while stack:
+        node = stack.pop()
+        yield node
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            continue
+        stack.extend(ast.iter_child_nodes(node))
+
+
+def _seed_evidence(path: Path) -> str:
+    """Return '<motif> ligne N' if this module seeds env at import, else ''."""
+    text = path.read_text(encoding="utf-8-sig")
+    tree = ast.parse(text)
+    for node in _iter_module_level_nodes(tree):
+        if _is_load_dotenv_call(node):
+            return f"load_dotenv() (ligne {node.lineno})"
+        if _is_environ_mutation(node):
+            kind = getattr(node, "func", None)
+            what = (
+                f"os.environ.{kind.attr}(...)"
+                if kind is not None
+                else "os.environ[...] ="
+            )
+            return f"{what} (ligne {node.lineno})"
+    return ""
+
+
+def _iter_test_files():
+    for path in sorted(TESTS_ROOT.rglob("test_*.py")):
+        if "_archived" in path.parts:
+            continue
+        yield path
+
+
+def _parse_failures() -> list:
+    failures = []
+    for path in _iter_test_files():
+        try:
+            ast.parse(path.read_text(encoding="utf-8-sig"))
+        except SyntaxError as exc:
+            failures.append(f"{path.relative_to(REPO_ROOT)}: {exc}")
+    return failures
+
+
+def discover_seeders() -> list:
+    """All test_*.py modules that seed os.environ at import time."""
+    seeders = []
+    for path in _iter_test_files():
+        evidence = _seed_evidence(path)
+        if evidence:
+            seeders.append(f"{path.relative_to(REPO_ROOT)}: {evidence}")
+    return seeders
+
 
 # La sonde vit dans un subprocess à environnement MINIMAL : le process pytest
-# a typiquement déjà chargé le .env (conftest / plugin dotenv), et un
-# subprocess héritier repartirait d'un os.environ déjà saturé — la fuite
-# serait invisible. Env réduit au strict nécessaire Windows + cwd = racine du
-# dépôt pour que l'éventuel load_dotenv() de la victime trouve le vrai .env —
-# c'est le chemin de la fuite. Seuls les NOMS de clés remontent, jamais les
-# valeurs.
+# a typiquement déjà chargé le .env (conftest --allow-dotenv) et un subprocess
+# héritier repartirait d'un os.environ déjà saturé — la fuite serait
+# invisible. Env réduit au strict nécessaire Windows + cwd = racine du dépôt
+# pour que l'éventuel load_dotenv() du semeur trouve le vrai .env — c'est le
+# chemin de la fuite. Seuls les NOMS de clés remontent, jamais les valeurs.
 _PROBE = """
 import importlib.util, json, os
 before = dict(os.environ)
-spec = importlib.util.spec_from_file_location("authenticite_victim", {victim!r})
+spec = importlib.util.spec_from_file_location("seed_probe", {victim!r})
 mod = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(mod)
 after = dict(os.environ)
@@ -42,9 +168,9 @@ _CHILD_ENV = {
 }
 
 
-def test_import_of_test_module_does_not_seed_os_environ():
+def _probe_import_gains(victim: Path) -> list:
     result = subprocess.run(
-        [sys.executable, "-c", _PROBE.format(victim=str(VICTIM))],
+        [sys.executable, "-c", _PROBE.format(victim=str(victim))],
         capture_output=True,
         text=True,
         cwd=REPO_ROOT,
@@ -60,9 +186,50 @@ def test_import_of_test_module_does_not_seed_os_environ():
         f"returncode={result.returncode} "
         f"stdout={result.stdout[-500:]!r} stderr={result.stderr[-500:]!r}"
     )
-    gained = json.loads(marker[len("GAINED:") :])
-    assert gained == [], (
-        f"l'import a semé os.environ : {gained} — un load_dotenv() au niveau "
-        "module d'un fichier test_*.py charge le .env local pour toute la "
-        "session (#1794/#1817)"
+    return json.loads(marker[len("GAINED:") :])
+
+
+def test_ast_sweep_parses_every_test_file():
+    """Un balayage qui saute des fichiers en silence rend un faux zéro.
+
+    8 fichiers du dépôt portent un BOM UTF-8 ; lus en utf-8 nu ils échouent
+    ast.parse et étaient hors population. Le garde compte ses échecs et
+    rougit si un seul lui échappe (#1827).
+    """
+    failures = _parse_failures()
+    assert failures == [], (
+        f"le balayage AST n'a pas pu parser {len(failures)} fichier(s) — ils "
+        f"sont hors population (faux zéro possible) : {failures}"
     )
+
+
+def test_no_test_module_seeds_env_at_import():
+    """Le garde vivant : la population de semeurs au niveau module est vide.
+
+    Rouge dès qu'un test_*.py appelle load_dotenv / mute os.environ au niveau
+    module — SANS édition : la population est découverte, pas codée en dur.
+    """
+    seeders = discover_seeders()
+    assert seeders == [], (
+        f"module(s) test_*.py qui sèment os.environ à l'import (#1794/#1817/"
+        f"#1827) : {seeders} — le chargement d'env appartient aux points "
+        "d'entrée (main()) ou au conftest (--allow-dotenv), jamais à l'import "
+        "d'un module de test"
+    )
+
+
+def test_discovered_seeders_do_not_seed_os_environ():
+    """Preuve dynamique par import NU (subprocess à env minimal).
+
+    Tourne sur la population découverte ; population vide aujourd'hui, ce
+    test est alors trivialement vert — le verdict de garde vit dans le test
+    statique ci-dessus. Si un semeur apparaît, il est importé ici à env
+    minimal et sa fuite réelle est listée (noms de clés uniquement).
+    """
+    for seeder in discover_seeders():
+        rel = seeder.split(":")[0]
+        gained = _probe_import_gains(REPO_ROOT / rel)
+        assert gained == [], (
+            f"l'import de {rel} a semé os.environ : {gained} — {seeder} "
+            "(#1794/#1817/#1827)"
+        )

--- a/tests/unit/api/test_api_direct.py
+++ b/tests/unit/api/test_api_direct.py
@@ -15,49 +15,52 @@ import requests
 import subprocess
 import threading
 from pathlib import Path
-from dotenv import load_dotenv
 import pytest
 
-# Charger l'environnement
-load_dotenv()
-
-# Vérifier disponibilité OPENAI_API_KEY et fichiers API
-API_ENVIRONMENT_AVAILABLE = True
-API_ENVIRONMENT_ERROR = None
+# #1827 : plus de load_dotenv() à l'import — ce fichier est collecté par la
+# gate (première entrée de son argv), donc tout import de collecte exécutait
+# le chargement du .env local pour TOUTE la session pytest (le même défaut
+# que #1794/#1817). Le drapeau de disponibilité devient PARESSEUX : évalué à
+# l'exécution du test, jamais figé à l'import — la clé vient de l'environnement
+# du process (env du step en CI, conftest --allow-dotenv ou shell en local).
 API_FILES_REQUIRED = ["api/main.py", "api/endpoints.py", "api/dependencies.py"]
 
-try:
+
+def _api_environment_status():
+    """Disponibilité évaluée À L'EXÉCUTION (pas à l'import) — #1827."""
     api_key = os.getenv("OPENAI_API_KEY")
     if not api_key or len(api_key) < 20:
-        API_ENVIRONMENT_AVAILABLE = False
-        API_ENVIRONMENT_ERROR = "OPENAI_API_KEY non configurée ou invalide"
+        return False, "OPENAI_API_KEY non configurée ou invalide"
 
-    # Vérifier fichiers API
     missing_files = [f for f in API_FILES_REQUIRED if not Path(f).exists()]
     if missing_files:
-        API_ENVIRONMENT_AVAILABLE = False
-        API_ENVIRONMENT_ERROR = f"Fichiers API manquants: {', '.join(missing_files)}"
+        return False, f"Fichiers API manquants: {', '.join(missing_files)}"
 
     # Vérifier disponibilité PyTorch (requis pour démarrage API via spacy/thinc)
     if sys.platform == "win32":
         try:
             import torch
         except (ImportError, OSError) as e:
-            API_ENVIRONMENT_AVAILABLE = False
-            API_ENVIRONMENT_ERROR = (
+            return False, (
                 f"PyTorch indisponible sur Windows (requis pour API) - {str(e)[:100]}"
             )
-except Exception as e:
-    API_ENVIRONMENT_AVAILABLE = False
-    API_ENVIRONMENT_ERROR = str(e)
+
+    return True, None
 
 
-@pytest.mark.skipif(
-    not API_ENVIRONMENT_AVAILABLE,
-    reason=f"API test environment not configured - {API_ENVIRONMENT_ERROR if API_ENVIRONMENT_ERROR else 'Missing OPENAI_API_KEY or API files'}",
-)
+def _skip_if_api_environment_unavailable():
+    """Skip évalué à l'exécution — remplace le skipif figé à l'import (#1827)."""
+    available, error = _api_environment_status()
+    if not available:
+        pytest.skip(
+            f"API test environment not configured - "
+            f"{error if error else 'Missing OPENAI_API_KEY or API files'}"
+        )
+
+
 def test_environment_setup():
     """Test 1: Vérification environnement."""
+    _skip_if_api_environment_unavailable()
     print("\n=== Test 1: Vérification environnement ===")
 
     # Vérifier clé OpenAI
@@ -75,12 +78,9 @@ def test_environment_setup():
     print("✓ Test environnement RÉUSSI")
 
 
-@pytest.mark.skipif(
-    not API_ENVIRONMENT_AVAILABLE,
-    reason=f"API test environment not configured - {API_ENVIRONMENT_ERROR if API_ENVIRONMENT_ERROR else 'Missing OPENAI_API_KEY or API files'}",
-)
 def test_api_startup_and_basic_functionality():
     """Test 2: Démarrage API et fonctionnalité de base."""
+    _skip_if_api_environment_unavailable()
     print("\n=== Test 2: Démarrage API et fonctionnalités ===")
 
     # Find a free port to avoid conflicts with Docker or other services
@@ -332,6 +332,12 @@ def run_all_tests():
 
         return True
 
+    except pytest.skip.Exception:
+        # #1827 : le skip d'exécution (env API absent) ne doit pas tracer en
+        # __main__ — Skipped hérite de BaseException, hors portée du except
+        # Exception ci-dessous.
+        print("\n⏭️ SKIP: environnement API non configuré")
+        return False
     except Exception as e:
         print(f"\n❌ ÉCHEC DE VALIDATION: {e}")
         return False


### PR DESCRIPTION
## Summary

Closes #1827 — the brother sweep of #1817/#1824. Two changes:

1. **`tests/unit/api/test_api_direct.py` stops seeding env at import.** The module-level `load_dotenv()` (line 22) is gone; the availability flag becomes **lazy** — evaluated at test execution (`_api_environment_status()` + `_skip_if_api_environment_unavailable()` at the top of each test), never frozen at import. This file is in the gate's argv (first entry, `tests/unit/`), so every push imported it and, in a local run, seeded the real key for the whole session (34 keys, proven by probe below). `run_all_tests()` (the `__main__` path) now catches `pytest.skip.Exception` so an unavailable env prints a SKIP line instead of a BaseException traceback.
2. **The `#1824` guard stops hardcoding its victim.** `test_import_does_not_seed_env.py` now DISCOVERS its population: an AST sweep over `tests/**/test_*.py` (excl. `_archived`) for module-level `load_dotenv` calls (simple or qualified) and direct `os.environ` mutations (`[...]=`, `setdefault`, `update`). A future seeder reddens it without an edit. Three tests: (a) parse-failures == 0 — the sweep counts its own parsing failures and reddens if any file escapes (the BOM lesson: 8 files carry a UTF-8 BOM that breaks `ast.parse` on plain `utf-8` reads; reading `utf-8-sig` absorbs them, and a sweep that silently skips files is exactly the false-zero defect the guard exists to prevent); (b) the living verdict: discovered population must be empty; (c) a dynamic probe importing each discovered seeder in a minimal-env subprocess (reusing the #1824 probe) — trivially green while the population is empty, executable proof the moment one appears.

"Module level" means everything that EXECUTES at import: module body + bodies of module-level `if`/`try`/`with`/`for`/`while`, recursively — never inside `def`/`class` (a `main()` entry point may legitimately call `load_dotenv()`: that is the #1824 fix itself, the guard's negative witness).

## Control of the control (executed, not deduced)

Ran the new guard against the INTACT brother (pre-fix tree):

| test | verdict | evidence |
|---|---|---|
| `test_ast_sweep_parses_every_test_file` | PASSED | 876 files, 0 parse failures (BOM absorbed) |
| `test_no_test_module_seeds_env_at_import` | **RED** | `tests/unit/api/test_api_direct.py: load_dotenv() (ligne 22)` — exactly the brother |
| `test_discovered_seeders_do_not_seed_os_environ` | **RED** | import of the brother seeded **34 keys** (incl. OPENAI_API_KEY) in the minimal-env subprocess |

After the fix: **3 passed** (7.5s). Disarm⇒red⇒restore, complete.

## Fate of the 2 tests (recette: passed +0, skipped +0)

The DoD's trap was freezing the flag to unavailable. Witness by stash — same command, same session, `OPENAI_API_KEY=sk-fake-...`:

| tree | verdict |
|---|---|
| main (stashed fix) | `2 skipped` — reason: `PyTorch indisponible (WinError 182)` (local session DLL artifact) |
| this PR | `2 skipped` — identical reasons |

**Same fate, `skipped` flat.** The lazy flag reads the same `os.environ`/`sys.modules` the eager flag read — the only mutation between them was the brother's own `load_dotenv()`. In the CI regime (key in step env, torch loads cleanly), both tests RUN before and after (the 28.52s startup duration measured in #1759); in the no-key regime both skip before and after; in `--allow-dotenv` local runs the conftest loads the `.env` itself (conftest.py:254), so the key is present either way.

## Files removed and why

None — no deletions (Cleanup Gate N/A).

## Test plan

- [x] Guard red on intact brother (control of the control) — 2 RED with evidence
- [x] Guard green after fix — 3 passed
- [x] Fate witness by stash — 2S vs 2S, same reasons, `skipped` flat
- [x] black + flake8 clean on both files
- [x] `tests/unit/api/` subdir sanity (background, result in PR comment)
- [ ] CI gate (expect identical counts to main `1dbf3100`: the 2 tests keep their CI fate — they run there)

🤖 Worker po-2025 — issue #1827 (brother sweep of #1817/#1824)
