### PR TITLE
fix(orchestration): the external modal solver repays the modal_solver loan (#1845)

### DIFF
--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -9954,28 +9954,48 @@ async def _invoke_external_modal_solver(
                 ready_initializer,
             )
 
-            if not settings.modal_solver == ModalSolverChoice.SPASS:
+            # #1845 decision, written where it applies: this site is
+            # INCONDITIONAL on binary presence — deliberately, unlike the
+            # pipeline routing site (~:7637, Track C #1279) which honors
+            # ``modal_prefer_spass_when_available``. The capability is
+            # registered as ``external_modal_solving`` (registry_setup.py) and
+            # requesting THAT service is the consent to run an external
+            # solver; the prefer flag governs routing, not this lane. What was
+            # missing here was never the guard — it was giving the setting
+            # BACK: the force below is a LOAN, not a doctrine change.
+            # ``settings`` is a module singleton, so an unrestored override
+            # leaks process-wide to every later caller (#1845). Both the loan
+            # and the restore go through ``object.__setattr__``, which leaves
+            # ``model_fields_set`` untouched — the default-vs-explicit
+            # provenance the #1339 discriminator reads stays intact.
+            _prev_modal_solver = settings.modal_solver
+            _loaned = _prev_modal_solver is not ModalSolverChoice.SPASS
+            if _loaned:
                 object.__setattr__(settings, "modal_solver", ModalSolverChoice.SPASS)
-            initializer = ready_initializer()
-            handler = ModalHandler(initializer_instance=initializer)
-            belief_set_str = "\n".join(str(f) for f in formulas)
-            is_consistent, msg = await asyncio.to_thread(
-                handler.is_modal_kb_consistent, belief_set_str
-            )
-            return {
-                "formulas": formulas,
-                # #1634: ``is_modal_kb_consistent`` is tri-state — the sibling
-                # phase (``_invoke_modal_logic``) already passes it through
-                # unflattened. This branch wrapped it in ``bool()``, so the
-                # external-solver lane reported a decided verdict where the
-                # reasoning lane reported none, for the very same KB.
-                "valid": is_consistent,
-                "modalities": modalities,
-                "solver": "spass",
-                "degraded": is_consistent is None,
-                "message": msg,
-                "logic_type": "modal",
-            }
+            try:
+                initializer = ready_initializer()
+                handler = ModalHandler(initializer_instance=initializer)
+                belief_set_str = "\n".join(str(f) for f in formulas)
+                is_consistent, msg = await asyncio.to_thread(
+                    handler.is_modal_kb_consistent, belief_set_str
+                )
+                return {
+                    "formulas": formulas,
+                    # #1634: ``is_modal_kb_consistent`` is tri-state — the sibling
+                    # phase (``_invoke_modal_logic``) already passes it through
+                    # unflattened. This branch wrapped it in ``bool()``, so the
+                    # external-solver lane reported a decided verdict where the
+                    # reasoning lane reported none, for the very same KB.
+                    "valid": is_consistent,
+                    "modalities": modalities,
+                    "solver": "spass",
+                    "degraded": is_consistent is None,
+                    "message": msg,
+                    "logic_type": "modal",
+                }
+            finally:
+                if _loaned:
+                    object.__setattr__(settings, "modal_solver", _prev_modal_solver)
         except Exception as e:
             logger.info(f"SPASS modal solver unavailable ({e}), falling back to Tweety")
     else:

--- a/tests/unit/argumentation_analysis/orchestration/test_external_modal_solver_restores_1845.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_external_modal_solver_restores_1845.py
@@ -1,0 +1,120 @@
+"""#1845 — the SPASS loan on ``settings.modal_solver`` must be repaid.
+
+``_invoke_external_modal_solver`` forced ``settings.modal_solver`` to SPASS on
+binary presence and NEVER restored it. ``settings`` is a module singleton, so
+the override leaked process-wide: every later caller inherited a solver it did
+not choose — including callers that had explicitly pinned TWEETY with both
+settings (the #1339 recipe, which this site does not read at all).
+
+Witness design: the test screens ``argumentation_analysis.core.config.settings``
+with a delegating object. Reads fall through to the real singleton; the
+function's ``object.__setattr__`` writes (which bypass every hook) land in the
+screen's ``__dict__`` — exactly what the production site will see and restore.
+The loan-repayment is asserted through the same path: after return, the value
+seen through ``settings`` must be back to the pinned TWEETY.
+
+``shutil.which("SPASS")`` is made to genuinely answer by placing a stub
+executable on the test PATH (the real detection runs — no module-level mock
+of shutil). The initializer fails ON PURPOSE so the repayment must survive
+the exception path, which is the path main leaks through.
+
+Born-red on main (measured): the screen's dict holds the forced SPASS after
+return; the assert fails.
+"""
+
+import asyncio
+import os
+from unittest import mock
+
+from argumentation_analysis.core.config import ModalSolverChoice
+import argumentation_analysis.core.config as cfg
+from argumentation_analysis.orchestration import invoke_callables
+
+
+def _put_stub_spass_on_path(monkeypatch, tmp_path):
+    """Make shutil.which("SPASS") genuinely answer, without mocking shutil."""
+    stub = tmp_path / "SPASS.exe"
+    stub.write_bytes(b"")  # never executed — only detected
+    monkeypatch.setenv("PATH", str(tmp_path) + ";" + os.environ["PATH"])
+    assert invoke_callables.shutil.which("SPASS") is not None
+
+
+class _SettingsScreen:
+    """Delegating screen over the real singleton.
+
+    The production site reads ``settings.modal_solver`` (delegated to the
+    real object) and writes via ``object.__setattr__`` (lands in this
+    screen's __dict__, bypassing __getattr__). The fix's finally-restore
+    writes back through the same channel — so what this screen's dict holds
+    after the call is exactly what the production site leaves behind.
+    """
+
+    def __init__(self, real):
+        object.__setattr__(self, "_real", real)
+
+    def __getattr__(self, name):
+        return getattr(object.__getattribute__(self, "_real"), name)
+
+
+class TestExternalModalSolverRestoresTheSetting:
+    """#1845: the force is a loan; the singleton must get it back."""
+
+    async def test_pinned_tweety_survives_the_spass_branch(self, monkeypatch, tmp_path):
+        _put_stub_spass_on_path(monkeypatch, tmp_path)
+
+        screen = _SettingsScreen(cfg.settings)
+        object.__setattr__(screen, "modal_solver", ModalSolverChoice.TWEETY)
+
+        # The handler lane fails on purpose: the finally-restore must hold on
+        # the EXCEPTION path too (that is the path main leaks through).
+        fake_initializer = mock.MagicMock(
+            side_effect=RuntimeError("synthetic initializer failure")
+        )
+        fake_bridge_cls = mock.MagicMock()
+        # to_thread calls it as a SYNC function in a worker thread.
+        fake_bridge_cls.return_value.execute_modal_query = mock.MagicMock(
+            return_value=(None, "stub fallback verdict")
+        )
+
+        with mock.patch.object(cfg, "settings", screen), mock.patch(
+            "argumentation_analysis.agents.core.logic.tweety_initializer.ready_initializer",
+            fake_initializer,
+        ), mock.patch(
+            "argumentation_analysis.agents.core.logic.tweety_bridge.TweetyBridge",
+            fake_bridge_cls,
+        ):
+            result = await invoke_callables._invoke_external_modal_solver(
+                "[](p => q)", {}
+            )
+
+        # The call completed via the Tweety fallback — the witness is not
+        # about the verdict but about what the call leaves behind.
+        assert result["solver"] == "tweety"
+        # #1845 né-rouge: main leaves the forced SPASS here, process-wide.
+        assert screen.__dict__["modal_solver"] == ModalSolverChoice.TWEETY
+
+    async def test_no_loan_when_solver_already_spass(self, monkeypatch, tmp_path):
+        """When the setting already says SPASS there is nothing to borrow: the
+        call must leave the value untouched (no force, no spurious restore)."""
+        _put_stub_spass_on_path(monkeypatch, tmp_path)
+
+        screen = _SettingsScreen(cfg.settings)
+        object.__setattr__(screen, "modal_solver", ModalSolverChoice.SPASS)
+
+        fake_initializer_mod = mock.MagicMock()
+        fake_handler = mock.MagicMock()
+        fake_handler.is_modal_kb_consistent = lambda kb: (True, "ok")
+
+        with mock.patch.object(cfg, "settings", screen), mock.patch(
+            "argumentation_analysis.agents.core.logic.tweety_initializer.ready_initializer",
+            return_value=fake_initializer_mod,
+        ), mock.patch(
+            "argumentation_analysis.agents.core.logic.modal_handler.ModalHandler",
+            return_value=fake_handler,
+        ):
+            result = await invoke_callables._invoke_external_modal_solver(
+                "[](p => q)", {}
+            )
+
+        assert result["solver"] == "spass"
+        assert screen.__dict__["modal_solver"] == ModalSolverChoice.SPASS


### PR DESCRIPTION
Closes #1845.

## Le défaut (les 3 propriétés du body, re-vérifiées)

`_invoke_external_modal_solver` (`invoke_callables.py` ~:9937) forçait `settings.modal_solver` à SPASS sur simple présence du binaire (`shutil.which`) et **ne le rendait jamais** — pas de `finally`, le singleton fuyait le override process-wide à chaque appelant ultérieur.

## Le fix

- **Le forçage devient un prêt** : valeur sauvegardée avant l'override, `try/finally` imbriqué qui restaure sur **tous** les chemins (return SPASS, exception handler, fallback Tweety — l'exception est le chemin que main fuit, il est testé explicitement).
- **Prêt et restitution passent par `object.__setattr__`** tous les deux → `model_fields_set` n'est pas pollué (la réserve du body : le discriminateur de provenance #1339 reste intact, pas besoin de `discard`).
- **La décision sur le drapeau est écrite sur place** (DoD item 2) : ce site reste **délibérément inconditionnel** sur la présence du binaire — la capacité s'appelle `external_modal_solving`, demander CE service est le consentement ; la politique `modal_prefer_spass_when_available` vit au site pipeline (~:7637, forme gardée #1279). Ce qui manquait était la restitution, pas le garde. Anti-pendule respecté : pas de suppression du forçage, pas de refactor des 3 sites.

