### PR TITLE
fix(tests): TestAspicCauseNotMasked stops traversing the LLM translator (#1836)

### DIFF
--- a/tests/unit/argumentation_analysis/orchestration/test_fallback_cause_not_masked_1826.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_fallback_cause_not_masked_1826.py
@@ -53,7 +53,19 @@ async def _aspic_with_failing_handler(monkeypatch):
         "analyze_aspic_framework",
         _boom,
     )
-    return await ic._invoke_aspic(SAMPLE_TEXT, {"arguments": ["a", "b"]})
+    # #1836 : sans règles fournies par l'appelant, _invoke_aspic traverse
+    # translate_to_aspic_rules (étape LLM) AVANT le handler stubbé — chaque
+    # test fuyait un POST réel vers un hôte LLM et passait par grâce d'un
+    # réseau vivant, plus faible que ce que son nom annonce. Les règles de
+    # l'appelant ne sont jamais écrasées (contrat documenté) et court-circuitent
+    # le translator : 0 egress, le test n'éprouve que la propagation de cause.
+    ctx = {
+        "arguments": ["a", "b"],
+        "defeasible_rules": [
+            {"head": "plausible_conclusion_1", "body": ["claim_a"], "name": "def_arg_1"}
+        ],
+    }
+    return await ic._invoke_aspic(SAMPLE_TEXT, ctx)
 
 
 class TestRankingCauseNotMasked:


### PR DESCRIPTION
## Summary

Closes #1836. The two `TestAspicCauseNotMasked` tests shipped in #1833 leaked one real LLM POST each: `_invoke_aspic` derives defeasible rules via `translate_to_aspic_rules` (a live LLM call, invoke_callables.py:4151-4157) **before** reaching the handler the test stubs. The monkeypatch neutralizes the handler, not the translator — so the gate metric went 4 → 6 on `7401abb6`.

## Fix

Supply `defeasible_rules` in the test helper's context. This short-circuits the translator at its documented guard (`if not context.get("defeasible_rules")` — "caller-supplied rules are never overridden"), so the test reaches the stubbed handler without any network step.

**Anti-pendule respected**: no `requires_api` marker added — the leak is removed, not relocated out of the gate's band (#1591 mode of failure, called out explicitly in the issue).

## Proof (same counter as the gate, fake ambient key)

| run | watched-LLM | detail |
|---|---|---|
| before (main `7401abb6`) | **2** | exactly the two tests named in the issue's CI breakdown (local host: openrouter.ai via ambient env; CI saw api.openai.com — same counter, same leak) |
| after (this PR) | **0** | 9 passed |

Témoin `TestRankingCauseNotMasked` stays green at 0 calls — the ranking path has no translator step, the natural experiment of the issue stands unmodified.

## DoD mapping (#1836)

- [x] Both `TestAspicCauseNotMasked` tests pass **without** outgoing calls — 0 watched-LLM locally
- [x] Following gate run reads `4 watched-LLM request(s)` — **verified on this PR's CI** (run 32534460865): `LLM egress (#1787): 4 watched-LLM request(s)`; per-test breakdown = exactly the four non-vacuity controls of `tests/unit/test_llm_egress_counter.py` (raw openai sdk, SK wrapper, httpx, httpx2) — the two aspic tests are gone from the breakdown
- [x] No `requires_api` marker added to the file
- [x] `TestRankingCauseNotMasked` stays green at 0 calls

## Files changed

`tests/unit/argumentation_analysis/orchestration/test_fallback_cause_not_masked_1826.py` — helper context gains `defeasible_rules` (+13/-1). No production code touched: the leak is in what the *test* exercises, not in `_invoke_aspic` (translator-before-handler is the intended #1425 behavior for genuine callers).