### PR TITLE
test(integration): the einstein and webapp failures name their cause (#1840)

### DIFF
--- a/tests/integration/test_einstein_demo_real.py
+++ b/tests/integration/test_einstein_demo_real.py
@@ -655,8 +655,10 @@ class TestEinsteinPerformanceMetrics:
                     stderr=asyncio.subprocess.PIPE,
                 )
 
+                memory_budget_seconds = 60.0
+                started = time.monotonic()
                 stdout, stderr = await asyncio.wait_for(
-                    process.communicate(), timeout=60.0
+                    process.communicate(), timeout=memory_budget_seconds
                 )
 
                 assert (
@@ -683,7 +685,22 @@ class TestEinsteinPerformanceMetrics:
                     ), f"Problème mémoire détecté: {issue}"
 
             except asyncio.TimeoutError:
-                pytest.fail("Timeout test mémoire")
+                # #1840: the bare message made a one-second overrun and a full
+                # deadlock indistinguishable. Carry the applied budget, the
+                # elapsed time, and whatever the demo printed before cutoff.
+                elapsed = time.monotonic() - started
+                try:
+                    process.kill()
+                    stdout, stderr = await process.communicate()
+                except Exception:
+                    stdout = stderr = b""
+                stdout_tail = stdout.decode("utf-8", errors="replace")[-2000:]
+                stderr_tail = stderr.decode("utf-8", errors="replace")[-2000:]
+                pytest.fail(
+                    f"Timeout test mémoire: budget={memory_budget_seconds}s, "
+                    f"écoulé={elapsed:.1f}s, returncode={process.returncode}, "
+                    f"stdout_tail={stdout_tail!r}, stderr_tail={stderr_tail!r}"
+                )
             except Exception as e:
                 pytest.fail(f"Erreur test mémoire: {e}")
 

--- a/tests/integration/webapp/test_full_webapp_lifecycle.py
+++ b/tests/integration/webapp/test_full_webapp_lifecycle.py
@@ -2,6 +2,7 @@ import pytest
 import sys
 import psutil
 import asyncio
+from pathlib import Path
 
 sys.path.insert(0, ".")
 
@@ -9,6 +10,48 @@ from argumentation_analysis.webapp.orchestrator import (
     UnifiedWebOrchestrator,
     WebAppStatus,
 )
+
+
+def _webapp_log_offset(orchestrator) -> int:
+    """Byte offset of the orchestrator's log file before the attempt (#1840)."""
+    for handler in getattr(orchestrator.logger, "handlers", []):
+        base = getattr(handler, "baseFilename", None)
+        if base and Path(base).exists():
+            return Path(base).stat().st_size
+    return 0
+
+
+def _webapp_failure_reason(orchestrator, log_offset: int = 0) -> str:
+    """The orchestrator's own reason for a failed start (#1840).
+
+    ``start_webapp()`` returns a bare bool; the orchestrator knows why it
+    failed (port, startup timeout, mute health endpoint) and writes it to its
+    log — with ``propagate = False``, so caplog cannot see it. Read the state
+    it leaves (status, attempted port, pid) plus the log lines written during
+    THIS run only (the log file appends across runs).
+    """
+    info = orchestrator.app_info
+    parts = [
+        f"status={getattr(info.status, 'value', info.status)}",
+        "port_tente="
+        f"{getattr(getattr(orchestrator, 'backend_manager', None), 'port', None)}",
+        f"backend_pid={info.backend_pid}",
+    ]
+    for handler in getattr(orchestrator.logger, "handlers", []):
+        base = getattr(handler, "baseFilename", None)
+        if not base or not Path(base).exists():
+            continue
+        with open(base, "r", encoding="utf-8", errors="replace") as f:
+            f.seek(log_offset)
+            lines = f.read().splitlines()
+        tail = "\n".join(lines[-40:]) if lines else "(log vide pour ce run)"
+        parts.append(
+            "\n--- log orchestrateur (40 dernières lignes de ce run) ---\n" + tail
+        )
+        break
+    else:
+        parts.append("(aucun fichier de log trouvé)")
+    return "\n".join(parts)
 
 
 @pytest.fixture
@@ -68,9 +111,10 @@ def test_backend_lifecycle(orchestrator):
         pid_before_stop = None
         try:
             # Start the webapp (only backend enabled)
