### PR TITLE
fix(tests): preserve the two #1830 elements over the merged #1827 fix — Skipped catch + loop-form probe

### DIFF
--- a/tests/integration/test_import_does_not_seed_env.py
+++ b/tests/integration/test_import_does_not_seed_env.py
@@ -227,12 +227,18 @@ def test_no_module_level_env_seeder_in_tests():
     )
 
 
-# Paramétrée sur la population découverte : tant que la population est propre,
-# la liste est vide et cette sonde ne collecte rien — le rouge visible est
-# alors le contrôle statique ci-dessus ; dès qu'un semeur apparaît, chaque
-# fichier fautif est prouvé à l'exécution.
-@pytest.mark.parametrize("seeder", _sower_paths())
-def test_seeder_import_does_not_seed_os_environ(seeder):
+# Boucle sur la population découverte (pas de @pytest.mark.parametrize) :
+# une paramétrisation vide collecte un placeholder test[NOTSET] SKIPPED sous
+# pytest 8.4.1 — un artefact de collecte, pas un signal. En forme boucle, la
+# population propre rend ce test trivialement vert SANS artefact ; dès qu'un
+# semeur apparaît, chaque fichier fautif est prouvé à l'exécution. Le rouge
+# porteur de sens reste le contrôle statique ci-dessus.
+def test_seeder_import_does_not_seed_os_environ():
+    for seeder in _sower_paths():
+        _assert_import_seeds_nothing(seeder)
+
+
+def _assert_import_seeds_nothing(seeder):
     victim = REPO_ROOT / seeder
     result = subprocess.run(
         [sys.executable, "-c", _PROBE.format(victim=str(victim))],

--- a/tests/unit/api/test_api_direct.py
+++ b/tests/unit/api/test_api_direct.py
@@ -339,6 +339,13 @@ def run_all_tests():
 
         return True
 
+    except pytest.skip.Exception:
+        # _ensure_api_environment() skippe quand l'env API est absent ; Skipped
+        # hérite de BaseException, le except Exception ci-dessous ne l'attrape
+        # pas — sans ce catch le __main__ trace une exception brute au lieu
+        # d'un message.
+        print("\n⏭️ SKIP: environnement API non configuré")
+        return False
     except Exception as e:
         print(f"\n❌ ÉCHEC DE VALIDATION: {e}")
         return False


### PR DESCRIPTION
## Summary

Follow-up sanctioned by the coordinator's #1830 closure (arbitration of the #1829/#1830 collision — two elements of the closed PR to preserve):

1. **`run_all_tests()` catches `pytest.skip.Exception`** — `_ensure_api_environment()` (merged in #1829) calls `pytest.skip()` when the API env is absent; `Skipped` inherits from `BaseException`, so the existing `except Exception` let it escape and the `__main__` path traced a raw exception.
2. **The dynamic seeder probe runs as a loop** instead of an empty `@pytest.mark.parametrize` — under pytest 8.4.1 an empty parametrization collects a placeholder `test[NOTSET]` SKIPPED, a collection artifact rather than a signal. Loop form: clean population → trivially green, no artifact.

## Evidence (executed)

- **Born-red, catch**: `env -u OPENAI_API_KEY python tests/unit/api/test_api_direct.py` before → bare `Skipped: API test environment not configured...` traceback; after → `⏭️ SKIP: environnement API non configuré`.
- **Substitution, loop probe**: temp canary (`tests/unit/test_zz_tmp_seeder_canary.py`, module-level `load_dotenv()`) → **2 failed** (static control + loop probe both redden, naming the canary); canary removed → **3 passed**. Probe body is unchanged from #1829 — only the wrapper moved from parametrize to loop.
- Guard collection: no `NOTSET` placeholder anymore; black + flake8 clean.

## Files removed and why

None.

## Test plan

- [x] `__main__` no-key path verified before/after (traceback → graceful skip)
- [x] Canary substitution on the loop probe (red→green)
- [ ] CI gate (guard lives under tests/integration — out of gate argv; brother tests' fate untouched: the catch only wraps `run_all_tests`, never the test functions)

🤖 Worker po-2025 — follow-up of #1827 (elements preserved from closed #1830)