### PR TITLE
fix(tests): repoint the 8 conversational patches to create_llm_service (#1839)

### DIFF
--- a/tests/integration/test_conversational_orchestration_integration.py
+++ b/tests/integration/test_conversational_orchestration_integration.py
@@ -11,6 +11,7 @@ Tests the full conversational pipeline with mock LLM, verifying:
 
 import asyncio
 import pytest
+from contextlib import contextmanager
 from unittest.mock import AsyncMock, MagicMock, patch, PropertyMock
 
 from argumentation_analysis.orchestration.conversational_orchestrator import (
@@ -51,6 +52,40 @@ def _make_mock_pipeline():
     return mock_kernel, mock_service, make_fake_agent
 
 
+@contextmanager
+def _pipeline_patches(mock_kernel, make_fake_agent):
+    """Every patch a run_conversational_analysis test needs, in one place.
+
+    The LLM double targets create_llm_service in the orchestrator namespace —
+    the module stopped importing OpenAIChatCompletion when #675 routed it
+    through the factory. Two post-processing stages also get doubles:
+    _invoke_stakes_extractor and _invoke_deep_synthesis build their own LLM
+    client inside invoke_callables, outside the orchestrator namespace, so
+    without these patches a budget-allowed run leaks one real LLM request.
+    """
+    with patch(
+        "argumentation_analysis.orchestration.conversational_orchestrator.create_llm_service"
+    ) as MockLLM, patch(
+        "argumentation_analysis.orchestration.conversational_orchestrator.sk.Kernel",
+        return_value=mock_kernel,
+    ), patch(
+        "argumentation_analysis.orchestration.conversational_orchestrator.ChatCompletionAgent",
+        side_effect=make_fake_agent,
+    ), patch(
+        "argumentation_analysis.agents.factory.get_plugin_instances",
+        return_value=[MagicMock()],
+    ), patch(
+        "argumentation_analysis.orchestration.invoke_callables._invoke_stakes_extractor",
+        new=AsyncMock(return_value={"error": "disabled in integration test"}),
+    ), patch(
+        "argumentation_analysis.orchestration.invoke_callables._invoke_deep_synthesis",
+        new=AsyncMock(return_value={"error": "disabled in integration test"}),
+    ), patch.dict(
+        "os.environ", {"OPENAI_API_KEY": "sk-test-fake-key"}
+    ):
+        yield MockLLM
+
+
 @pytest.mark.integration
 class TestConversationalPipelineIntegration:
     """End-to-end pipeline tests with mock LLM."""
@@ -59,20 +94,7 @@ class TestConversationalPipelineIntegration:
         """Full pipeline result contains all expected top-level fields."""
         mock_kernel, mock_service, make_fake_agent = _make_mock_pipeline()
 
-        with patch(
-            "argumentation_analysis.orchestration.conversational_orchestrator.sk.Kernel",
-            return_value=mock_kernel,
-        ), patch(
-            "argumentation_analysis.orchestration.conversational_orchestrator.OpenAIChatCompletion"
-        ) as MockLLM, patch(
-            "argumentation_analysis.orchestration.conversational_orchestrator.ChatCompletionAgent",
-            side_effect=make_fake_agent,
-        ), patch(
-            "argumentation_analysis.agents.factory.get_plugin_instances",
-            return_value=[MagicMock()],
-        ), patch.dict(
-            "os.environ", {"OPENAI_API_KEY": "sk-test-fake-key"}
-        ):
+        with _pipeline_patches(mock_kernel, make_fake_agent) as MockLLM:
             MockLLM.return_value = mock_service
             result = await run_conversational_analysis(
                 text=SAMPLE_TEXT, max_turns_per_phase=2
@@ -102,20 +124,7 @@ class TestConversationalPipelineIntegration:
         """The 3 macro-phases run in sequence: Extraction, Formal, Synthesis."""
         mock_kernel, mock_service, make_fake_agent = _make_mock_pipeline()
 
-        with patch(
-            "argumentation_analysis.orchestration.conversational_orchestrator.sk.Kernel",
-            return_value=mock_kernel,
-        ), patch(
-            "argumentation_analysis.orchestration.conversational_orchestrator.OpenAIChatCompletion"
-        ) as MockLLM, patch(
-            "argumentation_analysis.orchestration.conversational_orchestrator.ChatCompletionAgent",
-            side_effect=make_fake_agent,
-        ), patch(
-            "argumentation_analysis.agents.factory.get_plugin_instances",
-            return_value=[MagicMock()],
-        ), patch.dict(
-            "os.environ", {"OPENAI_API_KEY": "sk-test-fake-key"}
-        ):
+        with _pipeline_patches(mock_kernel, make_fake_agent) as MockLLM:
             MockLLM.return_value = mock_service
             result = await run_conversational_analysis(
                 text=SAMPLE_TEXT, max_turns_per_phase=2
@@ -179,20 +188,7 @@ class TestTraceAnalyzerIntegration:
         """Pipeline generates a non-empty trace report."""
         mock_kernel, mock_service, make_fake_agent = _make_mock_pipeline()
 
-        with patch(
-            "argumentation_analysis.orchestration.conversational_orchestrator.sk.Kernel",
-            return_value=mock_kernel,
-        ), patch(
-            "argumentation_analysis.orchestration.conversational_orchestrator.OpenAIChatCompletion"
-        ) as MockLLM, patch(
-            "argumentation_analysis.orchestration.conversational_orchestrator.ChatCompletionAgent",
-            side_effect=make_fake_agent,
-        ), patch(
-            "argumentation_analysis.agents.factory.get_plugin_instances",
-            return_value=[MagicMock()],
-        ), patch.dict(
-            "os.environ", {"OPENAI_API_KEY": "sk-test-fake-key"}
-        ):
+        with _pipeline_patches(mock_kernel, make_fake_agent) as MockLLM:
             MockLLM.return_value = mock_service
             result = await run_conversational_analysis(
                 text=SAMPLE_TEXT, max_turns_per_phase=2
@@ -208,20 +204,7 @@ class TestTraceAnalyzerIntegration:
         """Trace report captures transitions for all 3 phases."""
         mock_kernel, mock_service, make_fake_agent = _make_mock_pipeline()
 
-        with patch(
-            "argumentation_analysis.orchestration.conversational_orchestrator.sk.Kernel",
-            return_value=mock_kernel,
-        ), patch(
-            "argumentation_analysis.orchestration.conversational_orchestrator.OpenAIChatCompletion"
-        ) as MockLLM, patch(
-            "argumentation_analysis.orchestration.conversational_orchestrator.ChatCompletionAgent",
-            side_effect=make_fake_agent,
-        ), patch(
-            "argumentation_analysis.agents.factory.get_plugin_instances",
-            return_value=[MagicMock()],
-        ), patch.dict(
-            "os.environ", {"OPENAI_API_KEY": "sk-test-fake-key"}
-        ):
+        with _pipeline_patches(mock_kernel, make_fake_agent) as MockLLM:
             MockLLM.return_value = mock_service
             result = await run_conversational_analysis(
                 text=SAMPLE_TEXT, max_turns_per_phase=2
@@ -241,20 +224,7 @@ class TestCrossKBSynergies:
         """All phases share the same RhetoricalAnalysisState instance."""
         mock_kernel, mock_service, make_fake_agent = _make_mock_pipeline()
 
-        with patch(
-            "argumentation_analysis.orchestration.conversational_orchestrator.sk.Kernel",
-            return_value=mock_kernel,
-        ), patch(
-            "argumentation_analysis.orchestration.conversational_orchestrator.OpenAIChatCompletion"
-        ) as MockLLM, patch(
-            "argumentation_analysis.orchestration.conversational_orchestrator.ChatCompletionAgent",
-            side_effect=make_fake_agent,
-        ), patch(
-            "argumentation_analysis.agents.factory.get_plugin_instances",
-            return_value=[MagicMock()],
-        ), patch.dict(
-            "os.environ", {"OPENAI_API_KEY": "sk-test-fake-key"}
-        ):
+        with _pipeline_patches(mock_kernel, make_fake_agent) as MockLLM:
             MockLLM.return_value = mock_service
             result = await run_conversational_analysis(
                 text=SAMPLE_TEXT, max_turns_per_phase=2
@@ -270,20 +240,7 @@ class TestCrossKBSynergies:
         """State snapshot should be a serializable dict."""
         mock_kernel, mock_service, make_fake_agent = _make_mock_pipeline()
 
-        with patch(
-            "argumentation_analysis.orchestration.conversational_orchestrator.sk.Kernel",
-            return_value=mock_kernel,
-        ), patch(
-            "argumentation_analysis.orchestration.conversational_orchestrator.OpenAIChatCompletion"
-        ) as MockLLM, patch(
-            "argumentation_analysis.orchestration.conversational_orchestrator.ChatCompletionAgent",
-            side_effect=make_fake_agent,
-        ), patch(
-            "argumentation_analysis.agents.factory.get_plugin_instances",
-            return_value=[MagicMock()],
-        ), patch.dict(
-            "os.environ", {"OPENAI_API_KEY": "sk-test-fake-key"}
-        ):
+        with _pipeline_patches(mock_kernel, make_fake_agent) as MockLLM:
             MockLLM.return_value = mock_service
             result = await run_conversational_analysis(
                 text=SAMPLE_TEXT, max_turns_per_phase=2
@@ -301,55 +258,43 @@ class TestConversationLog:
         """Each log entry should have phase, turn, agent, content."""
         mock_kernel, mock_service, make_fake_agent = _make_mock_pipeline()
 
-        with patch(
-            "argumentation_analysis.orchestration.conversational_orchestrator.sk.Kernel",
-            return_value=mock_kernel,
-        ), patch(
-            "argumentation_analysis.orchestration.conversational_orchestrator.OpenAIChatCompletion"
-        ) as MockLLM, patch(
-            "argumentation_analysis.orchestration.conversational_orchestrator.ChatCompletionAgent",
-            side_effect=make_fake_agent,
-        ), patch(
-            "argumentation_analysis.agents.factory.get_plugin_instances",
-            return_value=[MagicMock()],
-        ), patch.dict(
-            "os.environ", {"OPENAI_API_KEY": "sk-test-fake-key"}
-        ):
+        with _pipeline_patches(mock_kernel, make_fake_agent) as MockLLM:
             MockLLM.return_value = mock_service
             result = await run_conversational_analysis(
                 text=SAMPLE_TEXT, max_turns_per_phase=2
             )
 
-        for entry in result["conversation_log"]:
+        # The log carries two families of entries: agent messages (phase/
+        # turn/agent/content) and typed system events — growth_validation,
+        # conflict_resolution, post_processing stages — which legitimately
+        # carry only phase + type + their own payload keys.
+        agent_entries = [e for e in result["conversation_log"] if "type" not in e]
+        system_entries = [e for e in result["conversation_log"] if "type" in e]
+        assert agent_entries, "no agent-message entries in conversation log"
+        for entry in agent_entries:
             assert "phase" in entry
             assert "turn" in entry
             assert "agent" in entry
             assert "content" in entry
+        for entry in system_entries:
+            assert "phase" in entry
+            assert entry["type"]
 
     async def test_multiple_agents_contribute_to_log(self):
         """Conversation log contains entries from multiple agents."""
         mock_kernel, mock_service, make_fake_agent = _make_mock_pipeline()
 
-        with patch(
-            "argumentation_analysis.orchestration.conversational_orchestrator.sk.Kernel",
-            return_value=mock_kernel,
-        ), patch(
-            "argumentation_analysis.orchestration.conversational_orchestrator.OpenAIChatCompletion"
-        ) as MockLLM, patch(
-            "argumentation_analysis.orchestration.conversational_orchestrator.ChatCompletionAgent",
-            side_effect=make_fake_agent,
-        ), patch(
-            "argumentation_analysis.agents.factory.get_plugin_instances",
-            return_value=[MagicMock()],
-        ), patch.dict(
-            "os.environ", {"OPENAI_API_KEY": "sk-test-fake-key"}
-        ):
+        with _pipeline_patches(mock_kernel, make_fake_agent) as MockLLM:
             MockLLM.return_value = mock_service
             result = await run_conversational_analysis(
                 text=SAMPLE_TEXT, max_turns_per_phase=2
             )
 
-        agents_in_log = set(entry["agent"] for entry in result["conversation_log"])
+        agents_in_log = {
+            entry["agent"]
+            for entry in result["conversation_log"]
+            if "type" not in entry
+        }
         assert (
             len(agents_in_log) >= 2
         ), f"Expected multiple agents in log, got: {agents_in_log}"


### PR DESCRIPTION
Closes #1839.

## Ce que le défaut était vraiment

Un défaut lu huit fois, comme l'issue l'énonçait : les 8 patches visaient `conversational_orchestrator.OpenAIChatCompletion`, attribut supprimé par #675 (`da5dbc14`) au profit de `create_llm_service`. Repointage vers ce que le module appelle réellement.

## Les deux réalités aval que le repoint seul a exposées (la « partie jugement » de l'issue)

**1. Le contrat du log portait sur un log qui n'existe plus.** Le run mocké émet des entrées système typées — `growth_validation` (`{'phase': ..., 're_prompt_count': 14, 'type': ...}`, production `conversational_orchestrator.py:2504`), `conflict_resolution` (#214), étages `post_processing` — qui n'ont légitimement pas `turn`/`agent`/`content`. `TestConversationLog` exigeait les 4 champs de CHAQUE entrée. Mise à jour du contrat (pas relâchement) : les 4 champs sur les entrées agent-message (`"type" not in entry`), `phase` + `type` non vide sur les entrées système, et `assert agent_entries` — un log sans aucune entrée agent reste rouge.

**2. Fuite LLM réelle, la même famille que #1836.** `_invoke_stakes_extractor` et `_invoke_deep_synthesis` construisent leur propre client LLM dans `invoke_callables` (`invoke_callables.py:10048`, `:10184`) — hors namespace patché. Chaque run autorisé par le budget horloge fuyait **1 POST réel vers openrouter.ai** (mesuré par le compteur egress #1787 : 2 requêtes dans le run fichier complet pré-fixe, 1 en run solo — positifs qui rendent le zéro post-fixe lisible), et payait ~40 s/test en timeouts de requête ratée (329 s → 5 s pour le fichier). Les deux reçoivent maintenant un double `AsyncMock(return_value={"error": ...})` dans le helper partagé.

Les 8 blocs de patches copiés-collés sont factorisés en un `_pipeline_patches()` unique — le 9ᵉ site n'aura plus à dériver.

## Témoins (runs réels, pas prédictions)

`python -m pytest tests/integration/test_conversational_orchestration_integration.py -q`

| étape | résultat |
|---|---|
| main `0002bd2f` (né-rouge) | **8 failed, 13 passed** (11,90 s) — AttributeError patch target |
| repoint seul | 6 verts, 2 rouges contrat + **2 fuites LLM** (openrouter.ai) |
| branche `de361928` | **21 passed, 0 failed** (5,17 s), **0 watched-LLM** |

## Contrôle de discrimination (exigé par le DoD)

Substitution dégénérée exécutée : `patch(create_llm_service, side_effect=RuntimeError("DEGENERATE DOUBLE"))` → **exactement les 8 tests pipeline rouges** (8 failed, 13 passed, 7,71 s), puis double normal restauré → 21 passed. Le patch repointé est sur le chemin vivant ; un `create=True` inertre serait resté vert face à cette rupture et ne peut pas passer ce contrôle. Pas de grep, exécution.

## DoD #1839

- [x] Les 8 tests passent (21 passed fichier entier, run cité)
- [x] Aucune modification de `conversational_orchestrator.py` (0 ligne production touchée)
- [x] Aucun `create=True` (le contrôle de discrimination le prouve par exécution)
- [x] Contrôle de discrimination effectué et cité ci-dessus
- [x] Runs cités, pas prédits

## Hors périmètre

Respecté : aucun des 11 autres rouges de #1783 touché. #1844 (#1838) est une PR séparée déjà en CI verte.