+            log_offset = _webapp_log_offset(orchestrator)
             success = await orchestrator.start_webapp()
 
-            assert success is True
+            assert success is True, _webapp_failure_reason(orchestrator, log_offset)
             assert orchestrator.app_info.status == WebAppStatus.RUNNING
             assert orchestrator.app_info.backend_pid is not None
             pid_before_stop = orchestrator.app_info.backend_pid


### PR DESCRIPTION
## What

The last two reds of the #1783 triage converted diagnosable failures into opaque ones. This PR makes each failure name its own cause — **measurement only, no functional fix** (issue anti-pendulum: the first deliverable is the number and the named cause).

### 1. `test_memory_efficiency_einstein` (was: `Failed: Timeout test mémoire`)

The `TimeoutError` branch relayed neither the budget nor the elapsed time nor the output. Now:

```
Failed: Timeout test mémoire: budget=60.0s, écoulé=12.3s, returncode=1, stdout_tail='…last 2000 chars…', stderr_tail='…'
```

On timeout the process is killed then drained (`communicate()` after kill returns the buffered output).

### 2. `test_backend_lifecycle` (was: `assert False is True`)

`start_webapp()` returns a bare bool; the orchestrator's reason lives in a `propagate = False` logger (caplog cannot see it) and in `trace_log` — which this test's `no_trace=True` fixture leaves **empty** (`add_trace` early-returns). The assert now carries the orchestrator's own state — status, attempted port (`backend_manager.port`), pid — plus the last 40 log lines **this run** wrote, read from the FileHandler's `baseFilename` with a per-run byte offset (the log file appends across runs).

## Instrument positive (degenerate substitution, executed)

Budget substituted 60.0 → 0.1s: the enriched message fired as designed — `budget=0.1s, écoulé=0.1s, returncode=1, stdout_tail='', stderr_tail=''` — then restored. The instrument has produced its positive; its zeros are readable.

## DoD: determinism classification (po-2025, main `0c0d7426`, env `projet-is-roo-new`)

| Test | 3 runs standalone | In full-tree run | Verdict |
|---|---|---|---|
| einstein | **3/3 green** — 9.24 / 5.65 / 5.30 s vs 60 s budget (margin ≥ 6.5×) | green (R850, this machine) | **machine/load-dependent** — red only in ai-01's full-tree run; standalone the budget is not even approached, a timeout needs a ~10× degradation |
| webapp | **3/3 red** — 8.02 / 7.99 / 8.0 s, identical cause each run | red (this machine + ai-01) | **deterministic** |

## The webapp cause, named by the new message

```
AssertionError: status=error
  port_tente=9020
  backend_pid=None
  [BACKEND] Erreur critique lors du lancement du processus backend:
  Failed to find environment 'projet-is'.
  FileNotFoundError: Could not find Python executable for environment 'projet-is'.
```

`MinimalBackendManager.start()` spawns the backend via `run_in_activated_env_async(env_name="projet-is")` (orchestrator.py:264, commented "Nom symbolique" — misleading: the name is load-bearing). `project_core/utils/shell.py` resolves it to a conda env named `projet-is` **or** a venv at `venvs/projet-is/` and raises otherwise. Machines without either cannot pass this test at any load or port — the coupling is to an environment *name*, not to code. (po-2023 reportedly has `C:/Tools/miniconda3/envs/projet-is` yet the sweep still showed this test red there — RAPPORTÉ, not measured here; a second cause may exist on that machine.)

## What this PR deliberately does NOT do

- No `xfail`/`skip` (webapp may be a real environment-coupling defect — marking it would hide it).
- No timeout increase on einstein (nothing measured says 60 s is too low; standalone runs sit at ≤ 9.2 s).
- No fix to the `projet-is` coupling — the fix decision (config-driven env name, `sys.executable` fallback, or an honest skip-when-absent) belongs to the follow-up, now that the cause is named.

## Files changed (2 test files, +64/−3)

- `tests/integration/test_einstein_demo_real.py` — enriched TimeoutError branch
- `tests/integration/webapp/test_full_webapp_lifecycle.py` — `_webapp_log_offset`/`_webapp_failure_reason` helpers + assert message

Full files re-run: **9 passed, 1 failed** (the deterministic webapp red — the finding itself, not a regression). Black clean. No deletions (Cleanup Gate n/a).

Closes #1840