### PR TITLE
fix(tests): fp11 tweety_solver pins the prefer flag too — the #1339 upgrade routes around a solver-only pin

### DIFF
--- a/tests/integration/argumentation_analysis/agents/core/logic/test_fp11_modal_kb_roundtrip.py
+++ b/tests/integration/argumentation_analysis/agents/core/logic/test_fp11_modal_kb_roundtrip.py
@@ -73,13 +73,23 @@ def modal_kb_builder():
 @pytest.fixture
 def tweety_solver():
     """Force the pure-Java default (``TWEETY``/``SimpleMlReasoner``) — the
-    always-available, always-deciding modal path (no external binary)."""
-    previous = settings.modal_solver
+    always-available, always-deciding modal path (no external binary).
+
+    Pinning ``modal_solver`` alone is NOT enough (#1339): when
+    ``modal_prefer_spass_when_available`` is on and a vendored SPASS binary
+    is detected (local dev machines), the resolver upgrades TWEETY to SPASS
+    — the verdict stays authentic but its message names "spass", and this
+    file's ``"tweety" in msg`` traceability asserts redden. CI runners have
+    no vendored SPASS, which is why this only bites locally."""
+    previous_solver = settings.modal_solver
+    previous_prefer = settings.modal_prefer_spass_when_available
     settings.modal_solver = ModalSolverChoice.TWEETY
+    settings.modal_prefer_spass_when_available = False
     try:
         yield
     finally:
-        settings.modal_solver = previous
+        settings.modal_solver = previous_solver
+        settings.modal_prefer_spass_when_available = previous_prefer
 
 
 class TestConstructModalKbRoundTripDecides:


### PR DESCRIPTION
## Summary

Side-finding from the #1759 real-arm run (PR #1828), delivered as its own small PR. `test_fp11_modal_kb_roundtrip.py`'s `tweety_solver` fixture pins `settings.modal_solver = TWEETY` but not `settings.modal_prefer_spass_when_available`. On machines with a vendored SPASS binary, `ModalHandler._resolve_active_solver_choice` (#1339) upgrades TWEETY→SPASS around the pin: the verdict stays authentic (decided, real query) but its message names "spass", and fp11's `"tweety" in msg.lower()` traceability asserts fail. CI runners detect no vendored SPASS, so the gap is invisible in CI — it bites local dev machines only. The bounded-signature file added in #1828 already pins both (same discovery, fixed inline there); this brings fp11 to the same shape.

## Evidence (executed on a vendored-SPASS machine, main tree)

- **Before**: `2 failed, 3 passed` — `test_consistent_kb_decides_true`, `test_inconsistent_kb_decides_false` (the two asserting `"tweety" in msg`), message was `Knowledge base is consistent (spass).`
- **After**: `5 passed` in 5.4s — same verdicts, message back to `(tweety)`.
- black + flake8 clean.

## Files removed and why

None.

## Test plan

- [x] Born-red on main reproduced (2 failed) — disarm⇒red⇒restore
- [x] Green after pin (5 passed)
- [ ] CI (no vendored SPASS on runners: expect fp11 counts unchanged there — the pin is a no-op on CI, a fix locally)

🤖 Worker po-2025 — side-finding of #1828 (#1759)