### PR TITLE
fix(governance): one capability surface per module, every entry demanded (#1842)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,24 +179,19 @@ Operational → Base agents (Sherlock, Watson, JTMS, FOL, Modal logic)
 > `@kernel_function`, which `grep -c '^\s*@kernel_function'` scores as a decorator. Count the
 > decorated `def`s, not the decorator lines.
 
-> ⚠ **Capability declarations are currently doubled** (#1842): `debate`, `governance` and
-> `quality` each declare capabilities twice — once in `orchestration/registry_setup.py` (the
-> surface `setup_registry` populates) and once in their own
-> `__init__.register_with_capability_registry`, which for these three is called **only by
-> tests**. `setup_registry` calls exactly one module function, `counter_argument`'s. A fifth
-> such function, in `synthesis/deep_synthesis_agent.py`, has **no caller at all** — not even
-> a test — and duplicates a service `setup_registry` already registers.
->
-> Across those three, the two surfaces share **exactly one capability**: `debate`'s
-> `adversarial_debate` (`governance` and `quality` share none; `quality_scoring` looks shared
-> but is a *capability* in A and a component *name* in B). Every other capability the three
-> `__init__`s declare is requested nowhere — 0 on both consumer surfaces, measured. Do not
-> "fix" this by calling the module function in addition to `setup_registry`: for `debate`
-> both surfaces use `register_agent` under the same name, so the second raises
-> `ValueError: Component 'debate_agent' is already registered` (measured); for `governance`
-> and `quality` it registers a *plugin* under a different name and adds capabilities nobody
-> requests, with no error. When adding a capability, add it to the surface `setup_registry`
-> populates, and give it a consumer.
+> ⚠ **One capability surface per module** (#1842, resolved): `debate`, `governance`,
+> `quality` and `synthesis/deep_synthesis_agent` each used to declare capabilities on a
+> second surface (`__init__.register_with_capability_registry`) that only tests — or nobody —
+> called. Those dead functions are deleted; the one table per module is the production
+> surface `orchestration/registry_setup.py` populates (`counter_argument` keeps its module
+> function, which `setup_registry` imports and calls). Each specialist's routing entry is
+> the capability production demands: `adversarial_debate`, `argument_quality`,
+> `governance_simulation`, `counter_argument_generation`, `deep_synthesis` — internal
+> features (scoring, virtues, voting methods) are not separate registry entries.
+> `tests/unit/argumentation_analysis/orchestration/test_one_capability_surface_1842.py`
+> guards both invariants: any new unwired definer reddens, and so does a declared
+> capability with zero production demanders. When adding a capability, add it to the surface
+> `setup_registry` populates, **and give it a consumer** — a phase asking for it.
 
 > ⚠ **"Requested" means `add_phase(capability="…")`, not `find_*_for_capability("…")`.**
 > Phases are what consume capabilities: `workflow_dsl.py` resolves `phase.capability` through

--- a/argumentation_analysis/agents/core/counter_argument/__init__.py
+++ b/argumentation_analysis/agents/core/counter_argument/__init__.py
@@ -41,17 +41,17 @@ __all__ = [
 
 
 def register_with_capability_registry(registry):
-    """Register counter-argument capabilities with the Lego registry."""
+    """Register counter-argument capabilities with the Lego registry.
+
+    #1842: this is the module's ONE capability table — the surface
+    ``registry_setup.setup_registry`` imports and calls. The routing entry
+    is the phase ask (``counter_argument_generation``); parsing,
+    vulnerability analysis, strategies and evaluation run inside the agent.
+    """
     registry.register_agent(
         name="counter_argument_agent",
         agent_class=CounterArgumentAgent,
-        capabilities=[
-            "counter_argument_generation",
-            "argument_parsing",
-            "vulnerability_analysis",
-            "rhetorical_strategy",
-            "counter_argument_evaluation",
-        ],
+        capabilities=["counter_argument_generation"],
         metadata={
             "description": (
                 "Generates counter-arguments using 5 rhetorical strategies, "

--- a/argumentation_analysis/agents/core/debate/__init__.py
+++ b/argumentation_analysis/agents/core/debate/__init__.py
@@ -62,24 +62,8 @@ __all__ = [
     "PersuasionProtocol",
 ]
 
-
-def register_with_capability_registry(registry):
-    """Register debate capabilities with the Lego registry."""
-    registry.register_agent(
-        name="debate_agent",
-        agent_class=DebateAgent,
-        capabilities=[
-            "adversarial_debate",
-            "argument_generation",
-            "strategy_adaptation",
-            "opponent_analysis",
-            "argument_scoring",
-        ],
-        metadata={
-            "description": (
-                "Generates arguments in adversarial debates with 8 personality "
-                "archetypes, adaptive strategies, 8-metric scoring, and "
-                "phase-based orchestration."
-            ),
-        },
-    )
+# #1842: no register_with_capability_registry here. The debate capability
+# table lives on the production surface (registry_setup.setup_registry) —
+# this module's former second table was only ever called by tests, and its
+# register_agent("debate_agent") would COLLIDE with the wired one
+# (ValueError: Component 'debate_agent' is already registered).

--- a/argumentation_analysis/agents/core/governance/__init__.py
+++ b/argumentation_analysis/agents/core/governance/__init__.py
@@ -30,23 +30,7 @@ __all__ = [
     "summarize_results",
 ]
 
-
-def register_with_capability_registry(registry):
-    """Register governance capabilities with the Lego registry."""
-    registry.register_plugin(
-        name="governance",
-        plugin_class=type("GovernanceMethods", (), {"methods": GOVERNANCE_METHODS}),
-        capabilities=[
-            "collective_decision_making",
-            "voting_methods",
-            "conflict_resolution",
-            "consensus_metrics",
-        ],
-        metadata={
-            "description": (
-                "Provides 7 governance/voting methods, conflict detection "
-                "and resolution, and consensus metrics for multi-agent "
-                "collective decision-making."
-            ),
-        },
-    )
+# #1842: no register_with_capability_registry here. The governance
+# capability table lives on the production surface
+# (registry_setup.setup_registry); this module's former second table was
+# only ever called by tests and shared no capability string with it.

--- a/argumentation_analysis/agents/core/quality/__init__.py
+++ b/argumentation_analysis/agents/core/quality/__init__.py
@@ -15,21 +15,6 @@ from argumentation_analysis.agents.core.quality.quality_evaluator import (
 
 __all__ = ["ArgumentQualityEvaluator", "VERTUES", "evaluer_argument"]
 
-
-def register_with_capability_registry(registry):
-    """Register quality evaluation capabilities with the Lego registry."""
-    registry.register_plugin(
-        name="quality_scoring",
-        plugin_class=ArgumentQualityEvaluator,
-        capabilities=[
-            "argument_quality_evaluation",
-            "virtue_scoring",
-        ],
-        metadata={
-            "description": (
-                "Evaluates argument quality across 9 argumentative virtues "
-                "(clarity, relevance, sources, refutation, logic, analogy, "
-                "reliability, exhaustiveness, low redundancy)."
-            ),
-        },
-    )
+# #1842: no register_with_capability_registry here. The quality capability
+# table lives on the production surface (registry_setup.setup_registry);
+# this module's former second table was only ever called by tests.

--- a/argumentation_analysis/agents/core/synthesis/deep_synthesis_agent.py
+++ b/argumentation_analysis/agents/core/synthesis/deep_synthesis_agent.py
@@ -55,8 +55,8 @@ class DeepSynthesisAgent(BaseAgent):
         "MUST NEVER appear in your output by their real name. Refer to every "
         "entity ONLY by an opaque label: the speaker is `Speaker_A`, a state "
         "is `State_Q`, an era is `era_A`, the document is `doc_A`, an argument "
-        "is `arg_1`. Characterize content ABSTRACTLY (\"the speaker frames X "
-        "as historically inevitable\") — never quote or paraphrase proper "
+        'is `arg_1`. Characterize content ABSTRACTLY ("the speaker frames X '
+        'as historically inevitable") — never quote or paraphrase proper '
         "nouns even if they appear in the data blocks below (those blocks may "
         "carry named entities inherited from upstream extraction; treat them "
         "as content only, never copy the names). If you cannot express an "
@@ -1343,9 +1343,7 @@ class DeepSynthesisAgent(BaseAgent):
             # Epic #1258 / Track 1 #1259 — prepend the opaque-ID directive only
             # when the agent runs in opaque mode (deanonymized=False).
             _opaque_guard = (
-                ""
-                if getattr(self, "_deanonymized", True)
-                else self.OPAQUE_ID_DIRECTIVE
+                "" if getattr(self, "_deanonymized", True) else self.OPAQUE_ID_DIRECTIVE
             )
             prompt = (
                 f"{_opaque_guard}{self.GROUNDED_SYNTHESIS_PROMPT}\n\n{briefing}\n\n"
@@ -1647,20 +1645,7 @@ class DeepSynthesisAgent(BaseAgent):
             return None
 
 
-# Module-level registry function
-def register_with_capability_registry(registry):
-    """Register DeepSynthesisAgent with the capability registry."""
-    registry.register_agent(
-        name="deep_synthesis_agent",
-        agent_class=DeepSynthesisAgent,
-        capabilities=[
-            "deep_synthesis",
-            "multi_page_report",
-            "grounded_analysis",
-        ],
-        metadata={
-            "description": "Aggregates spectacular-run state into multi-page grounded markdown report (9 sections)",
-            "sections": 9,
-            "report_version": "1.0.0",
-        },
-    )
+# #1842: no register_with_capability_registry here. This dead second
+# surface (zero callers — not even tests) duplicated the production
+# deep_synthesis_service declaration on registry_setup's surface with an
+# identical capability list.

--- a/argumentation_analysis/orchestration/registry_setup.py
+++ b/argumentation_analysis/orchestration/registry_setup.py
@@ -119,11 +119,10 @@ def setup_registry(
         registry.register_agent(
             name="quality_evaluator",
             agent_class=ArgumentQualityEvaluator,
-            capabilities=[
-                "argument_quality",
-                "virtue_detection",
-                "quality_scoring",
-            ],
+            # #1842: one table, demander-gated — virtue_detection and
+            # quality_scoring had zero production consumers (the 9 virtues
+            # run inside the evaluator; the registry routes the phase ask).
+            capabilities=["argument_quality"],
             metadata={"description": "9-virtue argument quality evaluator"},
             invoke=_invoke_quality_evaluator,
         )
@@ -140,11 +139,9 @@ def setup_registry(
         registry.register_agent(
             name="debate_agent",
             agent_class=DebateAgent,
-            capabilities=[
-                "adversarial_debate",
-                "argument_stress_test",
-                "debate_scoring",
-            ],
+            # #1842: stress-testing and scoring run inside the debate phase;
+            # neither had a production consumer for the registry to route.
+            capabilities=["adversarial_debate"],
             metadata={"description": "Multi-personality adversarial debate agent"},
             invoke=_invoke_debate_analysis,
         )
@@ -161,11 +158,11 @@ def setup_registry(
         registry.register_agent(
             name="governance_agent",
             agent_class=GovernanceAgent,
-            capabilities=[
-                "governance_simulation",
-                "multi_method_voting",
-                "preference_aggregation",
-            ],
+            # #1842: _invoke_governance already runs the multi-method vote
+            # and preference aggregation inside the governance_simulation
+            # phase (GE-4 #1462) — separate registry strings had no router
+            # value: any phase asking them resolved to this same invoke.
+            capabilities=["governance_simulation"],
             metadata={"description": "7-method governance voting agent"},
             invoke=_invoke_governance,
         )
@@ -701,7 +698,10 @@ def setup_registry(
         registry.register_service(
             name="deep_synthesis_service",
             service_class=type("DeepSynthesisService", (), {}),
-            capabilities=["deep_synthesis", "multi_page_report", "grounded_analysis"],
+            # #1842: the report shape (multi-page, grounded, 9 sections) is
+            # what the deep_synthesis phase produces, not separate routing
+            # asks — neither string had a production consumer.
+            capabilities=["deep_synthesis"],
             metadata={
                 "description": "Aggregates spectacular-run state into multi-page grounded markdown report (9 sections)",
                 "sections": 9,

--- a/tests/unit/argumentation_analysis/agents/core/counter_argument/test_counter_argument.py
+++ b/tests/unit/argumentation_analysis/agents/core/counter_argument/test_counter_argument.py
@@ -120,7 +120,14 @@ class TestCounterArgumentRegistration:
         assert len(agents) >= 1
         assert agents[0].name == "counter_argument_agent"
 
-    def test_register_multiple_capabilities(self):
+    def test_register_routes_the_phase_ask(self):
+        """The one-table registration routes the demanded capability (#1842).
+
+        Parsing, vulnerability analysis, strategies and evaluation are the
+        agent's internals — the registry routes the phase ask
+        (counter_argument_generation), the only capability production
+        code ever demands.
+        """
         from argumentation_analysis.core.capability_registry import CapabilityRegistry
         from argumentation_analysis.agents.core.counter_argument import (
             register_with_capability_registry,
@@ -129,15 +136,11 @@ class TestCounterArgumentRegistration:
         registry = CapabilityRegistry()
         register_with_capability_registry(registry)
 
-        for cap in [
-            "counter_argument_generation",
-            "argument_parsing",
-            "vulnerability_analysis",
-            "rhetorical_strategy",
-            "counter_argument_evaluation",
-        ]:
-            agents = registry.find_agents_for_capability(cap)
-            assert len(agents) >= 1, f"Missing capability: {cap}"
+        agents = registry.find_agents_for_capability("counter_argument_generation")
+        assert len(agents) >= 1
+        # Secondary vocabulary stays OFF the routing table: nothing in
+        # production asks for it (#1842 DoD — no declared-without-demander).
+        assert registry.find_agents_for_capability("argument_parsing") == []
 
 
 # ── Parser tests ──────────────────────────────────────────────────

--- a/tests/unit/argumentation_analysis/agents/core/debate/test_debate.py
+++ b/tests/unit/argumentation_analysis/agents/core/debate/test_debate.py
@@ -190,18 +190,17 @@ class TestDebateRegistration:
         assert "adversarial_debate" in all_caps
         assert "argument_generation" in all_caps
 
-    def test_register_with_convenience_function(self):
-        """register_with_capability_registry() works."""
-        from argumentation_analysis.core.capability_registry import (
-            CapabilityRegistry,
-        )
-        from argumentation_analysis.agents.core.debate import (
-            register_with_capability_registry,
-        )
+    def test_debate_registered_on_production_surface(self):
+        """The debate specialist is reachable through the REAL registry.
 
-        registry = CapabilityRegistry()
-        register_with_capability_registry(registry)
+        #1842: this module no longer carries its own capability table —
+        the production surface (registry_setup.setup_registry) is the one
+        table, and its debate_agent would collide with any second
+        register_agent under the same name.
+        """
+        from argumentation_analysis.orchestration.registry_setup import setup_registry
 
+        registry = setup_registry(include_optional=False)
         agents = registry.find_agents_for_capability("adversarial_debate")
         assert len(agents) == 1
         assert agents[0].name == "debate_agent"

--- a/tests/unit/argumentation_analysis/orchestration/test_one_capability_surface_1842.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_one_capability_surface_1842.py
@@ -1,0 +1,209 @@
+"""One capability surface per module — static guards (#1842).
+
+#1842 established that ``debate``, ``governance`` and ``quality`` declared
+their capabilities TWICE, in two vocabularies: the production surface
+(``orchestration/registry_setup.py``, called by ``setup_registry``) and a
+per-module ``register_with_capability_registry`` that only tests ever called
+(for ``debate`` the two even collided on the ``register_agent`` name — wiring
+both would crash registry construction with ``ValueError``). A fifth definer
+(``synthesis/deep_synthesis_agent.py``) was dead under even tests.
+
+These guards pin the subtractive resolution:
+
+1. ``test_register_functions_are_all_wired`` — every module defining
+   ``register_with_capability_registry`` must be the one ``registry_setup``
+   imports and calls. A new dead definer (the deep_synthesis failure mode)
+   reddens immediately.
+2. ``test_declared_capabilities_have_production_demanders`` — every
+   capability declared for the five specialists is demanded by production
+   code: an ``add_phase(capability=...)`` literal (the real consumption
+   mechanism, workflow_dsl resolution) or a ``find_*_for_capability(...)``
+   literal. The find_* idiom is mostly test-side, so production literals are
+   the criterion; the census is on string literals in ``argumentation_analysis/``.
+
+Out of scope by design (#1842 ≠ #1604): the formal/Tweety specialists'
+declarations are not covered by guard 2 — their orphan census is #1604's.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[4]
+PROD_ROOT = PROJECT_ROOT / "argumentation_analysis"
+REGISTRY_SETUP = PROD_ROOT / "orchestration" / "registry_setup.py"
+
+IN_SCOPE_COMPONENTS = {
+    "counter_argument_agent",
+    "quality_evaluator",
+    "debate_agent",
+    "governance_agent",
+    "deep_synthesis_service",
+}
+
+
+def _module_path(py: Path) -> str:
+    rel = py.relative_to(PROJECT_ROOT)
+    parts = rel.with_suffix("").parts
+    if parts and parts[-1] == "__init__":
+        parts = parts[:-1]  # match ast.ImportFrom module paths for packages
+    return ".".join(parts)
+
+
+def _definers_of_register_function() -> set[str]:
+    """Modules under argumentation_analysis/ defining the register function."""
+    definers = set()
+    for py in PROD_ROOT.rglob("*.py"):
+        try:
+            tree = ast.parse(py.read_text(encoding="utf-8"))
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and (
+                node.name == "register_with_capability_registry"
+            ):
+                definers.add(_module_path(py))
+    return definers
+
+
+def _wired_register_modules() -> set[str]:
+    """Modules whose register function registry_setup actually imports."""
+    tree = ast.parse(REGISTRY_SETUP.read_text(encoding="utf-8"))
+    wired = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module:
+            for alias in node.names:
+                if alias.name == "register_with_capability_registry":
+                    wired.add(node.module)
+    return wired
+
+
+def _declared_capabilities() -> dict[str, list[str]]:
+    """Component -> capabilities, from the wired declaration surfaces."""
+    sources = [
+        REGISTRY_SETUP,
+        PROD_ROOT / "agents" / "core" / "counter_argument" / "__init__.py",
+    ]
+    declared: dict[str, list[str]] = {}
+    for src in sources:
+        tree = ast.parse(src.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            fname = getattr(node.func, "attr", "") or getattr(node.func, "id", "")
+            if not fname.startswith("register_"):
+                continue
+            comp = None
+            if node.args and isinstance(node.args[0], ast.Constant):
+                comp = node.args[0].value
+            for kw in node.keywords:
+                if kw.arg == "name" and isinstance(kw.value, ast.Constant):
+                    comp = kw.value.value
+            if comp not in IN_SCOPE_COMPONENTS:
+                continue
+            for kw in node.keywords:
+                if kw.arg == "capabilities" and isinstance(kw.value, ast.List):
+                    caps = [
+                        e.value for e in kw.value.elts if isinstance(e, ast.Constant)
+                    ]
+                    declared.setdefault(comp, []).extend(caps)
+    return declared
+
+
+def _production_demanded_capabilities() -> set[str]:
+    """Capability string literals production code actually asks for."""
+    demanded = set()
+    for py in PROD_ROOT.rglob("*.py"):
+        if "test" in py.parts:
+            continue
+        try:
+            tree = ast.parse(py.read_text(encoding="utf-8"))
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            callee = getattr(node.func, "attr", "") or getattr(node.func, "id", "")
+            if callee == "add_phase":
+                for kw in node.keywords:
+                    if kw.arg == "capability" and isinstance(kw.value, ast.Constant):
+                        demanded.add(kw.value.value)
+            elif "for_capability" in callee:
+                if node.args and isinstance(node.args[0], ast.Constant):
+                    demanded.add(node.args[0].value)
+    return demanded
+
+
+class TestOneCapabilitySurface:
+    def test_register_functions_are_all_wired(self):
+        """Every definer of the register function is wired through setup_registry.
+
+        The pre-#1842 state had four definers no production code called —
+        for ``debate`` wiring the second surface would not merely dilute
+        metrics, it would crash registry construction (name collision).
+        """
+        definers = _definers_of_register_function()
+        wired = _wired_register_modules()
+        unwired = definers - wired
+        assert not unwired, (
+            f"Modules defining register_with_capability_registry that "
+            f"registry_setup never wires: {sorted(unwired)}. A second, dead "
+            f"capability surface — the #1842 defect (and its deep_synthesis "
+            f"recurrence). Either wire it or delete the function."
+        )
+
+    def test_declared_capabilities_have_production_demanders(self):
+        """No specialist capability stays declared-and-never-demanded."""
+        declared = _declared_capabilities()
+        demanded = _production_demanded_capabilities()
+        orphans = {
+            comp: [c for c in caps if c not in demanded]
+            for comp, caps in declared.items()
+        }
+        orphans = {comp: caps for comp, caps in orphans.items() if caps}
+        assert not orphans, (
+            f"Declared capabilities with zero production demanders: "
+            f"{orphans}. Every kept capability needs an add_phase or "
+            f"find_*_for_capability consumer, or it must leave the "
+            f"declaration (#1842 DoD). Formal/Tweety specialists are "
+            f"#1604's scope, not this guard's."
+        )
+
+    def test_in_scope_components_are_declared(self):
+        """The census itself is alive: all five specialists declare a table."""
+        declared = _declared_capabilities()
+        missing = IN_SCOPE_COMPONENTS - set(declared)
+        assert not missing, (
+            f"In-scope components with no capability declaration found in "
+            f"the wired surfaces: {sorted(missing)} — the declaration "
+            f"extraction is likely stale (renamed component or moved file)."
+        )
+
+
+@pytest.mark.parametrize(
+    "capability",
+    sorted(
+        {
+            "adversarial_debate",
+            "argument_quality",
+            "governance_simulation",
+            "counter_argument_generation",
+            "deep_synthesis",
+        }
+    ),
+)
+def test_kept_capabilities_resolve_in_real_registry(capability):
+    """Runtime pin: the real setup_registry serves every kept capability.
+
+    Population is the production registry — not one the test fabricates
+    (the #1842 DoD replacing the old convenience-functions test).
+    """
+    from argumentation_analysis.orchestration.registry_setup import setup_registry
+
+    registry = setup_registry(include_optional=False)
+    providers = registry.find_for_capability(capability)
+    assert providers, (
+        f"Capability {capability!r} has no provider in the real "
+        f"setup_registry population."
+    )

--- a/tests/unit/argumentation_analysis/orchestration/test_unified_pipeline.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_unified_pipeline.py
@@ -222,7 +222,12 @@ class TestRegistrySetup:
         assert summary["total_registrations"] > 0
 
     def test_counter_argument_capabilities(self):
-        """Counter-argument agent provides expected capabilities."""
+        """Counter-argument agent routes the demanded capability (#1842).
+
+        Parsing and vulnerability analysis are the agent's internals, not
+        registry entries — nothing in production asks for them, so the
+        one-table resolution keeps them off the routing surface.
+        """
         from argumentation_analysis.orchestration.unified_pipeline import (
             setup_registry,
         )
@@ -231,8 +236,8 @@ class TestRegistrySetup:
         agents = registry.find_agents_for_capability("counter_argument_generation")
         assert len(agents) >= 1
         agent_reg = agents[0]
-        assert "argument_parsing" in agent_reg.capabilities
-        assert "vulnerability_analysis" in agent_reg.capabilities
+        assert "counter_argument_generation" in agent_reg.capabilities
+        assert "argument_parsing" not in agent_reg.capabilities
 
     def test_quality_evaluator_registered(self):
         """Quality evaluator is registered."""

--- a/tests/unit/argumentation_analysis/test_architecture_compliance.py
+++ b/tests/unit/argumentation_analysis/test_architecture_compliance.py
@@ -247,35 +247,42 @@ class TestRegistryCompliance:
         assert "belief_maintenance" in all_caps
         assert "local_llm" in all_caps
 
-    def test_register_with_convenience_functions(self):
-        """All modules with register_with_capability_registry work."""
-        from argumentation_analysis.core.capability_registry import (
-            CapabilityRegistry,
-        )
-        from argumentation_analysis.agents.core.counter_argument import (
-            register_with_capability_registry as reg_counter,
-        )
-        from argumentation_analysis.agents.core.debate import (
-            register_with_capability_registry as reg_debate,
-        )
-        from argumentation_analysis.agents.core.quality import (
-            register_with_capability_registry as reg_quality,
-        )
-        from argumentation_analysis.agents.core.governance import (
-            register_with_capability_registry as reg_governance,
+    def test_setup_registry_covers_all_specialists(self):
+        """Every specialist module appears in the REAL setup_registry output.
+
+        #1842 (DoD): the previous test built its own registry and called
+        the per-module convenience functions itself — a fabricated
+        population that could not reveal production wiring only imports
+        one of them. Here the population is exactly what production
+        builds, and each specialist must appear on it with its invoke
+        wired.
+        """
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            setup_registry,
         )
 
-        registry = CapabilityRegistry()
-        reg_counter(registry)
-        reg_debate(registry)
-        reg_quality(registry)
-        reg_governance(registry)
+        registry = setup_registry(include_optional=False)
 
-        all_caps = registry.get_all_capabilities()
-        assert "counter_argument_generation" in all_caps
-        assert "adversarial_debate" in all_caps
-        assert "argument_quality_evaluation" in all_caps
-        assert "collective_decision_making" in all_caps
+        expected = {
+            "counter_argument_agent": "counter_argument_generation",
+            "quality_evaluator": "argument_quality",
+            "debate_agent": "adversarial_debate",
+            "governance_agent": "governance_simulation",
+            "deep_synthesis_service": "deep_synthesis",
+        }
+        for component, capability in expected.items():
+            providers = registry.find_for_capability(capability)
+            names = [getattr(p, "name", None) for p in providers]
+            assert component in names, (
+                f"{component} missing from the real setup_registry "
+                f"population for capability {capability!r} — the production "
+                f"wiring dropped a specialist."
+            )
+            by_name = [p for p in providers if getattr(p, "name", None) == component]
+            assert by_name and by_name[0].invoke is not None, (
+                f"{component} registered without an invoke callable — a "
+                f"specialist the pipeline cannot actually route to."
+            )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What — the subtractive reconciliation

Per the issue's direction: **one table per module, each entry justified by a demander**. The production surface (`orchestration/registry_setup.py`, what `setup_registry` populates) is the one table; the four dead second surfaces are deleted; every kept routing entry is a capability production code demands.

### Surface A trims (registry_setup.py)

| component | before | after |
|---|---|---|
| `debate_agent` | adversarial_debate, argument_stress_test, debate_scoring | **[adversarial_debate]** |
| `quality_evaluator` | argument_quality, virtue_detection, quality_scoring | **[argument_quality]** |
| `governance_agent` | governance_simulation, multi_method_voting, preference_aggregation | **[governance_simulation]** |
| `deep_synthesis_service` | deep_synthesis, multi_page_report, grounded_analysis | **[deep_synthesis]** |

Dropped strings: **zero production demanders** (AST census of `add_phase(capability=…)` + `find_*_for_capability(…)` literals under `argumentation_analysis/`). They are internals of the phase that runs them — `_invoke_governance` already runs the multi-method vote and preference aggregation inside `governance_simulation` (GE-4 #1462), the 9 virtues run inside the evaluator, the report shape is what `deep_synthesis` produces.

**Why not give them a consumer instead**: a phase asking `multi_method_voting` would resolve to the *same* agent and the *same* `_invoke_governance` the `governance_simulation` phase already routes to — a fabricated consumer adding no routing (théâtre, #1019). When the cross-repo N-person chantier lands here, it adds its phase AND re-adds its strings in the same PR — the standing rule this repo now documents.

### Dead surfaces deleted

- `debate/__init__.py`, `governance/__init__.py`, `quality/__init__.py` — `register_with_capability_registry` called only by tests (debate's would **collide**: `ValueError: Component 'debate_agent' is already registered`).
- `synthesis/deep_synthesis_agent.py` — the fifth definer, **zero callers at all**, duplicating `deep_synthesis_service`'s declaration.
- `counter_argument/__init__.py` — keeps its module function (the one surface `setup_registry` imports), trimmed to `[counter_argument_generation]`.

## Guards — born-red on main, exactly the named defects

New `tests/unit/argumentation_analysis/orchestration/test_one_capability_surface_1842.py`:

1. **one-surface guard** (AST): every definer of `register_with_capability_registry` is wired through `registry_setup`. On main: RED naming exactly `debate`, `governance`, `quality`, `synthesis.deep_synthesis_agent`.
2. **demander guard** (AST): no in-scope declared capability lacks a production demander. On main: RED listing **exactly the 12 strings** across the 5 components.
3. **census liveness**: the first draft of guard 2 passed vacuously (declaration extraction missed keyword-style `name=` args) — the liveness test caught it, extraction fixed, then the red appeared. The vacuous-green class is exactly what this guard exists to prevent.
4. **runtime pin**: each kept capability resolves in the REAL `setup_registry()` population.

Scope note (anti-pendule): the demander guard is deliberately restricted to the five specialists — the formal/Tweety side has 16 more orphans, that is #1604's census, not this PR's.

## Test updates

- `test_architecture_compliance.py` — the fabricated-population `test_register_with_convenience_functions` (built its own registry, called the four functions itself — structurally unable to see production wires only one) is replaced by a real-`setup_registry` check: each of the five specialists present **with its invoke wired** (issue DoD).
- `test_debate.py` — convenience-function test → production-surface test.
- `test_counter_argument.py` — multi-capability registry test → routes-the-phase-ask test (asserts the secondary vocabulary stays OFF the table).

## Validation

- **147 passed / 0 failed** across all touched test files + `test_capability_duality_invariant.py` (the duality suite lives on the real registry population — every workflow-demanded capability keeps its provider).
- Born-red protocol executed: guards written first, reddened on main with the precise defect lists, then the fix, then green.
- Black clean. `registry_setup.py` (in the CI mypy gate) passes `--strict`. Pre-existing mypy errors in `counter_argument/__init__.py` + `deep_synthesis_agent.py`: **main 10 → this branch 9** (the deleted dead function was one).
- Pre-existing, NOT fixed here (verified via stash on main): `test_french_fallacy_plugin_has_kernel_functions` leaks **1 watched-LLM request** to the local `text-generation-webui` host — #1794 family, deserves its own ticket.
- CLAUDE.md `:168` block (governance counts) was already corrected by #1850; this PR updates the ⚠ doubled-declarations block to the resolved one-surface state.

Closes #1842