### PR TITLE
docs(claude-md): correct the specialist capability counts (#1842)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,15 +164,28 @@ Operational → Base agents (Sherlock, Watson, JTMS, FOL, Modal logic)
 - **`pm/`** — `SherlockEnqueteAgent` (investigation orchestration)
 - **`pl/`** — Propositional logic agent
 - **`debate/`** — `DebateAgent(BaseAgent)` — multi-personality adversarial debate with Walton-Krabbe protocols, argument scoring, knowledge bases. Alias: `EnhancedArgumentationAgent`.
-- **`counter_argument/`** — `CounterArgumentAgent(BaseAgent)` — generates counter-arguments using 5 rhetorical strategies (reductio ad absurdum, counter-example, distinction, reformulation, concession). 5-criteria weighted evaluator.
-- **`governance/`** — Governance simulation: 7 voting methods (majority, Borda, Condorcet, approval, etc.), conflict resolution, consensus metrics. NOT a BaseAgent — logic exposed via plugin.
-- **`quality/`** — Argument quality evaluation: 9 virtue detectors (clarity, coherence, relevance, etc.). Exposed via plugin.
+- **`counter_argument/`** — `CounterArgumentAgent(BaseAgent)`. `definitions.py` carries **two distinct enums, do not conflate them**: `CounterArgumentType` (5 — direct refutation, counter-example, alternative explanation, premise challenge, reductio ad absurdum) and `RhetoricalStrategy` (5 — socratic questioning, reductio ad absurdum, analogical counter, authority appeal, statistical evidence). 5-criteria weighted evaluator.
+- **`governance/`** — Governance simulation. `governance_methods.py` exposes **7 governance methods**, of which **5 are voting rules** (majority, plurality, Borda, Condorcet, quadratic) and **2 are distributed-consensus protocols** (Byzantine, Raft) — the latter are not scrutins, do not count them as voting methods. `social_choice.py` adds **8 more social-choice functions**: approval voting, STV, Copeland, Kemeny-Young (+ a `_safe` variant), Schulze, Condorcet winner, pairwise matrix. Plus conflict resolution and consensus metrics. NOT a BaseAgent — logic exposed via plugin.
+- **`quality/`** — Argument quality evaluation: **9 virtue detectors** in `quality_evaluator.py`, named in French — `clarte`, `pertinence`, `presence_sources`, `refutation_constructive`, `structure_logique`, `analogie_pertinente`, `fiabilite_sources`, `exhaustivite`, `redondance_faible`. `agentic_virtue_detectors.py` adds LLM-backed variants through an **injectable** `LLMCallable` (so a grep for `kernel.invoke`/`ChatCompletion` will wrongly report this module as LLM-free). Exposed via plugin.
 
 ### Semantic Kernel Plugins (`argumentation_analysis/plugins/`)
 
-- **`quality_scoring_plugin.py`** — `QualityScoringPlugin`: 3 `@kernel_function` methods wrapping `ArgumentQualityEvaluator`
+- **`quality_scoring_plugin.py`** — `QualityScoringPlugin`: **4** `@kernel_function` methods wrapping `ArgumentQualityEvaluator` (`evaluate_argument_quality`, `get_quality_score`, `evaluate_with_cross_kb_context`, `list_virtues`)
 - **`french_fallacy_plugin.py`** — `FrenchFallacyPlugin`: 3 `@kernel_function` methods for 3-tier hybrid fallacy detection (French NLP)
-- **`governance_plugin.py`** — `GovernancePlugin`: 4 `@kernel_function` methods for voting, conflict detection, consensus metrics
+- **`governance_plugin.py`** — `GovernancePlugin`: **6** `@kernel_function` methods (`detect_conflicts_fn`, `resolve_conflict_fn`, `compute_consensus_metrics`, `list_governance_methods`, `social_choice_vote`, `find_condorcet_winner`)
+
+> ⚠ **Counting `@kernel_function` with a plain grep over-counts**: the class docstrings of
+> `quality_scoring_plugin.py` and `french_fallacy_plugin.py` each open a line with
+> `@kernel_function`, which `grep -c '^\s*@kernel_function'` scores as a decorator. Count the
+> decorated `def`s, not the decorator lines.
+
+> ⚠ **Capability declarations are currently doubled** (#1842): `debate`, `governance` and
+> `quality` each declare capabilities twice, in two disjoint vocabularies — once in
+> `orchestration/registry_setup.py` (the surface that actually runs) and once in their own
+> `__init__.register_with_capability_registry`, which for these three is called **only by
+> tests**. Only `counter_argument` is wired through its module function. When adding a
+> capability, add it to the surface `setup_registry` calls, and give it a consumer: several
+> declared capabilities are requested by no `find_*_for_capability` call at all.
 
 ### Lego Architecture (`argumentation_analysis/core/capability_registry.py`)
 


### PR DESCRIPTION
CLAUDE.md was the **father** of a wrong count — the place an author looks to decide what to write, so its errors propagate into every downstream description. Five entries were wrong; each correction below was measured against the source, not reasoned.

## Ce qui était faux, et la mesure

| Entrée | Ce que disait CLAUDE.md | Mesuré | Correction |
|---|---|---|---|
| `governance/` | « 7 voting methods (majority, Borda, Condorcet, **approval**, etc.) » | `governance_methods.py` a 7 `def`, mais **2 ne sont pas des scrutins** (`byzantine_consensus:84`, `raft_consensus:96` — protocoles de consensus distribué). `approval` **n'est pas dans ce fichier**. `social_choice.py` en porte **8 de plus**, non mentionnées. | 7 méthodes dont **5 scrutins** + **8 règles de choix social** |
| `counter_argument/` | « 5 rhetorical strategies (reductio ad absurdum, counter-example, **distinction, reformulation, concession**) » | `definitions.py` porte **deux enums distincts** de 5 membres chacun — `CounterArgumentType` et `RhetoricalStrategy`. La ligne les **confondait**, et 3 des 5 noms cités **n'existent nulle part**. | Les deux enums nommés séparément |
| `quality/` | « 9 virtue detectors (clarity, coherence, relevance, etc.) » | Le **compte de 9 est juste** ; les exemples ne le sont pas — les détecteurs sont nommés **en français** (`clarte`, `pertinence`, `presence_sources`, …). | Noms réels listés |
| `quality_scoring_plugin.py` | 3 `@kernel_function` | **4** | corrigé |
| `governance_plugin.py` | 4 `@kernel_function` | **6** | corrigé |
| `french_fallacy_plugin.py` | 3 `@kernel_function` | **3 — déjà juste** | **laissé intact** |

Le dernier point est délibéré : un balayage qui rougit tout ne discrimine pas. Le site déjà correct reste debout.

## Deux avertissements ajoutés — chacun est un piège rencontré en mesurant

1. **`grep -c '^\s*@kernel_function'` sur-compte.** Il rendait 5/4/6 ; les vrais comptes sont **4/3/6**. Deux docstrings de classe *commencent* une ligne par le mot `@kernel_function`, que le motif score comme un décorateur. Sans ce contrôle j'introduisais **deux nouvelles erreurs en en corrigeant une**. Compter les `def` décorés, pas les lignes de décorateur.
2. **Les déclarations de capacités sont doublées** (#1842) : `debate`, `governance` et `quality` déclarent chacun leurs capacités **deux fois, en vocabulaires disjoints** — une fois dans `orchestration/registry_setup.py` (la surface qui tourne réellement) et une fois dans leur propre `register_with_capability_registry`, qui pour ces trois-là n'est appelé **que par un test fabriquant sa propre population**.

Une note est aussi ajoutée sur `quality/` : il atteint un LLM par **dépendance injectée** (`LLMCallable`), donc un recensement par motif d'appel (`kernel.invoke`/`ChatCompletion`) le déclare à tort sans LLM. C'est un angle mort structurel du grep, pas une particularité locale.

## Contrôle externe

CoursIA #12256 écrivait « **7+** » méthodes de vote. C'était **plus juste que notre propre documentation** — un observateur externe lisant le code voyait mieux que notre fichier de référence.

## Périmètre

**1 fichier**, `CLAUDE.md`, +18/−5. Aucun code. Aucune suppression de fichier (la règle `## Files removed and why` ne s'applique pas). Aucun `.github/`, aucun `.claude/rules/`, aucune donnée de corpus.

🤖 Mesuré firsthand @ `myia-ai-01:2025-Epita-Intelligence-Symbolique`