### PR TITLE
docs(readme): restore the Discourse Pattern Mining pointer lost to the #450 rewrite (#1838)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,16 @@ Entry points: `api/main.py` (FastAPI), `argumentation_analysis/run_orchestration
 
 The analysis corpus is encrypted at rest. Passphrase is configured via `TEXT_CONFIG_PASSPHRASE` in `.env`. See [security documentation](docs/security/) for handling rules.
 
+## Discourse Pattern Mining
+
+Quantitative analysis of discourse signatures across the encrypted corpus — fallacy spectra, Tricherie/Influence asymmetry, co-occurrence patterns, and cross-coverage with formal reasoning.
+
+- **Report**: `docs/reports/discourse_patterns.md` (generated, committed with opaque IDs only)
+- **Enrichment workflow**: `docs/security/dataset_enrichment.md` — how to add new extracts and regenerate
+- **CLI**: `python scripts/dataset/tasks.py pattern-add|pattern-rerun|pattern-report`
+
+All analyses use opaque IDs; qualitative data remains local (`.analysis_kb/`, gitignored).
+
 ## Documentation
 
 | Directory             | Content                                       |


### PR DESCRIPTION
Closes #1838 (cas A — les 3 `TestReadmePointer`). Cas B déjà clos par #1841.

## La décision énoncée (ce que #1838 demande)

**Le pointeur est restauré, le test est conservé.** Le trancher demandait de savoir si la section avait été retirée *par décision* (privacy) ou *par accident* (réécriture) :

- `e011c2bd` (2026-05-05, #450 « rewrite README for visitor clarity ») emporte la section — **accident de réécriture**, un jour après sa livraison.
- Le scrub privacy `847d1712` (2026-05-11) est **postérieur de 6 jours** et ne touche que la section `Dataset` — il n'a **jamais vu** la section Pattern Mining. Aucun motif privacy dans le retrait.

Les deux cibles du pointeur existent toujours (`docs/reports/discourse_patterns.md`, `docs/security/dataset_enrichment.md`) : le test décrit un état vrai du dépôt que le README a cessé de refléter.

## Ce qui est restauré

La section `## Discourse Pattern Mining` de `34574286`, adaptée au style compact du README actuel (pas de `---`, insérée après `## Dataset`). Les lignes ne nomment **que des chemins** + la note opaque-IDs d'origine. La description reste exacte du rapport actuel : Fallacy Spectra (§1), Tricherie ↔ Influence (§2), Co-occurrence (§3), Cross-coverage Informal ↔ Formal (§5) tous présents.

Aucun contenu descriptif du corpus réintroduit : le scrub `847d1712` reste acquis (section `Dataset` inchangée), et le garde `test_readme_no_plaintext_refs_in_pattern_section` (forbidden `full_text`/`raw_text`/`source_name` sur les 2000 chars de la section) **passe**.

## Témoin (run réel, pas prédiction)

`python -m pytest tests/integration/test_enrichment_workflow.py -q`

| run | résultat |
|---|---|
| main `0002bd2f` | **3 failed, 15 passed** (1,13 s) — exactement les 3 `TestReadmePointer` |
| branche `fee242d3` | **18 passed, 0 failed** (0,50 s) |

Les 3 tests passent parce que le README pointe à nouveau vers deux fichiers existants — assertions inchangées (`test_enrichment_workflow.py:148-158`).

## DoD #1838

- [x] Cas A : les 3 `TestReadmePointer` passent par restauration du pointeur (aucune assertion modifiée)
- [x] Cas A : aucun détail de corpus réintroduit (scrub `847d1712` acquis ; garde privacy vert)
- [x] Cas B : sémantique « script absent = erreur (exit 1 + `not found`) » énoncée et livrée dans #1841 (injection de chemin absent) — aucune assertion élargie
- [x] Contrôle : `pytest tests/integration/test_enrichment_workflow.py` → **0 failed** (run cité ci-dessus)

## Diff

`README.md` seul, **+10 lignes, 0 suppression** (Cleanup Gate : rien à justifier côté suppressions).