### PR TITLE
fix(tests): enrichment graceful tests match the delivered C.1-C.4 reality (#1813)

### DIFF
--- a/tests/integration/test_enrichment_workflow.py
+++ b/tests/integration/test_enrichment_workflow.py
@@ -1,21 +1,36 @@
-"""Tests for the enrichment workflow CLI and docs (Issue #413).
+"""Tests for the enrichment workflow CLI and docs (Issue #413, #1813).
 
 Validates:
 - tasks.py CLI parses commands and flags correctly
-- Graceful error when dependent scripts (C.1–C.4) are not yet available
+- Graceful error when a dependent script path is missing (injected — the
+  C.1-C.4 scripts are delivered now, so the "not yet available" premise
+  of the original tests is dead; the guarantee itself stays)
+- The delivered C.1-C.4 scripts are dispatched with the right argv, with
+  the subprocess intercepted so no real run fires from this file (the
+  pre-fix version executed build_pattern_report.py for real, which is
+  where the native abort of #1813 lived)
 - Enrichment doc exists and contains key sections
 - README points to Discourse Pattern Mining
 - Privacy guard catches intentional leaks
 """
 
+import importlib.util
 import pathlib
 import subprocess
 import sys
+import types
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent
 TASKS_CLI = REPO_ROOT / "scripts" / "dataset" / "tasks.py"
 ENRICH_DOC = REPO_ROOT / "docs" / "security" / "dataset_enrichment.md"
 README = REPO_ROOT / "README.md"
+
+
+def _load_tasks_module():
+    spec = importlib.util.spec_from_file_location("dataset_tasks", TASKS_CLI)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 class TestTasksCLI:
@@ -33,23 +48,63 @@ class TestTasksCLI:
         assert result.returncode != 0
         assert "--source" in result.stderr or "--source" in result.stdout
 
-    def test_pattern_rerun_graceful_missing_script(self):
-        result = subprocess.run(
-            [sys.executable, str(TASKS_CLI), "pattern-rerun", "--skip-existing"],
-            capture_output=True,
-            text=True,
+    def test_pattern_rerun_graceful_missing_script(self, monkeypatch, capsys):
+        tasks = _load_tasks_module()
+        monkeypatch.setattr(
+            tasks, "BATCH_SCRIPT", tasks.SCRIPTS_DIR / "definitely_missing_1813.py"
         )
-        assert result.returncode == 1
-        assert "not found" in result.stderr.lower()
+        rc = tasks.cmd_pattern_rerun(types.SimpleNamespace(skip_existing=True))
+        assert rc == 1
+        assert "not found" in capsys.readouterr().err.lower()
 
-    def test_pattern_report_graceful_missing_script(self):
-        result = subprocess.run(
-            [sys.executable, str(TASKS_CLI), "pattern-report"],
-            capture_output=True,
-            text=True,
+    def test_pattern_report_graceful_missing_script(self, monkeypatch, capsys):
+        tasks = _load_tasks_module()
+        monkeypatch.setattr(
+            tasks, "REPORT_SCRIPT", tasks.SCRIPTS_DIR / "definitely_missing_1813.py"
         )
-        assert result.returncode == 1
-        assert "not found" in result.stderr.lower()
+        rc = tasks.cmd_pattern_report(types.SimpleNamespace())
+        assert rc == 1
+        assert "not found" in capsys.readouterr().err.lower()
+
+    def test_delivered_scripts_exist(self):
+        tasks = _load_tasks_module()
+        assert tasks.ADD_SCRIPT.is_file(), "C.1-C.4 delivered: add_extract.py"
+        assert tasks.BATCH_SCRIPT.is_file(), "C.1-C.4 delivered: run_corpus_batch.py"
+        assert (
+            tasks.REPORT_SCRIPT.is_file()
+        ), "C.1-C.4 delivered: build_pattern_report.py"
+
+    def test_pattern_rerun_dispatches_delivered_script(self, monkeypatch):
+        tasks = _load_tasks_module()
+        captured = []
+        monkeypatch.setattr(
+            tasks,
+            "subprocess",
+            types.SimpleNamespace(call=lambda cmd: captured.append(cmd) or 0),
+        )
+        rc = tasks.cmd_pattern_rerun(types.SimpleNamespace(skip_existing=True))
+        assert rc == 0
+        assert captured == [
+            [
+                sys.executable,
+                str(tasks.BATCH_SCRIPT),
+                "--workflow",
+                "spectacular",
+                "--skip-existing",
+            ]
+        ]
+
+    def test_pattern_report_dispatches_delivered_script(self, monkeypatch):
+        tasks = _load_tasks_module()
+        captured = []
+        monkeypatch.setattr(
+            tasks,
+            "subprocess",
+            types.SimpleNamespace(call=lambda cmd: captured.append(cmd) or 0),
+        )
+        rc = tasks.cmd_pattern_report(types.SimpleNamespace())
+        assert rc == 0
+        assert captured == [[sys.executable, str(tasks.REPORT_SCRIPT)]]
 
     def test_invalid_command_exits_error(self):
         result = subprocess.run(


### PR DESCRIPTION
Closes item 1 of #1813 (the remaining open object). Item 2 (native abort / pybind11 family) is explicitly left un-hunted per the coordinator's R833 note.

## What changed

The two "graceful missing script" tests asserted `pattern-rerun` / `pattern-report` fail with `rc=1` + `not found` — a premise that died when the C.1–C.4 scripts landed (#437/#517/#527): the scripts exist, so both tests reddened on main, AND the second one executed `build_pattern_report.py` **for real** from the test file — which is where the native abort observed in #1813 lived (po-2023's comment 2: the fatal `Aborted` fired during the 4th test's subprocess chain).

Update-to-reality rather than removal — the graceful-failure guarantee stays, only the dead witness goes:

- **Graceful path by injection**: monkeypatch the module-level script constant to a missing path → the `rc=1` + `not found` on stderr contract is exercised independent of repository state (same mechanism, no dependence on scripts being absent).
- **Reality locks**: the three delivered scripts exist (`add_extract.py`, `run_corpus_batch.py`, `build_pattern_report.py`), and the dispatch builds the expected argv (`--workflow spectacular --skip-existing` for rerun) with `subprocess` intercepted — **no real run can fire from this file anymore**.

Note: the coordinator's R833 summary counted "3 graceful missing tests"; the grep is formal — there are **2** in this file (the third CLI test, `pattern-add` args, never asserted graceful-missing and stays green).

## Out of scope, proven preexisting

The 3 `TestReadmePointer` failures are untouched: proof by source — `Discourse Pattern Mining`, `dataset_enrichment`, `discourse_patterns` are **absent from README.md** (0/0/0 occurrences; removed by the #450 rewrite and the #847d1712 privacy cleanup), so they cannot pass on main. Same "legitimate behavior changed" family — reported on the issue for a separate claim.

## Witness (po-2025, local — the file lives outside the CI gate argv, so local is the deciding instrument)

| run | TestTasksCLI | TestReadmePointer |
|---|---|---|
| main `a3c0674d` | **2 failed** (both graceful) | 3 failed (preexisting) |
| this branch `905b2841` | **8/8 passed** | 3 failed (unchanged) |

Side observation logged on the issue, not chased: one solo run died in `jpype.startJVM` with a fatal access violation (the 22/22 benign startup AV turned fatal once in this session) — item-2 family, explicitly out of bounds.

## Files changed

`tests/integration/test_enrichment_workflow.py` (+72/−17) — test file only, zero production code.