### PR TITLE
fix(modal): the consistency label observes the reasoner, not a second resolver read (#1846)

### DIFF
--- a/argumentation_analysis/agents/core/logic/modal_handler.py
+++ b/argumentation_analysis/agents/core/logic/modal_handler.py
@@ -323,8 +323,15 @@ class ModalHandler:
         # #1339: report the RESOLVED solver (SPASS when auto-routed), not the
         # raw ``settings.modal_solver`` — otherwise a conversational call that
         # auto-upgrades to SPASS would still label its verdict "tweety".
-        solver_name = self._resolve_active_solver_choice().value
+        # #1846 advances that fix one step: _get_active_reasoner() already
+        # consults _resolve_active_solver_choice(), so deriving the label
+        # from a SECOND call made label and reasoner two reads of one
+        # instrument — a reasoner swapped under the verdict kept deciding
+        # under a stale stamp (degenerate substitution: 8 passed, 0 red).
+        # The class name OBSERVES the object that will actually decide
+        # (SPASSMlReasoner vs SimpleMlReasoner).
         reasoner = self._get_active_reasoner()
+        solver_name = "spass" if "SPASS" in type(reasoner).__name__ else "tweety"
         logger.debug(f"Checking modal KB consistency with {solver_name}.")
 
         # #1326: normalize identifiers amont de parseBeliefBase so underscored

--- a/tests/unit/argumentation_analysis/agents/core/logic/test_modal_label_observes_reasoner_1846.py
+++ b/tests/unit/argumentation_analysis/agents/core/logic/test_modal_label_observes_reasoner_1846.py
@@ -1,0 +1,99 @@
+"""#1846 — the consistency label must OBSERVE the reasoner, not re-compute it.
+
+``modal_handler.py`` derived ``solver_name`` from a SECOND call to
+``_resolve_active_solver_choice()`` — the same instrument that
+``_get_active_reasoner()`` already consulted. Label and reasoner were two
+reads of one resolver, so they agreed vacuously: a reasoner swapped under the
+verdict kept deciding under a stale ``"tweety"`` stamp. The coordinator's
+degenerate substitution (replace ``_get_active_reasoner``'s body with the
+SPASS reasoner) left **every** ``"tweety" in msg`` assert green — 8 passed,
+zero red, on main.
+
+This file pins the fix: the label is derived from ``type(reasoner).__name__``
+(the observation) — the substitution below is that degenerate control, made
+permanent, and it must stay discriminating.
+"""
+
+from types import SimpleNamespace
+from unittest import mock
+
+from argumentation_analysis.agents.core.logic import modal_handler as mh_module
+from argumentation_analysis.agents.core.logic.modal_handler import ModalHandler
+from argumentation_analysis.core.config import ModalSolverChoice
+
+
+def _make_handler(monkeypatch, reasoner):
+    """Real ``ModalHandler`` over a stub initializer — no JVM needed.
+
+    Same shape as the #1759 bounded-signature harness: production path stays
+    genuine up to the reasoner call.
+    """
+    initializer = mock.MagicMock()
+    initializer.get_modal_parser.return_value = mock.MagicMock()
+    initializer.get_modal_reasoner.return_value = reasoner
+    handler = ModalHandler(initializer_instance=initializer)
+    # Substitution A (#1846): the reasoner the verdict will actually come
+    # from is SPASS-shaped, whatever the resolver says.
+    monkeypatch.setattr(handler, "_get_active_reasoner", lambda: reasoner)
+    monkeypatch.setattr(
+        handler, "_build_contradiction_probe", lambda belief_set: object()
+    )
+    monkeypatch.setattr(
+        mh_module,
+        "jpype",
+        SimpleNamespace(
+            JClass=lambda name: lambda payload: (name, payload),
+            JException=type("JException", (Exception,), {}),
+        ),
+    )
+    return handler
+
+
+class TestLabelObservesTheReasoner:
+    """#1846: solver_name is an observation of the reasoner object."""
+
+    def test_swapped_reasoner_moves_the_label_with_it(self, monkeypatch):
+        """Né-rouge: a SPASS-shaped reasoner under a TWEETY-resolved route.
+
+        Pre-fix the label re-computed the routing intention (tweety) while
+        the substituted reasoner decided — the exact blindness the issue
+        measured. Post-fix the label reports what type(reasoner) shows.
+        """
+
+        class SubstitutedSPASSReasoner:  # name carries SPASS — observed
+            def query(self, belief_set, formula):
+                return False  # does not entail contradiction -> consistent
+
+        handler = _make_handler(monkeypatch, SubstitutedSPASSReasoner())
+        # Pin the resolver to TWEETY so the two pre-fix reads would agree.
+        monkeypatch.setattr(
+            handler,
+            "_resolve_active_solver_choice",
+            lambda: ModalSolverChoice.TWEETY,
+        )
+
+        is_consistent, message = handler.is_modal_kb_consistent("[](p => q)")
+
+        assert is_consistent is True
+        assert "spass" in message
+        assert "tweety" not in message
+
+    def test_tweety_shaped_reasoner_keeps_the_tweety_label(self, monkeypatch):
+        """The derivation is not a blanket "always spass": a plain reasoner
+        under a plain route still labels tweety — routing unchanged."""
+
+        class PlainReasoner:
+            def query(self, belief_set, formula):
+                return False
+
+        handler = _make_handler(monkeypatch, PlainReasoner())
+        monkeypatch.setattr(
+            handler,
+            "_resolve_active_solver_choice",
+            lambda: ModalSolverChoice.TWEETY,
+        )
+
+        is_consistent, message = handler.is_modal_kb_consistent("[](p => q)")
+
+        assert is_consistent is True
+        assert "tweety" in message


### PR DESCRIPTION
Closes #1846.

## Le fix

`modal_handler.py` : `solver_name` était dérivé d'un **second** appel à `_resolve_active_solver_choice()` — le même instrument que `_get_active_reasoner()` consulte déjà. Étiquette et raisonneur = deux lectures d'un résolveur unique, d'accord vacuitaire. L'étiquette est maintenant dérivée de `type(reasoner).__name__` (`SPASSMlReasoner` vs `SimpleMlReasoner`) : une **observation** de l'objet qui décide réellement.

Le commentaire `:323` (#1339) est **avancé d'un cran**, pas régressé : pas de retour au `settings.modal_solver` brut — la fidélité passe de résolution → raisonneur.

## Témoins (exécutés, pas déduits)

| contrôle | résultat |
|---|---|
| Né-rouge sur main : substitution unitaire (reasoner SPASS-shaped sous résolveur pinné TWEETY) | **1 failed** — l'étiquette disait `tweety` |
| Après fix, même test | **passed** — étiquette `spass`, `"tweety" not in message` |
| Substitution A rejouée sur branche fixée (`_get_active_reasoner` → SPASS inconditionnel) | **4 failed / 4 passed** — exactement les 4 « via the DEFAULT pure-Java reasoner », là où **main mesurait 8 passed / 0 rouge** |
| Baseline branche fixée, `test_spass_real.py` complet | **8 passed** |
| Non-régression : bounded signature (#1759) + normalizer (#1326) + nouveaux tests | **28 passed** au total |

## DoD #1846

- [x] `solver_name` dérivé de l'objet reasoner réellement obtenu (nom de classe)
- [x] Test né-rouge : la substitution A fait maintenant rougir 4 tests (zéro sur main — mesuré des deux côtés)
- [x] Les 4 asserts `"tweety" in msg` intacts (la substitution B du coord avait déjà prouvé qu'ils discriminent le routage : 4F/4P)

## Anti-pendule respecté

`_resolve_active_solver_choice()` reste l'autorité du **routage** (`_get_active_reasoner` l'appelle toujours) ; seul le **label** a changé de source. Le test `test_tweety_shaped_reasoner_keeps_the_tweety_label` verrouille que la dérivation n'est pas un « toujours spass ».

## Diff

2 fichiers : `modal_handler.py` (+10/−2, commentaires + 2 lignes de code) + fichier de test dédié (`test_modal_label_observes_reasoner_1846.py`, pattern `_make_handler` réutilisé du harnais #1759 — vrai handler, stub initializer, pas de JVM).