## Le témoin né-rouge (né-rouge mesuré sur main)

Un **écran déléguant** sur `config.settings` : les lectures retombent sur le vrai singleton ; les `object.__setattr__` de la fonction atterrissent dans le `__dict__` de l'écran — exactement ce que le site production voit et restitue. Le pin et l'assert passent par le même chemin : déterministe, indépendant du runner.

- `shutil.which("SPASS")` répond **vraiment** : un `SPASS.exe` factice posé sur le PATH du test (la détection réelle s'exécute — pas de mock de shutil).
- L'initializer échoue **exprès** (RuntimeError synthétique) → la restitution doit tenir sur le chemin d'exception.

| contrôle | résultat |
|---|---|
| main (stash du fix) : test 1 | **1 failed** — l'écran retient le SPASS forcé après retour (le loan non rendu) |
| branche fixée : test 1 + test 2 | **2 passed** — TWEETY pinné survit ; déjà-SPASS reste intouché |
| famille modal complète : track_c_1279 (le jumeau gardé), garde #1804 (subprocess), invoke_modal_logic_nl_kb + témoins | **14 passed** |

## Diff

2 fichiers : `invoke_callables.py` (loan/finally + décision écrite, ~+25 lignes dans le bloc existant) + fichier de test dédié (`test_external_modal_solver_restores_1845.py`).

## Note de méthode

La première forme du témoin (pin sur la référence figée + assert post-appel) passait à tort sur main sous pytest malgré un forçage démontré par exécution (proxy instrumenté : le dict de l'écran portait le SPASS). L'écran déléguant supprime cette interférence du runner et rend le témoin discriminant sur toute machine.