### PR TITLE
fix(tests): tolerate a cache-less pytest run — one _cache() helper for the 9 config.cache sites

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -335,6 +335,30 @@ def pytest_unconfigure(config):
         _dotenv_patcher = None
 
 
+class _NullCache:
+    """#1820 : cache de secours quand ``-p no:cacheprovider`` est passé —
+    ``config.cache`` n'existe pas et chaque accès levait en INTERNALERROR avant
+    toute collecte. ``get``/``set`` round-trippent dans un dict de classe : le
+    transport intra-session (sessionstart écrit ``jvm_started``, la fixture
+    ``jvm_session`` le lit) reste fonctionnel — un set-noop aurait fait sauter
+    à tort les tests JVM d'une session où la JVM VIT. Portée = le process
+    pytest : chaque invocation repart vierge (sémantique cache froid), rien
+    ne persiste entre runs."""
+
+    _store: dict = {}
+
+    def get(self, key, default=None):
+        return self._store.get(key, default)
+
+    def set(self, key, value):
+        self._store[key] = value
+
+
+def _cache(config):
+    """#1820 : accès unique au cache pytest pour les 9 sites de conftest."""
+    return getattr(config, "cache", None) or _NullCache()
+
+
 def pytest_collection_finish(session):
     """
     Hook exécuté après la collecte des tests.
@@ -343,7 +367,7 @@ def pytest_collection_finish(session):
     is_e2e_session = any(
         item.get_closest_marker("e2e") is not None for item in session.items
     )
-    session.config.cache.set("is_e2e_session", is_e2e_session)
+    _cache(session.config).set("is_e2e_session", is_e2e_session)
     if is_e2e_session:
         logger.warning(
             "Session de test E2E détectée. L'initialisation globale de la JVM sera sautée."
@@ -418,22 +442,22 @@ def pytest_sessionstart(session):
         logger.info(
             "Mode collection uniquement : JVM non initialisée (évite conflit torch/DLL)"
         )
-        session.config.cache.set("jvm_started", False)
+        _cache(session.config).set("jvm_started", False)
         return
 
     if session.config.getoption("--disable-jvm-session"):
         logger.warning("Initialisation de la JVM sautée via --disable-jvm-session.")
-        session.config.cache.set("jvm_started", False)
+        _cache(session.config).set("jvm_started", False)
         return
 
     # La décision est prise après la collecte, dans pytest_collection_finish
-    is_e2e_session = session.config.cache.get("is_e2e_session", False)
+    is_e2e_session = _cache(session.config).get("is_e2e_session", False)
 
     if is_e2e_session:
         logger.warning(
             "Décision confirmée: L'initialisation globale de la JVM est sautée pour la session E2E."
         )
-        session.config.cache.set("jvm_started", False)
+        _cache(session.config).set("jvm_started", False)
         return
 
     # #1641 (B): pytest captures logs per-test and only releases them on a test
@@ -466,7 +490,7 @@ def pytest_sessionstart(session):
         # a genuine raise; the l.522 double-check still covers a real post-start
         # crash — three distinct causes, three distinct messages, all kept.
         _jvm_ok = initialize_jvm(session_fixture_owns_jvm=True)
-        session.config.cache.set("jvm_started", bool(_jvm_ok))
+        _cache(session.config).set("jvm_started", bool(_jvm_ok))
         if _jvm_ok:
             logger.info("JVM initialisée avec succès depuis pytest_sessionstart.")
         else:
@@ -480,7 +504,7 @@ def pytest_sessionstart(session):
         logger.error(
             f"ÉCHEC CRITIQUE de l'initialisation de la JVM dans pytest_sessionstart: {e}"
         )
-        session.config.cache.set("jvm_started", False)
+        _cache(session.config).set("jvm_started", False)
         # On ne lance pas pytest.exit ici pour laisser les tests non-JVM s'exécuter
         # Mais on pourrait le faire si la JVM est absolument critique pour toute la suite.
     finally:
@@ -541,8 +565,8 @@ def jvm_session(request):
     L'initialisation réelle a été déplacée vers `pytest_sessionstart` pour une exécution
     plus précoce et plus sûre. Cette fixture vérifie si l'initialisation a réussi.
     """
-    jvm_started = request.config.cache.get("jvm_started", False)
-    is_e2e_session = request.config.cache.get("is_e2e_session", False)
+    jvm_started = _cache(request.config).get("jvm_started", False)
+    is_e2e_session = _cache(request.config).get("is_e2e_session", False)
 
     is_no_jvm_test = "no_jvm_session" in request.node.keywords
     is_jvm_disabled_globally = request.config.getoption("--disable-jvm-session")


