### PR TITLE
fix(tests): both tweety_solver fixtures pin the prefer flag — and the settings comment that produced them (#1339)

### DIFF
--- a/argumentation_analysis/core/config.py
+++ b/argumentation_analysis/core/config.py
@@ -71,11 +71,13 @@ class ArgAnalysisSettings(BaseSettings):
     #
     # ⚠ #1339 — POUR ÉPINGLER TWEETY, IL FAUT LES DEUX RÉGLAGES. Une phrase
     # antérieure affirmait ici qu'« un ``modal_solver`` explicitement choisi est
-    # toujours respecté ». C'est vrai pour SPASS et **faux pour TWEETY**, et
-    # c'est inimplémentable en l'état : TWEETY est à la fois le défaut et un
-    # choix explicite légitime, donc ``_resolve_active_solver_choice``
-    # (``modal_handler.py``) ne peut pas les distinguer — c'est ce drapeau, et
-    # lui seul, qui les sépare. Poser ``modal_solver = TWEETY`` sans poser
+    # toujours respecté ». C'est vrai pour SPASS et **faux pour TWEETY** :
+    # ``_resolve_active_solver_choice`` (``modal_handler.py``) compare la
+    # *valeur* du champ, et la valeur d'un TWEETY explicite est identique à
+    # celle du TWEETY par défaut. (La provenance, elle, est bien disponible —
+    # ``model_fields_set`` distingue les deux, mesuré — mais le resolver ne la
+    # consulte pas. Ne pas lire cette note comme une impossibilité.)
+    # Poser ``modal_solver = TWEETY`` sans poser
     # ``modal_prefer_spass_when_available = False`` laisse le resolver remonter
     # vers SPASS **autour du pin** dès qu'un binaire vendoré est détecté : le
     # verdict reste authentique, mais son message nomme ``spass`` et tout assert

--- a/argumentation_analysis/core/config.py
+++ b/argumentation_analysis/core/config.py
@@ -67,9 +67,21 @@ class ArgAnalysisSettings(BaseSettings):
     # sans OOM, au lieu du défaut SimpleMlReasoner (Kripke naïf, OOM sur KB
     # réels ~12 atomes, FP-16 #1231). Anti-pendule : on *soustrait* le défaut
     # OOM-prone en routant vers le solveur capable, on n'empile pas un try/except
-    # sur l'OOM. Un utilisateur/fixture peut forcer TWEETY (False) pour tester
-    # le path SimpleMlReasoner explicitement — un ``modal_solver`` explicitement
-    # choisi est toujours respecté.
+    # sur l'OOM.
+    #
+    # ⚠ #1339 — POUR ÉPINGLER TWEETY, IL FAUT LES DEUX RÉGLAGES. Une phrase
+    # antérieure affirmait ici qu'« un ``modal_solver`` explicitement choisi est
+    # toujours respecté ». C'est vrai pour SPASS et **faux pour TWEETY**, et
+    # c'est inimplémentable en l'état : TWEETY est à la fois le défaut et un
+    # choix explicite légitime, donc ``_resolve_active_solver_choice``
+    # (``modal_handler.py``) ne peut pas les distinguer — c'est ce drapeau, et
+    # lui seul, qui les sépare. Poser ``modal_solver = TWEETY`` sans poser
+    # ``modal_prefer_spass_when_available = False`` laisse le resolver remonter
+    # vers SPASS **autour du pin** dès qu'un binaire vendoré est détecté : le
+    # verdict reste authentique, mais son message nomme ``spass`` et tout assert
+    # de traçabilité ``"tweety" in msg`` rougit. La croyance induite par
+    # l'ancienne phrase a produit le défaut dans plusieurs fixtures de test
+    # (#1831, #1834) ; elle est corrigée ici plutôt que site par site.
     #
     modal_prefer_spass_when_available: bool = True
 

--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -7623,24 +7623,28 @@ async def _invoke_modal_logic(
     # conditional on (a) a detected vendored SPASS path, (b) the prefer flag,
     # (c) ``modal_solver == TWEETY``.
     #
+    # Restored in ``finally`` so the global choice never leaks past this call
+    # (#1219 lesson: no unconditional, leaked force-set).
+    #
     # ⚠ #1339 — this comment used to add "an explicit ``modal_solver`` choice is
     # always respected". That is true for SPASS and FALSE for TWEETY, and the
-    # condition just above shows why it cannot be otherwise: the test is
+    # condition just above shows why, AS IMPLEMENTED: the test is
     # ``_prev_modal_solver == TWEETY``, which compares the field's VALUE — and
-    # an explicit TWEETY carries the same value as the default TWEETY. To pin
-    # TWEETY *against this site* you must set BOTH ``modal_solver = TWEETY`` and
+    # an explicit TWEETY carries the same value as the default TWEETY. (The
+    # provenance is available — ``model_fields_set`` tells an explicit pin from
+    # the default, measured — this site simply does not consult it. Read this as
+    # "not done", not as "cannot be done".) To pin TWEETY *against this site*
+    # you must set BOTH ``modal_solver = TWEETY`` and
     # ``modal_prefer_spass_when_available = False``; pinning the solver alone
     # lets this site route to SPASS around the pin, and every ``"tweety" in msg``
     # traceability assert downstream reddens. The old sentence produced exactly
     # that defect in several test fixtures (#1831, #1834).
     #
-    # ⚠ That recipe is NOT a whole-process guarantee: it protects against THIS
-    # site, not against every one. ``_invoke_external_modal_solver`` (same file,
-    # ~L9937) forces SPASS on ``shutil.which("SPASS")`` alone — it reads neither
-    # setting and never restores. Tracked separately; do not read the BOTH
-    # recipe as protection there.
-    # Restored in ``finally`` so the global choice never leaks past this call
-    # (#1219 lesson: no unconditional, leaked force-set).
+    # ⚠ That recipe is NOT a whole-process guarantee — it protects against THIS
+    # site only. ``_invoke_external_modal_solver`` (same file, ~L9937) forces
+    # SPASS on ``shutil.which("SPASS")`` alone: it reads neither setting AND,
+    # unlike this site, never restores — the force-set leaks process-wide.
+    # Tracked as #1845; do not read the BOTH recipe as protection there.
     from argumentation_analysis.core.config import settings as _modal_settings
     from argumentation_analysis.core.config import ModalSolverChoice
     from argumentation_analysis.agents.core.logic.modal_handler import (

--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -7621,8 +7621,19 @@ async def _invoke_modal_logic(
     # them (#1239/#1242, firsthand 4/4). Anti-pendule: *route* to the solver
     # that can decide rather than catch the OOM and report degraded. The flip is
     # conditional on (a) a detected vendored SPASS path, (b) the prefer flag,
-    # (c) the default TWEETY solver — an explicit ``modal_solver`` choice is
-    # always respected (the #1219 regression test pins TWEETY via that path).
+    # (c) ``modal_solver == TWEETY``.
+    #
+    # ⚠ #1339 — this comment used to add "an explicit ``modal_solver`` choice is
+    # always respected". That is true for SPASS and FALSE for TWEETY, and the
+    # condition just above shows why it cannot be otherwise: the test is
+    # ``_prev_modal_solver == TWEETY``, which cannot tell an EXPLICIT TWEETY
+    # from the DEFAULT TWEETY — they are the same value. The prefer flag is the
+    # only thing that separates them. To pin TWEETY you must set BOTH
+    # ``modal_solver = TWEETY`` and ``modal_prefer_spass_when_available = False``;
+    # pinning the solver alone lets this site route to SPASS around the pin, and
+    # every ``"tweety" in msg`` traceability assert downstream reddens. The old
+    # sentence produced exactly that defect in several test fixtures
+    # (#1831, #1834).
     # Restored in ``finally`` so the global choice never leaks past this call
     # (#1219 lesson: no unconditional, leaked force-set).
     from argumentation_analysis.core.config import settings as _modal_settings

--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -7626,14 +7626,19 @@ async def _invoke_modal_logic(
     # ⚠ #1339 — this comment used to add "an explicit ``modal_solver`` choice is
     # always respected". That is true for SPASS and FALSE for TWEETY, and the
     # condition just above shows why it cannot be otherwise: the test is
-    # ``_prev_modal_solver == TWEETY``, which cannot tell an EXPLICIT TWEETY
-    # from the DEFAULT TWEETY — they are the same value. The prefer flag is the
-    # only thing that separates them. To pin TWEETY you must set BOTH
-    # ``modal_solver = TWEETY`` and ``modal_prefer_spass_when_available = False``;
-    # pinning the solver alone lets this site route to SPASS around the pin, and
-    # every ``"tweety" in msg`` traceability assert downstream reddens. The old
-    # sentence produced exactly that defect in several test fixtures
-    # (#1831, #1834).
+    # ``_prev_modal_solver == TWEETY``, which compares the field's VALUE — and
+    # an explicit TWEETY carries the same value as the default TWEETY. To pin
+    # TWEETY *against this site* you must set BOTH ``modal_solver = TWEETY`` and
+    # ``modal_prefer_spass_when_available = False``; pinning the solver alone
+    # lets this site route to SPASS around the pin, and every ``"tweety" in msg``
+    # traceability assert downstream reddens. The old sentence produced exactly
+    # that defect in several test fixtures (#1831, #1834).
+    #
+    # ⚠ That recipe is NOT a whole-process guarantee: it protects against THIS
+    # site, not against every one. ``_invoke_external_modal_solver`` (same file,
+    # ~L9937) forces SPASS on ``shutil.which("SPASS")`` alone — it reads neither
+    # setting and never restores. Tracked separately; do not read the BOTH
+    # recipe as protection there.
     # Restored in ``finally`` so the global choice never leaks past this call
     # (#1219 lesson: no unconditional, leaked force-set).
     from argumentation_analysis.core.config import settings as _modal_settings

--- a/tests/integration/argumentation_analysis/agents/core/logic/test_fp11_modal_kb_roundtrip.py
+++ b/tests/integration/argumentation_analysis/agents/core/logic/test_fp11_modal_kb_roundtrip.py
@@ -79,8 +79,10 @@ def tweety_solver():
     ``modal_prefer_spass_when_available`` is on and a vendored SPASS binary
     is detected (local dev machines), the resolver upgrades TWEETY to SPASS
     — the verdict stays authentic but its message names "spass", and this
-    file's ``"tweety" in msg`` traceability asserts redden. CI runners have
-    no vendored SPASS, which is why this only bites locally."""
+    file's ``"tweety" in msg`` traceability asserts redden. This only bites
+    locally NOT because CI runners lack SPASS (``ext_tools/spass/SPASS.exe`` is
+    git-tracked and ``_get_spass_path`` only tests existence, so every checkout
+    detects it) but because this directory is outside the gate's argv."""
     previous_solver = settings.modal_solver
     previous_prefer = settings.modal_prefer_spass_when_available
     settings.modal_solver = ModalSolverChoice.TWEETY

--- a/tests/integration/argumentation_analysis/agents/core/logic/test_spass_real.py
+++ b/tests/integration/argumentation_analysis/agents/core/logic/test_spass_real.py
@@ -124,13 +124,24 @@ class TestModalConsistencyDecidesViaDefault:
     def tweety_solver(self):
         """Force the pure-Java default (``TWEETY``/``SimpleMlReasoner``) for the
         test. This reasoner decides consistency via ``query`` with no external
-        binary — the honest, always-available modal path."""
-        previous = settings.modal_solver
+        binary — the honest, always-available modal path.
+
+        Pinning ``modal_solver`` alone is NOT enough (#1339): when
+        ``modal_prefer_spass_when_available`` is on and a vendored SPASS binary
+        is detected (local dev machines), the resolver upgrades TWEETY to SPASS
+        around the pin — the verdict stays authentic but its message names
+        "spass", and this class's ``"tweety" in msg`` traceability asserts
+        redden. CI runners have no vendored SPASS, which is why this only bites
+        locally: the pin is a no-op there and CI green cannot prove this fix."""
+        previous_solver = settings.modal_solver
+        previous_prefer = settings.modal_prefer_spass_when_available
         settings.modal_solver = ModalSolverChoice.TWEETY
+        settings.modal_prefer_spass_when_available = False
         try:
             yield
         finally:
-            settings.modal_solver = previous
+            settings.modal_solver = previous_solver
+            settings.modal_prefer_spass_when_available = previous_prefer
 
     def test_inconsistent_kb_reports_inconsistent(self, modal_bridge, tweety_solver):
         """An inconsistent modal KB (``Rain`` and ``!Rain``) must yield
@@ -258,12 +269,25 @@ class TestUnderscoredKbDecidesViaDefault:
 
     @pytest.fixture
     def tweety_solver(self):
-        previous = settings.modal_solver
+        """Same pin as the sibling class above, and the same reason it needs two
+        settings rather than one.
+
+        Pinning ``modal_solver`` alone is NOT enough (#1339): when
+        ``modal_prefer_spass_when_available`` is on and a vendored SPASS binary
+        is detected (local dev machines), the resolver upgrades TWEETY to SPASS
+        around the pin — the verdict stays authentic but its message names
+        "spass", and this class's ``"tweety" in msg`` traceability asserts
+        redden. CI runners have no vendored SPASS, which is why this only bites
+        locally: the pin is a no-op there and CI green cannot prove this fix."""
+        previous_solver = settings.modal_solver
+        previous_prefer = settings.modal_prefer_spass_when_available
         settings.modal_solver = ModalSolverChoice.TWEETY
+        settings.modal_prefer_spass_when_available = False
         try:
             yield
         finally:
-            settings.modal_solver = previous
+            settings.modal_solver = previous_solver
+            settings.modal_prefer_spass_when_available = previous_prefer
 
     def test_underscored_consistent_kb_decides_true(self, modal_bridge, tweety_solver):
         """A consistent KB with underscored atoms must DECIDE ``True`` via a real

--- a/tests/integration/argumentation_analysis/agents/core/logic/test_spass_real.py
+++ b/tests/integration/argumentation_analysis/agents/core/logic/test_spass_real.py
@@ -131,8 +131,14 @@ class TestModalConsistencyDecidesViaDefault:
         is detected (local dev machines), the resolver upgrades TWEETY to SPASS
         around the pin — the verdict stays authentic but its message names
         "spass", and this class's ``"tweety" in msg`` traceability asserts
-        redden. CI runners have no vendored SPASS, which is why this only bites
-        locally: the pin is a no-op there and CI green cannot prove this fix."""
+        redden. Why CI green cannot prove this fix: NOT because runners lack
+        SPASS — ``ext_tools/spass/SPASS.exe`` is git-tracked and
+        ``_get_spass_path`` only tests existence, so every checkout detects it.
+        The reason is that ``tests/integration/argumentation_analysis/`` is
+        outside the gate's argv (``ci.yml`` admits only ``orchestration``,
+        ``services``, ``workers``, ``api``). The pin is therefore NOT a no-op on
+        CI — it is what will keep these tests green the day this directory is
+        admitted."""
         previous_solver = settings.modal_solver
         previous_prefer = settings.modal_prefer_spass_when_available
         settings.modal_solver = ModalSolverChoice.TWEETY
@@ -277,8 +283,14 @@ class TestUnderscoredKbDecidesViaDefault:
         is detected (local dev machines), the resolver upgrades TWEETY to SPASS
         around the pin — the verdict stays authentic but its message names
         "spass", and this class's ``"tweety" in msg`` traceability asserts
-        redden. CI runners have no vendored SPASS, which is why this only bites
-        locally: the pin is a no-op there and CI green cannot prove this fix."""
+        redden. Why CI green cannot prove this fix: NOT because runners lack
+        SPASS — ``ext_tools/spass/SPASS.exe`` is git-tracked and
+        ``_get_spass_path`` only tests existence, so every checkout detects it.
+        The reason is that ``tests/integration/argumentation_analysis/`` is
+        outside the gate's argv (``ci.yml`` admits only ``orchestration``,
+        ``services``, ``workers``, ``api``). The pin is therefore NOT a no-op on
+        CI — it is what will keep these tests green the day this directory is
+        admitted."""
         previous_solver = settings.modal_solver
         previous_prefer = settings.modal_prefer_spass_when_available
         settings.modal_solver = ModalSolverChoice.TWEETY


### PR DESCRIPTION
Closes the sibling sweep called for by the R839 comment on #1339 (#1831 itself asks for no sweep — attribution corrigée après relecture) — **corrigé sur deux points**, parce que mon propre balayage était sous-dimensionné et que la racine n'était pas dans les tests.

## 1. Le défaut est à **deux** sites, pas un

`test_spass_real.py` porte le défaut de #1339 deux fois : deux fixtures **homonymes** `tweety_solver`.

| Fixture | Classe | Tests qui assertent la traçabilité |
|---|---|---|
| `:124` | `TestModalConsistencyDecidesViaDefault` | `:145`, `:160` |
| `:260` | `TestUnderscoredKbDecidesViaDefault` | `:279`, `:297` |

Les fixtures `spass_solver` (`:177`, `:313`) sont saines : elles pinnent SPASS et attendent `"spass"` — pin et attente concordent.

### Témoin né-rouge, reproduit firsthand
Machine avec `ext_tools/spass/SPASS.exe` présent (la CI n'en a pas) :
```
AVANT : 4 failed, 4 passed   → AssertionError: got msg='Knowledge base is inconsistent (spass).'
APRÈS : 8 passed
```

## 2. La racine n'est pas dans les tests — c'est le commentaire du réglage

`argumentation_analysis/core/config.py` documentait `modal_prefer_spass_when_available` ainsi :

> « Un utilisateur/fixture peut forcer TWEETY (False) pour tester le path SimpleMlReasoner explicitement — **un `modal_solver` explicitement choisi est toujours respecté**. »

C'est un #1019 : **le champ et son lecteur ne disent pas la même chose.** Le résolveur (`modal_handler.py`) :

```python
if settings.modal_solver == ModalSolverChoice.SPASS:
    return ModalSolverChoice.SPASS            # explicite SPASS → respecté ✓
if (settings.modal_solver == ModalSolverChoice.TWEETY
        and bool(settings.modal_prefer_spass_when_available)
        and _get_spass_path() is not None):
    return ModalSolverChoice.SPASS            # explicite TWEETY → ÉCRASÉ ✗
```

La promesse est vraie pour SPASS et **fausse pour TWEETY**. Et elle n'est pas seulement imprécise : elle est **inimplémentable en l'état**. TWEETY est à la fois la valeur par défaut et un choix explicite légitime — le résolveur n'a aucun moyen de les distinguer. **Ce drapeau _est_ le désambiguïsateur**, ce qui est exactement ce que la phrase niait.

Un auteur de fixture qui lit cette phrase pinne `modal_solver` seul et croit avoir fini. C'est ce qui s'est passé en #1831, et deux fois de plus ici. **Corriger la phrase ferme la source ; corriger les sites un par un ne fait que courir après.** (Commentaire seul, aucun changement de comportement, black clean, import vérifié.)

## 3. Correction de mon balayage R839 — une erreur de granularité

J'avais publié sur #1339 : « **1 seul** fichier porte le défaut, asserts `:145`/`:160` — non reproduit, pas de SPASS sur ai-01 ». **Les deux réserves étaient fausses** : SPASS *est* embarqué ici (une commande le montrait, je ne l'ai pas lancée), et il y a 4 rouges, pas 2.

La cause : le balayage AST a trouvé 4 fichiers, j'ai refusé de *compter* et j'ai discriminé — mais **au niveau du fichier** (« ce fichier asserte-t-il la traçabilité ? »), alors que **l'unité du défaut est la fixture**. Un fichier portant deux fois la même fixture rend un « oui » unique, et le second exemplaire devient invisible à l'étape même censée le débusquer. Discriminer au lieu de compter est nécessaire ; le faire à la granularité de l'objet défectueux l'est tout autant. Rectifié sur #1339 (issuecomment-5368973155).

## ⚠ La CI ne peut pas prouver la partie test

~~Les runners n'ont pas de SPASS embarqué ⇒ le pin du drapeau y est un no-op~~ — **RÉFUTÉ en relecture** : `git ls-files ext_tools/spass/` rend `SPASS.exe` **et** l'adaptateur, tous deux *tracked* ; `jvm_setup.py:701` enregistre le premier candidat qui `Path(...).exists()` et `_get_spass_path` ne teste jamais la lançabilité — **tout** checkout, CI comprise, détecte SPASS. La vraie et seule raison est que `tests/integration/argumentation_analysis/` est **hors argv du gate** (l'admission #1814 ne couvre que `orchestration`/`services`/`workers`/`api`). Prédiction : **gate inchangée**. Le seul témoin qui décide est le run local ci-dessus — même situation que #1831, mergée sur le même raisonnement.

## Black
`test_spass_real.py` est **déjà non conforme sur main** (vérifié par `git stash`) ; les 2 hunks réclamés portent sur des lignes que ce patch ne touche pas, et aucun reformat n'est mêlé au fix. `config.py` est clean.

## ⚠ PR du coordinateur
Auteur = coordinateur, pas un worker. Les deux lanes sont occupées (#1783, #1820) et le témoin décisif n'existe que sur cette machine. Aucune review ne peut se déclencher (workers et coord poussent sous la même identité GH) — le garde est procédural : **4 fichiers, +80/−12** (`config.py`, `invoke_callables.py`, `test_spass_real.py`, `test_fp11_modal_kb_roundtrip.py`) — 2 fixtures + 3 sites de commentaire, **aucune ligne non-commentaire dans les fichiers de production**, aucun `.github/`, aucun `.claude/rules/`, aucune donnée de corpus, aucun changement de comportement.

🤖 Coordinator ai-01 — R840


---

## Relecture par trois agents indépendants — ce qu'elle a changé

Trois relectures sur trois lentilles disjointes (**adversariale** / **périmètre-et-discipline** / **qualité-des-tests**) ont convergé sur le même verdict : *le code est propre par les trois mesures, le **texte** ne l'est pas.* Une PR dont la thèse est « je retire un commentaire-père qui enseignait une croyance fausse » en avait **installé trois nouvelles**. Corrigées par **soustraction**, jamais en remplaçant une phrase par son contraire.

| Affirmation | Où | Verdict | Geste |
|---|---|---|---|
| « c'est **inimplémentable en l'état** » | `config.py` | **RÉFUTÉE** — `model_fields_set` distingue un TWEETY explicite (`['modal_solver']`) du défaut (`[]`), et `object.__setattr__` ne le pollue pas (pydantic 2.11.10, mesuré) | soustraite ; la phrase mécanique vraie est conservée — le resolver compare la **valeur**, il ne consulte pas la provenance |
| « the prefer flag is **the only thing** that separates them » | `invoke_callables.py` | **RÉFUTÉE** (même mesure) | soustraite |
| « CI runners have **no vendored SPASS** … the pin is a **no-op** there » | 2 fixtures + le body | **RÉFUTÉE** — `SPASS.exe` est *tracked*, la détection ne teste que l'existence | remplacée par la vraie raison : **hors argv du gate**. La PR **sous-vendait son propre correctif** — le pin n'est pas un no-op sur CI, il est ce qui gardera ces tests verts le jour où ce répertoire entre dans l'argv |
| « **2 fichiers** » | body, *dans le paragraphe d'attestation lui-même* | **FAUX** (4 après correction) | corrigé sur place |
| « le balayage que **#1831** appelait » | body, ligne 1 | **MIS-ATTRIBUÉ** — #1831 ne demande aucun balayage | corrigé |

**Balayage élargi d'un site.** La phrase « CI n'a pas de SPASS » avait un jumeau **déjà mergé** : `test_fp11_modal_kb_roundtrip.py:83`, corrigé ici aussi. En revanche `test_modal_consistency_bounded_signature.py` énonce la chose **correctement** (« a vendored SPASS binary is detected (local dev machines) ») et est **délibérément laissé intact** — un balayage qui rougit tous les sites ne discrimine pas.

**Deux défauts de production trouvés en chemin, sortis en issues plutôt qu'ajoutés ici :**

- **#1845** — `_invoke_external_modal_solver` (~L9937) force SPASS sur `shutil.which("SPASS")` seul : il ne lit **ni** réglage et ne **restaure jamais**. `settings` étant un singleton de module, la fuite est *process-wide*. ⇒ la recette « poser les DEUX » ne protège **pas** de ce site-là, et le commentaire le dit désormais explicitement plutôt que de promettre une garantie qu'il ne tient pas.
- **#1846** — `modal_handler.py:326-327` : l'étiquette du verdict et le raisonneur sortent du **même résolveur appelé deux fois**. Substitution exécutée — raisonneur intégralement remplacé par SPASS, étiquette intacte ⇒ **8 passed**, aucun test du dépôt ne rougit. Le contrôle inverse (retirer la lecture du drapeau) rend **4 failed / 4 passed**, ce qui prouve que les asserts discriminent bien sur l'axe épinglé ici et ne doivent **pas** être touchés.

**Contrôles refaits après rebase sur `0002bd2f`** : `test_spass_real.py` **8 passed** (5,59 s), `test_fp11_modal_kb_roundtrip.py` **5 passed** (3,15 s), dette black **identique octet pour octet** à `main` sur le seul fichier qui en porte (2 hunks pré-existants, aucun chevauchement avec le diff). Aucune suppression de fichier, aucun `.github/`, aucun `.claude/rules/`, aucun secret, aucune donnée de corpus.

⚠ Rappel mesuré par la relecture périmètre : `ci.yml:37` porte `continue-on-error: true` sur l'étape black — un `lint-and-format SUCCESS` **ne certifie rien** sur black, dans un sens comme dans l'autre. Le seul témoin valable est la mesure locale ci-dessus.
