### PR TITLE
fix(orchestration): unmask real cause behind frozen JVM message (#1826)

### DIFF
--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -3575,13 +3575,24 @@ def _eaf_beliefs_from_context(
 
 
 def _python_ranking_fallback(
-    arguments: List[str], attacks: List[List[str]], method: str
+    arguments: List[str],
+    attacks: List[List[str]],
+    method: str,
+    cause: Optional[Exception] = None,
 ) -> Dict[str, Any]:
     """Fail-loud stub — ranking semantics requires JVM/Tweety (#1019, RA-8 #1053).
 
     Previous pure-Python fallback produced synthetic scores that entered state
     as authentic formal results (anti-theater violation). Now raises instead.
+    #1826: quand le handler lui-même a échoué, ``cause`` porte l'erreur réelle —
+    une entrée mal formée ne doit pas se lire « JVM absente » alors que la JVM
+    tourne. Sans cause (appel direct/tripwire), le message environnemental
+    reste le bon diagnostic.
     """
+    if cause is not None:
+        raise RuntimeError(
+            f"Ranking semantics ({method}) unavailable: {cause}"
+        ) from cause
     raise RuntimeError(
         f"Ranking semantics ({method}) unavailable: JVM/Tweety required. "
         "Install JVM and ensure Tweety JARs are on the classpath."
@@ -3701,9 +3712,10 @@ async def _invoke_ranking(input_text: str, context: Dict[str, Any]) -> Dict[str,
             result = _enrich_ranking_with_justification(result, args, attacks, context)
         return result
     except Exception as e:
-        logger.info(f"Ranking handler unavailable ({e}), using Python fallback")
-        result = _python_ranking_fallback(args, attacks, method)
-        return _enrich_ranking_with_justification(result, args, attacks, context)
+        logger.info(
+            f"Ranking handler failed ({e}); failing loud with the cause (#1826)"
+        )
+        return _python_ranking_fallback(args, attacks, method, cause=e)
 
 
 def _propagate_structured_arg_cause(
@@ -4101,12 +4113,17 @@ def _python_aspic_fallback(
     defeasible: List[str],
     fallacies: List[Any],
     context: Dict[str, Any],
+    cause: Optional[Exception] = None,
 ) -> Dict[str, Any]:
     """Fail-loud stub — ASPIC+ analysis requires JVM/Tweety (#1019, RA-8 #1053).
 
     Previous pure-Python fallback produced synthetic defensibility scores that
     entered state as authentic formal results (anti-theater violation).
+    #1826: ``cause`` porte l'échec réel du handler quand il y en a un —
+    sans cause (appel direct/tripwire), le message environnemental reste.
     """
+    if cause is not None:
+        raise RuntimeError(f"ASPIC+ analysis unavailable: {cause}") from cause
     raise RuntimeError(
         "ASPIC+ analysis unavailable: JVM/Tweety required. "
         "Install JVM and ensure Tweety JARs are on the classpath."
@@ -4239,8 +4256,10 @@ async def _invoke_aspic(input_text: str, context: Dict[str, Any]) -> Dict[str, A
             handler.analyze_aspic_framework, strict, defeasible, axioms
         )
     except Exception as e:
-        logger.info(f"ASPIC+ handler unavailable ({e}), using Python fallback")
-        return _python_aspic_fallback(args, strict, defeasible, fallacies, context)
+        logger.info(f"ASPIC+ handler failed ({e}); failing loud with the cause (#1826)")
+        return _python_aspic_fallback(
+            args, strict, defeasible, fallacies, context, cause=e
+        )
 
 
 async def _invoke_belief_revision(
@@ -4879,8 +4898,8 @@ async def _invoke_social(input_text: str, context: Dict[str, Any]) -> Dict[str, 
             state=context.get("_state_object"),
         )
     except Exception as e:
-        logger.info(f"Social handler unavailable ({e}), using Python fallback")
-        return _python_social_fallback(args, attacks, votes, context)
+        logger.info(f"Social handler failed ({e}); failing loud with the cause (#1826)")
+        return _python_social_fallback(args, attacks, votes, context, cause=e)
 
 
 def _python_social_fallback(
@@ -4888,12 +4907,17 @@ def _python_social_fallback(
     attacks: List[List[str]],
     votes: Dict[str, Any],
     context: Dict[str, Any],
+    cause: Optional[Exception] = None,
 ) -> Dict[str, Any]:
     """Fail-loud stub — Social AF requires JVM/Tweety (#1019, RA-8 #1053).
 
     Previous pure-Python fallback produced synthetic social scores that entered
     state as authentic formal results (anti-theater violation).
+    #1826: ``cause`` porte l'échec réel du handler quand il y en a un —
+    sans cause (appel direct/tripwire), le message environnemental reste.
     """
+    if cause is not None:
+        raise RuntimeError(f"Social argumentation unavailable: {cause}") from cause
     raise RuntimeError(
         "Social argumentation unavailable: JVM/Tweety required. "
         "Install JVM and ensure Tweety JARs are on the classpath."
@@ -4905,12 +4929,19 @@ def _python_eaf_fallback(
     attacks: List[List[str]],
     semantics: str,
     context: Dict[str, Any],
+    cause: Optional[Exception] = None,
 ) -> Dict[str, Any]:
     """Fail-loud stub — EAF analysis requires JVM/Tweety (#1019, RA-8 #1053).
 
     Previous pure-Python fallback produced synthetic epistemic states that entered
     state as authentic formal results (anti-theater violation).
+    #1826: ``cause`` porte l'échec réel du handler quand il y en a un —
+    sans cause (appel direct/tripwire), le message environnemental reste.
     """
+    if cause is not None:
+        raise RuntimeError(
+            f"Epistemic AF analysis ({semantics}) unavailable: {cause}"
+        ) from cause
     raise RuntimeError(
         f"Epistemic AF analysis ({semantics}) unavailable: JVM/Tweety required. "
         "Install JVM and ensure Tweety JARs are on the classpath."
@@ -4947,8 +4978,8 @@ async def _invoke_eaf(input_text: str, context: Dict[str, Any]) -> Dict[str, Any
             handler.analyze_epistemic_framework, args, attacks, beliefs, semantics
         )
     except Exception as e:
-        logger.info(f"EAF handler unavailable ({e}), using Python fallback")
-        return _python_eaf_fallback(args, attacks, semantics, context)
+        logger.info(f"EAF handler failed ({e}); failing loud with the cause (#1826)")
+        return _python_eaf_fallback(args, attacks, semantics, context, cause=e)
 
 
 async def _invoke_delp(input_text: str, context: Dict[str, Any]) -> Dict[str, Any]:

--- a/tests/unit/argumentation_analysis/orchestration/test_fallback_cause_not_masked_1826.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_fallback_cause_not_masked_1826.py
@@ -1,0 +1,140 @@
+"""#1826 — un échec de handler ne doit pas se déguiser en « JVM absente ».
+
+Le stub fail-loud (voulu, #1019/RA-8 #1053) levait un message figé
+« JVM/Tweety required. Install JVM... » pour TOUT échec du handler — y
+compris une entrée mal formée, avec la JVM qui tourne. La cause réelle
+n'était visible qu'à INFO dans un log noyé ; le chemin d'erreur observable
+l'avalait. Un lecteur (ou un agent PM, ou un test) concluait « JVM absente »
+à tort.
+
+Contrôles par substitution dégénérée : on force le handler à lever une
+erreur NON-JVM (``ValueError("bad shape")``) et l'erreur observable doit
+porter cette cause — pas l'affirmation environnementale figée. Sweep des
+frères : aspic par substitution (2ᵉ chemin ``_invoke_*`` prouvé), social et
+eaf au niveau stub (l'appel direct avec ``cause`` porte la cause ; sans
+``cause`` le tripwire environnemental reste — le fail-loud de #1019 est
+intact, et le message direct de eaf n'était épinglé nulle part).
+"""
+
+import pytest
+
+from argumentation_analysis.orchestration import invoke_callables as ic
+
+SAMPLE_TEXT = "Claim one. Claim two. Claim three."
+
+
+def _boom(*_args, **_kwargs):
+    raise ValueError("bad shape")
+
+
+async def _ranking_with_failing_handler(monkeypatch):
+    monkeypatch.setattr(
+        "argumentation_analysis.agents.core.logic.ranking_handler.RankingHandler."
+        "__init__",
+        lambda self: None,
+    )
+    monkeypatch.setattr(
+        "argumentation_analysis.agents.core.logic.ranking_handler.RankingHandler."
+        "rank_arguments",
+        _boom,
+    )
+    ctx = {"arguments": ["a", "b"], "attacks": [["a", "b"]]}
+    return await ic._invoke_ranking(SAMPLE_TEXT, ctx)
+
+
+async def _aspic_with_failing_handler(monkeypatch):
+    monkeypatch.setattr(
+        "argumentation_analysis.agents.core.logic.aspic_handler.ASPICHandler."
+        "__init__",
+        lambda self: None,
+    )
+    monkeypatch.setattr(
+        "argumentation_analysis.agents.core.logic.aspic_handler.ASPICHandler."
+        "analyze_aspic_framework",
+        _boom,
+    )
+    return await ic._invoke_aspic(SAMPLE_TEXT, {"arguments": ["a", "b"]})
+
+
+class TestRankingCauseNotMasked:
+    async def test_non_jvm_error_names_its_cause(self, monkeypatch):
+        with pytest.raises(RuntimeError) as excinfo:
+            await _ranking_with_failing_handler(monkeypatch)
+        message = str(excinfo.value)
+        assert "bad shape" in message, (
+            f"#1826: l'erreur observable doit porter la cause réelle du handler, "
+            f"pas un message figé — got: {message!r}"
+        )
+
+    async def test_non_jvm_error_does_not_claim_missing_jvm(self, monkeypatch):
+        with pytest.raises(RuntimeError) as excinfo:
+            await _ranking_with_failing_handler(monkeypatch)
+        message = str(excinfo.value)
+        assert "JVM/Tweety required" not in message, (
+            f"#1826: une erreur d'entrée (bad shape) ne doit pas s'affirmer "
+            f"« JVM absente » alors que la JVM tourne — got: {message!r}"
+        )
+
+
+class TestAspicCauseNotMasked:
+    async def test_non_jvm_error_names_its_cause(self, monkeypatch):
+        with pytest.raises(RuntimeError) as excinfo:
+            await _aspic_with_failing_handler(monkeypatch)
+        message = str(excinfo.value)
+        assert "bad shape" in message, (
+            f"#1826: l'erreur observable doit porter la cause réelle du handler, "
+            f"pas un message figé — got: {message!r}"
+        )
+
+    async def test_non_jvm_error_does_not_claim_missing_jvm(self, monkeypatch):
+        with pytest.raises(RuntimeError) as excinfo:
+            await _aspic_with_failing_handler(monkeypatch)
+        message = str(excinfo.value)
+        assert "JVM/Tweety required" not in message, (
+            f"#1826: une erreur d'entrée (bad shape) ne doit pas s'affirmer "
+            f"« JVM absente » alors que la JVM tourne — got: {message!r}"
+        )
+
+
+class TestStubKeepsEnvironmentalMessageWhenNoCause:
+    """Le tripwire direct (cause=None) garde le message environnemental :
+    sans exception handler à rapporter, « installe la JVM » reste la bonne
+    lecture — le fail-loud de #1019 est intact."""
+
+    def test_direct_stub_call_still_claims_jvm(self):
+        with pytest.raises(RuntimeError, match="JVM/Tweety required"):
+            ic._python_ranking_fallback(["a"], [], "categorizer")
+
+    def test_eaf_stub_without_cause_still_claims_jvm(self):
+        with pytest.raises(RuntimeError, match="JVM/Tweety required"):
+            ic._python_eaf_fallback(["a"], [], "grounded", {})
+
+
+class TestBrothersStubCarriesCause:
+    """Sweep frères (#1826) : social et eaf portent la cause quand il y en a
+    une — l'échec réel du handler remonte dans l'erreur observable."""
+
+    def test_social_stub_with_cause_names_it(self):
+        with pytest.raises(RuntimeError) as excinfo:
+            ic._python_social_fallback(["a"], [], {}, {}, cause=ValueError("bad shape"))
+        message = str(excinfo.value)
+        assert "bad shape" in message, f"got: {message!r}"
+        assert "JVM/Tweety required" not in message, f"got: {message!r}"
+
+    def test_eaf_stub_with_cause_names_it(self):
+        with pytest.raises(RuntimeError) as excinfo:
+            ic._python_eaf_fallback(
+                ["a"], [], "grounded", {}, cause=ValueError("bad shape")
+            )
+        message = str(excinfo.value)
+        assert "bad shape" in message, f"got: {message!r}"
+        assert "JVM/Tweety required" not in message, f"got: {message!r}"
+
+    def test_aspic_stub_with_cause_names_it(self):
+        with pytest.raises(RuntimeError) as excinfo:
+            ic._python_aspic_fallback(
+                ["a"], [], [], [], {}, cause=ValueError("bad shape")
+            )
+        message = str(excinfo.value)
+        assert "bad shape" in message, f"got: {message!r}"
+        assert "JVM/Tweety required" not in message, f"got: {message!r}"


### PR DESCRIPTION
## Summary
- Le stub fail-loud (`_python_ranking_fallback` + frères aspic/social/eaf) levait un message figé `JVM/Tweety required. Install JVM...` pour **tout** échec du handler — y compris une entrée mal formée, JVM allumée. La cause réelle ne vivait qu'à INFO dans un log noyé ; le chemin d'erreur observable l'avalait.
- Les 4 stubs prennent maintenant un `cause: Optional[Exception]` ; les 4 sites `except` masquants passent l'exception et lèvent `"... unavailable: {cause}" from cause` — la même forme que les sites direct-raise déjà bénis (ABA/ADF/PL/etc., census #1826).
- L'appel direct sans cause garde le tripwire environnemental (fail-loud #1019/RA-8 #1053 intact). Dung = tripwire documenté sans appelant vivant ; son site `_invoke_*` renvoie déjà un dict honest-absent qui interpole la cause.

## DoD (substitution dégénérée)
Handler forcé à lever `ValueError("bad shape")` (JVM présente) → l'erreur observable doit nommer `bad shape`, jamais `JVM/Tweety required` :
- **ranking** via `_invoke_ranking` : né-rouge sur main (message figé), vert après fix ✅
- **aspic** via `_invoke_aspic` : idem, 2ᵉ chemin `_invoke_*` prouvé ✅
- **social + eaf** au niveau stub : portent la cause, gardent le tripwire sans cause ✅ (le message direct de eaf n'était épinglé nulle part)

## Test plan (exécuté localement)
- 9 tests nouveaux verts ; `tests/integration/test_tweety_fallbacks.py` (61) inchangé vert — les regex `Ranking semantics ({method}) unavailable` / `JVM/Tweety required` sur appels directs tiennent.
- `tests/unit/argumentation_analysis/test_value_gates.py` vert — les gates `match="X unavailable"` (EAF/ASPIC via `to_thread` side_effect) tiennent grâce à la forme `unavailable: {cause}`.
- Fichiers épinglant les stubs (fail_loud_downstream_1019, dung_aspic_wiring, track_tt, ra8_anti_theater) verts.
- Total : 135 passed.
- 4 rouges préexistants `TestGetDeterminismParams` confirmés sur main (stash) — hors périmètre.

## Files
- `argumentation_analysis/orchestration/invoke_callables.py` — 4 stubs + 4 sites except (log devenu véridique : « failed with the cause », plus de « using Python fallback » mensonger)
- `tests/unit/argumentation_analysis/orchestration/test_fallback_cause_not_masked_1826.py` — nouveau (substitutions + tripwire)

### Files removed and why
Aucun.