### PR DESCRIPTION
## Ce que fait la PR

Le micro-fix `-p no:cacheprovider` mandaté (R837 msg du 20/08, re-dispatché R840 canal GitHub) : sous `-p no:cacheprovider`, `config.cache` n'existe pas et chaque accès dans `tests/conftest.py` levait `AttributeError` → `INTERNALERROR` **avant toute collecte** — tout run lancé sans le cacheprovider était impossible.

**Le correctif** : un **seul** helper `_cache(config)` (`getattr(config, "cache", None) or _NullCache()`) traversé par les **9 sites** (:346/:421/:426/:430/:436/:469/:483/:544/:545). Aucune garde recopiée, aucune réorganisation.

**Pourquoi `_NullCache` round-trippe au lieu d'être un noop** — découvert en validation : un `set` no-op laissait `jvm_started=True` (écrit par `pytest_sessionstart` après une init JVM **réussie**) ne jamais atteindre la fixture `jvm_session`, qui lisait `False` et **sautait à tort des tests d'une session où la JVM vit** (constaté : 3 skipped ; après round-trip : 3 passed). Le dict de classe porte le transport intra-session ; sa portée = le process pytest, donc chaque invocation repart vierge — sémantique de cache froid préservée entre runs, `pytest_collection_finish` continue d'écrire après que `pytest_sessionstart` a lu (l'ordre documenté ne change pas).

## Preuves — rouge avant / vert après, les deux combinaisons

Bande = `tests/unit/test_conftest_jvm_return_1641.py`, `-o addopts=` (neutralise le `--timeout` de #1759 absent de l'env local ; armé en CI). Rouge constaté sur main (`1dbf3100`) **avant** le patch, pas supposé :

| combinaison | avant (main) | après |
|---|---|---|
| `-p no:cacheprovider` | INTERNALERROR `conftest.py:430` — `AttributeError: 'Config' object has no attribute 'cache'` | **3 passed** |
| `--disable-jvm-session -p no:cacheprovider` | INTERNALERROR `conftest.py:426` — idem | **3 passed** |
| sans drapeau (cache réel) | 3 passed | 3 passed (inchangé) |

La 2ᵉ combinaison est le point du mandat : `:421`/`:426` s'exécutent **avant** `:430` — une garde posée sur le seul `:430` (ma proposition initiale) aurait laissé le symptôme intact et aurait été verte pour la mauvaise raison. Les deux sont couvertes, par le même helper.

**`test_conftest_jvm_return_1641.py` vérifié, pas supposé** : il mocke `session.config.cache` → `getattr` rend le MagicMock (véridique), chemin du mock préservé, **3 passed** sans drapeau.

En passant, combo 1 a produit une init JVM **réussie** avec l'access violation cosmétique documentée (R834 : le message n'est pas le signal — les tests tournent après) puis les 3 tests passés : le transport intra-session `_NullCache` est prouvé sur le chemin JVM vivante, pas seulement sur le chemin mock.

## DoD (dispatch R840) — état par item

- [x] **`-p no:cacheprovider` ne fait plus INTERNALERROR** — cette PR, les deux combinaisons.
- [x] **Mesure de l'inertie** — livrée le 20/08 (issuecomment-5353642466), verdict « réel mais INERTE sur CI » : le gate argv ne collecte aucun marqueur `e2e` (grep exhaustif des 16 sous-dirs), cache froid garanti sur runners hébergés ⇒ valeur lue = valeur juste = `False`. Reprise sans changement.
- [ ] **Transport corrigé** / **substitution dégénérée deux-invocations** — ⛔ **explicitement hors mandat R837** (« Le transport lui-même ne bouge pas. La dette reste lisible et documentée par ta mesure. Si un jour elle doit être payée, la seule sortie identifiée reste de décider depuis l'argv »). Le dispatch R840 re-colle la DoD de l'issue qui les liste — **arbitrage coord demandé** : si le mandat est étendu à l'argv-décision, ce sera une PR séparée sur la zone qui a coûté deux régressions (Phase 8 + D3.1.1), avec le contrôle D3.1.1 comme contrôle central. Cette PR ne touche ni l'ordre des hooks ni le mécanisme de détection.

## Anti-pendules respectés

Ni l'init JVM déplacée après la collecte (Phase 8), ni `"e2e" in item.keywords` (D3.1.1) — la détection reste par marqueurs des items collectés, seuls les 9 accès cache passent par le helper.

## Recette gate

`tests/conftest.py` seul, aucun test ajouté/retiré : **passed +0 / skipped plat attendu** vs main `cf5aa2d6` (mesure même-instrument junit XML à la suite).

Closes #1820 (item crash) — les items transport restent à arbitrage.