### PR TITLE
docs(claude-md): the two capability surfaces share one term, they are not disjoint (#1842)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,12 +180,18 @@ Operational → Base agents (Sherlock, Watson, JTMS, FOL, Modal logic)
 > decorated `def`s, not the decorator lines.
 
 > ⚠ **Capability declarations are currently doubled** (#1842): `debate`, `governance` and
-> `quality` each declare capabilities twice, in two disjoint vocabularies — once in
-> `orchestration/registry_setup.py` (the surface that actually runs) and once in their own
+> `quality` each declare capabilities twice — once in `orchestration/registry_setup.py` (the
+> surface `setup_registry` populates) and once in their own
 > `__init__.register_with_capability_registry`, which for these three is called **only by
-> tests**. Only `counter_argument` is wired through its module function. When adding a
-> capability, add it to the surface `setup_registry` calls, and give it a consumer: several
-> declared capabilities are requested by no `find_*_for_capability` call at all.
+> tests**. Only `counter_argument` is wired through its module function. The two surfaces
+> share exactly one term, `adversarial_debate`; every *other* capability these three
+> `__init__`s declare has **zero** `find_*_for_capability` consumers (measured). Do not
+> "fix" this by calling the module function in addition to `setup_registry`: for `debate`
+> both surfaces use `register_agent` under the same name, so the second raises
+> `ValueError: Component 'debate_agent' is already registered` (measured); for `governance`
+> and `quality` it registers a *plugin* under a different name and silently adds capabilities
+> nobody requests. When adding a capability, add it to the surface `setup_registry`
+> populates, and give it a consumer.
 
 ### Lego Architecture (`argumentation_analysis/core/capability_registry.py`)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,15 +183,30 @@ Operational → Base agents (Sherlock, Watson, JTMS, FOL, Modal logic)
 > `quality` each declare capabilities twice — once in `orchestration/registry_setup.py` (the
 > surface `setup_registry` populates) and once in their own
 > `__init__.register_with_capability_registry`, which for these three is called **only by
-> tests**. Only `counter_argument` is wired through its module function. The two surfaces
-> share exactly one term, `adversarial_debate`; every *other* capability these three
-> `__init__`s declare has **zero** `find_*_for_capability` consumers (measured). Do not
+> tests**. `setup_registry` calls exactly one module function, `counter_argument`'s. A fifth
+> such function, in `synthesis/deep_synthesis_agent.py`, has **no caller at all** — not even
+> a test — and duplicates a service `setup_registry` already registers.
+>
+> Across those three, the two surfaces share **exactly one capability**: `debate`'s
+> `adversarial_debate` (`governance` and `quality` share none; `quality_scoring` looks shared
+> but is a *capability* in A and a component *name* in B). Every other capability the three
+> `__init__`s declare is requested nowhere — 0 on both consumer surfaces, measured. Do not
 > "fix" this by calling the module function in addition to `setup_registry`: for `debate`
 > both surfaces use `register_agent` under the same name, so the second raises
 > `ValueError: Component 'debate_agent' is already registered` (measured); for `governance`
-> and `quality` it registers a *plugin* under a different name and silently adds capabilities
-> nobody requests. When adding a capability, add it to the surface `setup_registry`
+> and `quality` it registers a *plugin* under a different name and adds capabilities nobody
+> requests, with no error. When adding a capability, add it to the surface `setup_registry`
 > populates, and give it a consumer.
+
+> ⚠ **"Requested" means `add_phase(capability="…")`, not `find_*_for_capability("…")`.**
+> Phases are what consume capabilities: `workflow_dsl.py` resolves `phase.capability` through
+> `find_for_capability` at run time, and production carries **49** distinct `capability=`
+> literals (89 counting tests and examples). Literal `find_*_for_capability("…")` calls are almost entirely a *test* idiom —
+> **57** sites under `tests/`, and in production exactly **one** real call site (plus one
+> inside a docstring). Counting consumers with that grep measures the test suite, not the
+> system: `argument_quality` (30 phases), `counter_argument_generation` (16),
+> `governance_simulation` (15) and `adversarial_debate` (11) are all consumed on real runs
+> while having almost no literal `find_*` site.
 
 ### Lego Architecture (`argumentation_analysis/core/capability_registry.py`)
 


### PR DESCRIPTION
Corrige la phrase que j'ai mergée il y a une heure dans `2c65e79e`. Signalement de `myia-po-2025` : `adversarial_debate` figure dans les **deux** surfaces, ce qui contredit « two disjoint vocabularies ».

## Ce qui est mesuré

| | surface A (`registry_setup`) | surface B (`__init__`) |
|---|---|---|
| `debate` | `adversarial_debate`, `argument_stress_test`, `debate_scoring` | **`adversarial_debate`**, `argument_generation`, `strategy_adaptation`, `opponent_analysis`, `argument_scoring` |
| `governance` | `governance_simulation`, `multi_method_voting`, `preference_aggregation` | `collective_decision_making`, `voting_methods`, `conflict_resolution`, `consensus_metrics` |
| `quality` | `argument_quality`, `virtue_detection`, `quality_scoring` | `argument_quality_evaluation`, `virtue_scoring` |

Terme partagé : **exactement un**, `adversarial_debate` — et c'est le seul terme de surface B avec un demandeur (3 sites). Les dix autres sont à 0. Instrument avec contrôle positif : `fallacy_detection` 8, `argument_quality` 4.

## Le fait que « vocabulaires parallèles » masquait

Les trois paires n'ont pas la même forme. Témoin exécuté sur main :

```
r = setup_registry()
debate      -> ValueError: Component 'debate_agent' is already registered.
governance  -> OK, plugin 'governance'        (autre nom, autre type)
quality     -> OK, plugin 'quality_scoring'
```

Câbler la surface B en plus de A ne diluerait pas une métrique pour `debate` : **le registre ne se construirait plus**. C'est un anti-pendule plus fort que celui que la phrase portait.

## Piège d'instrument rencontré

`setup_registry` **ne prend pas de registre** — elle crée et retourne le sien (`include_optional: bool` est son unique paramètre). Un `setup_registry(mon_registre)` passe le registre comme drapeau, jette le résultat, et fait paraître les trois spécialistes **absents de la production** — faux négatif qui inverse la lecture du ticket. Rencontré et écarté ; la note est dans le body de #1842.

## Contrôles

- Grep de la **classe** d'affirmation (pas de la phrase supprimée) : il a trouvé une seconde occurrence vivante dans le **résumé d'ouverture** de #1842, corrigée aussi.
- Comptes `@kernel_function` re-vérifiés à l'**AST** : 4 / 3 / 6 — conformes à ce que CLAUDE.md annonce, et l'avertissement de sur-comptage nomme exactement les deux fichiers concernés.
- `Only counter_argument is wired through its module function` : 1 seul import de `register_with_capability_registry` dans `registry_setup.py`, et c'est le sien.

Refs #1842.

---

## Amendement `84f17ba4` — relecture adversariale du diff de cette PR

Cette PR corrige un texte faux. Par la leçon mesurée au round précédent, c'est **l'endroit le plus exposé pour en écrire un nouveau** — j'ai donc fait relire son propre diff. Trois défauts trouvés, tous dans le texte que je venais d'écrire :

**1. Le critère de consommation nommait le mauvais mécanisme (le plus grave).** Le *fait* était juste, le *conseil* trompeur. Les capacités sont demandées par `add_phase(capability="…")`, que `workflow_dsl.py:654` résout via `find_for_capability` à l'exécution — **49** littéraux distincts en production. Les appels littéraux `find_*_for_capability("…")` sont un **idiome de test** : **57** sites sous `tests/`, et en production **un seul** site réel (plus un dans une docstring). Mesure qui tranche :

| capacité | `add_phase` | `find_*` littéral |
|---|---|---|
| `argument_quality` | **30** | 4 |
| `counter_argument_generation` | **16** | 2 |
| `governance_simulation` | **15** | 1 |
| `adversarial_debate` | **11** | 3 |
| les 10 de surface B | **0** | 0 |

Compter les consommateurs au grep `find_*` mesure la suite de tests, pas le système. Un lecteur suivant l'ancien conseil aurait écrit une forme d'appel que le système n'utilise pas.

**2. « exactly one term » était mesuré sur trois modules, asserté sur « the two surfaces »** — dont le paragraphe venait d'élargir le vocabulaire à `counter_argument`. Portée maintenant écrite là où le compte est fait. Vérifié : `debate ∩ = {adversarial_debate}`, `governance ∩ = ∅`, `quality ∩ = ∅`. Le piège `quality_scoring` est nommé : **capacité** en A, **nom de composant** en B — il paraît partagé et ne l'est pas.

**3. Le doublement touche un quatrième module.** `synthesis/deep_synthesis_agent.py` définit un cinquième `register_with_capability_registry` avec **zéro appelant** — pas même un test, confirmé par un balayage tous types de fichiers — dupliquant un service que `setup_registry` enregistre déjà. « called only by tests » n'avait pas de case pour cet état.

Sur-affirmation retirée au passage : `register()` émet un `logger.info`, donc le chemin plugin n'est pas « silencieux », seulement sans erreur.

⚠ Écart d'instruments rencontré : mon « 89 littéraux » et le « 49 » du relecteur étaient **deux portées**, pas deux vérités (89 = dépôt entier, 49 = production). Le chiffre publié porte désormais sa portée.
